### PR TITLE
Refactor: Apply Scala 3 brace syntax, remove mutable state, and improve code style across all modules

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -68,9 +68,9 @@ object Main {
           |  aiskills install ~/my-skills/my-skill                  # Install from home-relative path
           |""".stripMargin,
       ) {
-        val source = Opts.argument[String](metavar = "source")
-        val global = Opts.flag("global", "Install globally (default: project install)", short = "g").orFalse
-        val agent = Opts
+        val source    = Opts.argument[String](metavar = "source")
+        val global    = Opts.flag("global", "Install globally (default: project install)", short = "g").orFalse
+        val agent     = Opts
           .option[String](
             "agent",
             s"Target agent (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
@@ -78,16 +78,19 @@ object Main {
           )
           .withDefault("universal")
         val allAgents = Opts.flag("all-agents", "Install to all agent directories").orFalse
-        val yes = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
+        val yes       = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
         (source, global, agent, allAgents, yes).mapN { (src, g, a, all, y) =>
-          Agent.fromString(a) match
+          Agent.fromString(a) match {
             case Some(agentEnum) =>
               Install.installSkill(src, InstallOptions(global = g, agent = agentEnum, allAgents = all, yes = y))
             case None =>
-              System.err.println(
-                s"Error: Invalid agent '$a'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
-              )
+              System
+                .err
+                .println(
+                  s"Error: Invalid agent '$a'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                )
               sys.exit(1)
+          }
         }
       }
 
@@ -106,7 +109,7 @@ object Main {
           |  aiskills read commit --prefer cursor          # Prefer Cursor's version
           |""".stripMargin,
       ) {
-        val names = Opts.arguments[String](metavar = "skill-names")
+        val names  = Opts.arguments[String](metavar = "skill-names")
         val prefer = Opts.option[String]("prefer", "Prefer skills from this agent's directory").orNone
         (names, prefer).mapN { (ns, p) =>
           val preferAgent = p.flatMap(Agent.fromString)
@@ -155,20 +158,22 @@ object Main {
             |""".stripMargin,
         ) {
           val skillName = Opts.argument[String](metavar = "skill-name").orNone
-          val from = Opts.option[String]("from", "Source agent").orNone
-          val to = Opts.option[String]("to", "Target agent").orNone
+          val from      = Opts.option[String]("from", "Source agent").orNone
+          val to        = Opts.option[String]("to", "Target agent").orNone
           val allAgents = Opts.flag("all-agents", "Sync to all other agent directories").orFalse
-          val yes = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
+          val yes       = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
           (skillName, from, to, allAgents, yes).mapN { (sn, f, t, all, y) =>
             val fromAgent = f.flatMap(Agent.fromString)
-            val toAgent = t.flatMap(Agent.fromString)
-            Sync.syncSkills(SyncOptions(
-              skillName = sn,
-              from = fromAgent,
-              to = toAgent,
-              allAgents = all,
-              yes = y,
-            ))
+            val toAgent   = t.flatMap(Agent.fromString)
+            Sync.syncSkills(
+              SyncOptions(
+                skillName = sn,
+                from = fromAgent,
+                to = toAgent,
+                allAgents = all,
+                yes = y,
+              )
+            )
           }
         }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -5,9 +5,9 @@ import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMetadata, Yaml}
 import extras.scala.io.syntax.color.*
 import cue4s.*
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
-object Install:
+object Install {
 
   /** Check if the source is a local path. */
   def isLocalPath(source: String): Boolean =
@@ -26,17 +26,17 @@ object Install:
       source.endsWith(".git")
 
   /** Extract the repo name from the git URL. */
-  def getRepoName(repoUrl: String): Option[String] =
+  def getRepoName(repoUrl: String): Option[String] = {
     val cleaned = repoUrl.stripSuffix(".git")
     cleaned.split("/").lastOption.flatMap { lastPart =>
       val maybeRepo = if lastPart.contains(":") then lastPart.split(":").lastOption else Some(lastPart)
       maybeRepo.filter(_.nonEmpty)
     }
+  }
 
   /** Expand ~ to home directory. */
   def expandPath(source: String): os.Path =
-    if source.startsWith("~/") || source.startsWith("$HOME/") then
-      os.home / os.RelPath(source.drop(2))
+    if source.startsWith("~/") || source.startsWith("$HOME/") then os.home / os.RelPath(source.drop(2))
     else
       os.Path(source, os.pwd)
 
@@ -60,17 +60,17 @@ object Install:
     else f"${bytes / (1024.0 * 1024.0)}%.1fMB"
 
   /** Install skill from local path, GitHub, or Git URL. */
-  def installSkill(source: String, options: InstallOptions): Unit =
-    val agents = if options.allAgents then Agent.all else List(options.agent)
+  def installSkill(source: String, options: InstallOptions): Unit = {
+    val agents    = if options.allAgents then Agent.all else List(options.agent)
     val isProject = !options.global
 
     // Resolve source once
     val resolvedSource = resolveSource(source)
 
-    for agent <- agents do
-      val folder = s"${agent.projectDirName}/skills"
+    for agent <- agents do {
+      val folder       = s"${agent.projectDirName}/skills"
       val globalFolder = s"${agent.globalDirName}/skills"
-      val targetDir =
+      val targetDir    =
         if isProject then os.pwd / os.RelPath(folder)
         else os.home / os.RelPath(globalFolder)
 
@@ -78,78 +78,95 @@ object Install:
         if isProject then s"project ($folder)".blue
         else s"global (~/$globalFolder)".dim
 
-      if agents.length > 1 then
-        println(s"\n--- ${agent.toString} ---".bold)
+      if agents.length > 1 then println(s"\n--- ${agent.toString} ---".bold)
+      else ()
 
       println(s"Installing from: ${source.cyan}")
       println(s"Location: $location")
-      if agents.length <= 1 then
-        if isProject then
-          println(s"Default install is project-local (./$folder). Use --global for ~/$globalFolder.".dim)
+      if agents.length <= 1 then {
+        if isProject then println(
+          s"Default install is project-local (./$folder). Use --global for ~/$globalFolder.".dim
+        )
         else
           println(s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim)
+      } else ()
       println()
 
-      resolvedSource match
+      resolvedSource match {
         case ResolvedSource.Local(localPath, sourceInfo) =>
           installFromLocal(localPath, targetDir, options, sourceInfo)
 
         case ResolvedSource.Git(repoDir, repoUrl, skillSubpath, sourceInfo) =>
-          if skillSubpath.nonEmpty then
-            installSpecificSkill(repoDir, skillSubpath, targetDir, isProject, options, sourceInfo)
-          else
+          if skillSubpath.nonEmpty then installSpecificSkill(
+            repoDir,
+            skillSubpath,
+            targetDir,
+            isProject,
+            options,
+            sourceInfo
+          )
+          else {
             val repoName = getRepoName(repoUrl)
             installFromRepo(repoDir, targetDir, options, repoName, sourceInfo)
+          }
+      }
 
       AgentsMd.updateAgentsMdForAgent(agent, options.global)
+    }
 
-    resolvedSource match
+    resolvedSource match {
       case ResolvedSource.Git(_, _, _, _) => resolvedSource.cleanup()
-      case _                              => ()
+      case _ => ()
+    }
 
     printPostInstallHints(isProject)
+  }
 
   /** Resolved source — either local or a cloned git repo. */
-  private enum ResolvedSource:
+  private enum ResolvedSource {
     case Local(localPath: os.Path, sourceInfo: InstallSourceInfo)
     case Git(repoDir: os.Path, repoUrl: String, skillSubpath: String, sourceInfo: InstallSourceInfo)
 
-    def cleanup(): Unit = this match
+    def cleanup(): Unit = this match {
       case Git(repoDir, _, _, _) =>
         val tempDir = repoDir / os.up
         os.remove.all(tempDir)
       case _ => ()
+    }
+  }
+
+  /** Parse a non-local source into (repoUrl, skillSubpath). */
+  private def parseGitSource(source: String): (String, String) = {
+    if isGitUrl(source) then (source, "")
+    else {
+      val parts = source.split("/").toList
+      parts match {
+        case owner :: repo :: Nil =>
+          (s"https://github.com/$source", "")
+        case owner :: repo :: rest =>
+          (s"https://github.com/$owner/$repo", rest.mkString("/"))
+        case _ =>
+          System.err.println("Error: Invalid source format".red)
+          System.err.println("Expected: owner/repo, owner/repo/skill-name, git URL, or local path")
+          sys.exit(1)
+      }
+    }
+  }
 
   /** Resolve source into either a local path or a cloned git repo. */
-  private def resolveSource(source: String): ResolvedSource =
-    if isLocalPath(source) then
-      val localPath = expandPath(source)
+  private def resolveSource(source: String): ResolvedSource = {
+    if isLocalPath(source) then {
+      val localPath  = expandPath(source)
       val sourceInfo = InstallSourceInfo(
         source = source,
         sourceType = SkillSourceType.Local,
         localRoot = Some(localPath),
       )
       ResolvedSource.Local(localPath, sourceInfo)
-    else
-      var repoUrl: String = ""
-      var skillSubpath: String = ""
+    } else {
+      val (repoUrl, skillSubpath) = parseGitSource(source)
 
-      if isGitUrl(source) then
-        repoUrl = source
-      else
-        val parts = source.split("/").toList
-        parts match
-          case owner :: repo :: Nil =>
-            repoUrl = s"https://github.com/$source"
-          case owner :: repo :: rest =>
-            repoUrl = s"https://github.com/$owner/$repo"
-            skillSubpath = rest.mkString("/")
-          case _ =>
-            System.err.println("Error: Invalid source format".red)
-            System.err.println("Expected: owner/repo, owner/repo/skill-name, git URL, or local path")
-            sys.exit(1)
-
-      val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+      val tempDir    = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
       os.makeDir.all(tempDir)
       val sourceInfo = InstallSourceInfo(
         source = source,
@@ -161,44 +178,51 @@ object Install:
       Try {
         os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
           .call(stderr = os.Pipe)
-      } match
+      } match {
         case Failure(ex) =>
           println(" failed")
           val msg = ex.getMessage
-          if msg.nonEmpty then println(msg.dim)
+          if msg.nonEmpty then println(msg.dim) else ()
           println("\nTip: For private repos, ensure git SSH keys or credentials are configured".yellow)
           os.remove.all(tempDir)
           sys.exit(1)
         case Success(_) =>
           println(" done")
+      }
 
       ResolvedSource.Git(tempDir / "repo", repoUrl, skillSubpath, sourceInfo)
+    }
+  }
 
-  private def printPostInstallHints(isProject: Boolean): Unit =
+  private def printPostInstallHints(isProject: Boolean): Unit = {
     println(s"\n${"Read skill:".dim} ${"aiskills read <skill-name>".cyan}")
-    if isProject then
-      println(s"${"Sync to other agents:".dim} ${"aiskills sync <skill-name> --from <agent> --to <agent>".cyan}")
+    if isProject then println(
+      s"${"Sync to other agents:".dim} ${"aiskills sync <skill-name> --from <agent> --to <agent>".cyan}"
+    )
+    else ()
+  }
 
   private def installFromLocal(
     localPath: os.Path,
     targetDir: os.Path,
     options: InstallOptions,
     sourceInfo: InstallSourceInfo,
-  ): Unit =
-    if !os.exists(localPath) then
+  ): Unit = {
+    if !os.exists(localPath) then {
       System.err.println(s"Error: Path does not exist: $localPath".red)
       sys.exit(1)
-
-    if !os.isDir(localPath) then
+    } else if !os.isDir(localPath) then {
       System.err.println("Error: Path must be a directory".red)
       sys.exit(1)
-
-    val skillMdPath = localPath / "SKILL.md"
-    if os.exists(skillMdPath) then
-      val isProject = targetDir.startsWith(os.pwd)
-      installSingleLocalSkill(localPath, targetDir, isProject, options, sourceInfo)
-    else
-      installFromRepo(localPath, targetDir, options, None, sourceInfo)
+    } else {
+      val skillMdPath = localPath / "SKILL.md"
+      if os.exists(skillMdPath) then {
+        val isProject = targetDir.startsWith(os.pwd)
+        installSingleLocalSkill(localPath, targetDir, isProject, options, sourceInfo)
+      } else
+        installFromRepo(localPath, targetDir, options, None, sourceInfo)
+    }
+  }
 
   private def installSingleLocalSkill(
     skillDir: os.Path,
@@ -206,31 +230,33 @@ object Install:
     isProject: Boolean,
     options: InstallOptions,
     sourceInfo: InstallSourceInfo,
-  ): Unit =
+  ): Unit = {
     val skillMdPath = skillDir / "SKILL.md"
-    val content = os.read(skillMdPath)
+    val content     = os.read(skillMdPath)
 
-    if !Yaml.hasValidFrontmatter(content) then
+    if !Yaml.hasValidFrontmatter(content) then {
       System.err.println("Error: Invalid SKILL.md (missing YAML frontmatter)".red)
       sys.exit(1)
+    } else {
+      val skillName  = skillDir.last
+      val targetPath = targetDir / skillName
 
-    val skillName = skillDir.last
-    val targetPath = targetDir / skillName
+      if !warnIfConflict(skillName, targetPath, isProject, options.yes) then println(s"Skipped: $skillName".yellow)
+      else {
+        os.makeDir.all(targetDir)
+        if !isPathInside(targetPath, targetDir) then {
+          System.err.println("Security error: Installation path outside target directory".red)
+          sys.exit(1)
+        } else {
+          os.copy(skillDir, targetPath, replaceExisting = true)
+          SkillMetadata.writeSkillMetadata(targetPath, buildLocalMetadata(sourceInfo, skillDir))
 
-    if !warnIfConflict(skillName, targetPath, isProject, options.yes) then
-      println(s"Skipped: $skillName".yellow)
-      return
-
-    os.makeDir.all(targetDir)
-    if !isPathInside(targetPath, targetDir) then
-      System.err.println("Security error: Installation path outside target directory".red)
-      sys.exit(1)
-
-    os.copy(skillDir, targetPath, replaceExisting = true)
-    SkillMetadata.writeSkillMetadata(targetPath, buildLocalMetadata(sourceInfo, skillDir))
-
-    println(s"\u2705 Installed: $skillName".green)
-    println(s"   Location: $targetPath")
+          println(s"\u2705 Installed: $skillName".green)
+          println(s"   Location: $targetPath")
+        }
+      }
+    }
+  }
 
   private def installSpecificSkill(
     repoDir: os.Path,
@@ -239,36 +265,39 @@ object Install:
     isProject: Boolean,
     options: InstallOptions,
     sourceInfo: InstallSourceInfo,
-  ): Unit =
-    val skillDir = repoDir / os.RelPath(skillSubpath)
+  ): Unit = {
+    val skillDir    = repoDir / os.RelPath(skillSubpath)
     val skillMdPath = skillDir / "SKILL.md"
 
-    if !os.exists(skillMdPath) then
+    if !os.exists(skillMdPath) then {
       System.err.println(s"Error: SKILL.md not found at $skillSubpath".red)
       sys.exit(1)
+    } else {
+      val content = os.read(skillMdPath)
+      if !Yaml.hasValidFrontmatter(content) then {
+        System.err.println("Error: Invalid SKILL.md (missing YAML frontmatter)".red)
+        sys.exit(1)
+      } else {
+        val skillName  = skillSubpath.split("/").last
+        val targetPath = targetDir / skillName
 
-    val content = os.read(skillMdPath)
-    if !Yaml.hasValidFrontmatter(content) then
-      System.err.println("Error: Invalid SKILL.md (missing YAML frontmatter)".red)
-      sys.exit(1)
+        if !warnIfConflict(skillName, targetPath, isProject, options.yes) then println(s"Skipped: $skillName".yellow)
+        else {
+          os.makeDir.all(targetDir)
+          if !isPathInside(targetPath, targetDir) then {
+            System.err.println("Security error: Installation path outside target directory".red)
+            sys.exit(1)
+          } else {
+            os.copy(skillDir, targetPath, replaceExisting = true)
+            SkillMetadata.writeSkillMetadata(targetPath, buildGitMetadata(sourceInfo, skillSubpath))
 
-    val skillName = skillSubpath.split("/").last
-    val targetPath = targetDir / skillName
-
-    if !warnIfConflict(skillName, targetPath, isProject, options.yes) then
-      println(s"Skipped: $skillName".yellow)
-      return
-
-    os.makeDir.all(targetDir)
-    if !isPathInside(targetPath, targetDir) then
-      System.err.println("Security error: Installation path outside target directory".red)
-      sys.exit(1)
-
-    os.copy(skillDir, targetPath, replaceExisting = true)
-    SkillMetadata.writeSkillMetadata(targetPath, buildGitMetadata(sourceInfo, skillSubpath))
-
-    println(s"\u2705 Installed: $skillName".green)
-    println(s"   Location: $targetPath")
+            println(s"\u2705 Installed: $skillName".green)
+            println(s"   Location: $targetPath")
+          }
+        }
+      }
+    }
+  }
 
   private def installFromRepo(
     repoDir: os.Path,
@@ -276,7 +305,7 @@ object Install:
     options: InstallOptions,
     repoName: Option[String],
     sourceInfo: InstallSourceInfo,
-  ): Unit =
+  ): Unit = {
     val rootSkillPath = repoDir / "SKILL.md"
 
     final case class SkillInfo(
@@ -287,121 +316,139 @@ object Install:
       size: Long,
     )
 
-    var skillInfos: List[SkillInfo] =
-      if os.exists(rootSkillPath) then
+    val rootSkillInfos: List[SkillInfo] =
+      if os.exists(rootSkillPath) then {
         val content = os.read(rootSkillPath)
-        if !Yaml.hasValidFrontmatter(content) then
+        if !Yaml.hasValidFrontmatter(content) then {
           System.err.println("Error: Invalid SKILL.md (missing YAML frontmatter)".red)
           sys.exit(1)
-
-        val frontmatterName = Yaml.extractYamlField(content, "name")
-        val skillName = if frontmatterName.nonEmpty then frontmatterName
-                        else repoName.getOrElse(repoDir.last)
-        List(SkillInfo(
-          skillDir = repoDir,
-          skillName = skillName,
-          description = Yaml.extractYamlField(content, "description"),
-          targetPath = targetDir / skillName,
-          size = getDirectorySize(repoDir),
-        ))
-      else
+        } else {
+          val frontmatterName = Yaml.extractYamlField(content, "name")
+          val skillName       =
+            if frontmatterName.nonEmpty then frontmatterName
+            else repoName.getOrElse(repoDir.last)
+          List(
+            SkillInfo(
+              skillDir = repoDir,
+              skillName = skillName,
+              description = Yaml.extractYamlField(content, "description"),
+              targetPath = targetDir / skillName,
+              size = getDirectorySize(repoDir),
+            )
+          )
+        }
+      } else
         Nil
 
-    if skillInfos.isEmpty then
-      def findSkills(dir: os.Path): List[os.Path] =
-        os.list(dir).toList.flatMap { entry =>
-          if os.isDir(entry) then
-            if os.exists(entry / "SKILL.md") then List(entry)
-            else findSkills(entry)
-          else Nil
+    val skillInfos: List[SkillInfo] =
+      if rootSkillInfos.nonEmpty then rootSkillInfos
+      else {
+        def findSkills(dir: os.Path): List[os.Path] =
+          os.list(dir).toList.flatMap { entry =>
+            if os.isDir(entry) then {
+              if os.exists(entry / "SKILL.md") then List(entry)
+              else findSkills(entry)
+            } else Nil
+          }
+
+        val skillDirs = findSkills(repoDir)
+
+        if skillDirs.isEmpty then {
+          System.err.println("Error: No SKILL.md files found in repository".red)
+          sys.exit(1)
+        } else {
+          val fromDirs = skillDirs.flatMap { skillDir =>
+            val skillMdPath = skillDir / "SKILL.md"
+            val content     = os.read(skillMdPath)
+
+            if !Yaml.hasValidFrontmatter(content) then None
+            else {
+              val skillName   = skillDir.last
+              val description = Yaml.extractYamlField(content, "description")
+              val targetPath  = targetDir / skillName
+              val size        = getDirectorySize(skillDir)
+              Some(SkillInfo(skillDir, skillName, description, targetPath, size))
+            }
+          }
+
+          if fromDirs.isEmpty then {
+            System.err.println("Error: No valid SKILL.md files found".red)
+            sys.exit(1)
+          } else
+            fromDirs
         }
-
-      val skillDirs = findSkills(repoDir)
-
-      if skillDirs.isEmpty then
-        System.err.println("Error: No SKILL.md files found in repository".red)
-        sys.exit(1)
-
-      skillInfos = skillDirs.flatMap { skillDir =>
-        val skillMdPath = skillDir / "SKILL.md"
-        val content = os.read(skillMdPath)
-
-        if !Yaml.hasValidFrontmatter(content) then None
-        else
-          val skillName = skillDir.last
-          val description = Yaml.extractYamlField(content, "description")
-          val targetPath = targetDir / skillName
-          val size = getDirectorySize(skillDir)
-          Some(SkillInfo(skillDir, skillName, description, targetPath, size))
       }
-
-      if skillInfos.isEmpty then
-        System.err.println("Error: No valid SKILL.md files found".red)
-        sys.exit(1)
 
     println(s"Found ${skillInfos.length} skill(s)\n".dim)
 
-    var skillsToInstall = skillInfos
+    val skillsToInstall: List[SkillInfo] =
+      if !options.yes && skillInfos.length > 1 then {
+        val labels = skillInfos.map { info =>
+          s"${info.skillName.padTo(25, ' ').bold} ${formatSize(info.size).dim}"
+        }
 
-    if !options.yes && skillInfos.length > 1 then
-      val labels = skillInfos.map { info =>
-        s"${info.skillName.padTo(25, ' ').bold} ${formatSize(info.size).dim}"
+        Prompts.sync.use { prompts =>
+          prompts.multiChoiceAllSelected("Select skills to install", labels) match {
+            case Completion.Finished(selectedLabels) =>
+              if selectedLabels.isEmpty then {
+                println("No skills selected. Installation cancelled.".yellow)
+                Nil
+              } else
+                skillInfos.filter { info =>
+                  selectedLabels.exists(_.contains(info.skillName))
+                }
+
+            case Completion.Fail(CompletionError.Interrupted) =>
+              println("\n\nCancelled by user".yellow)
+              sys.exit(0)
+
+            case Completion.Fail(CompletionError.Error(msg)) =>
+              System.err.println(s"Error: $msg")
+              sys.exit(1)
+          }
+        }
+      } else
+        skillInfos
+
+    if skillsToInstall.nonEmpty then {
+      val isProject = targetDir.startsWith(os.pwd)
+
+      val installedCount = skillsToInstall.count { info =>
+        if warnIfConflict(info.skillName, info.targetPath, isProject, options.yes) then {
+          os.makeDir.all(targetDir)
+          if !isPathInside(info.targetPath, targetDir) then {
+            System.err.println("Security error: Installation path outside target directory".red)
+            false
+          } else {
+            os.copy(info.skillDir, info.targetPath, replaceExisting = true)
+            SkillMetadata.writeSkillMetadata(
+              info.targetPath,
+              buildMetadataFromSource(sourceInfo, info.skillDir, repoDir),
+            )
+            println(s"\u2705 Installed: ${info.skillName}".green)
+            true
+          }
+        } else {
+          println(s"Skipped: ${info.skillName}".yellow)
+          false
+        }
       }
 
-      val cancelled = Prompts.sync.use { prompts =>
-        prompts.multiChoiceAllSelected("Select skills to install", labels) match
-          case Completion.Finished(selectedLabels) =>
-            if selectedLabels.isEmpty then
-              println("No skills selected. Installation cancelled.".yellow)
-              true
-            else
-              skillsToInstall = skillInfos.filter { info =>
-                selectedLabels.exists(_.contains(info.skillName))
-              }
-              false
-
-          case Completion.Fail(CompletionError.Interrupted) =>
-            println("\n\nCancelled by user".yellow)
-            sys.exit(0)
-
-          case Completion.Fail(CompletionError.Error(msg)) =>
-            System.err.println(s"Error: $msg")
-            sys.exit(1)
-      }
-      if cancelled then return
-
-    val isProject = targetDir.startsWith(os.pwd)
-    var installedCount = 0
-
-    for info <- skillsToInstall do
-      if warnIfConflict(info.skillName, info.targetPath, isProject, options.yes) then
-        os.makeDir.all(targetDir)
-        if !isPathInside(info.targetPath, targetDir) then
-          System.err.println("Security error: Installation path outside target directory".red)
-        else
-          os.copy(info.skillDir, info.targetPath, replaceExisting = true)
-          SkillMetadata.writeSkillMetadata(
-            info.targetPath,
-            buildMetadataFromSource(sourceInfo, info.skillDir, repoDir),
-          )
-          println(s"\u2705 Installed: ${info.skillName}".green)
-          installedCount += 1
-      else
-        println(s"Skipped: ${info.skillName}".yellow)
-
-    println(s"\n\u2705 Installation complete: $installedCount skill(s) installed".green)
+      println(s"\n\u2705 Installation complete: $installedCount skill(s) installed".green)
+    } else ()
+  }
 
   private def buildMetadataFromSource(
     sourceInfo: InstallSourceInfo,
     skillDir: os.Path,
     repoDir: os.Path,
   ): SkillSourceMetadata =
-    if sourceInfo.sourceType == SkillSourceType.Local then
-      buildLocalMetadata(sourceInfo, skillDir)
-    else
-      val subpath = skillDir.relativeTo(repoDir).toString
+    if sourceInfo.sourceType == SkillSourceType.Local then buildLocalMetadata(sourceInfo, skillDir)
+    else {
+      val subpath           = skillDir.relativeTo(repoDir).toString
       val normalizedSubpath = if subpath == "." then "" else subpath
       buildGitMetadata(sourceInfo, normalizedSubpath)
+    }
 
   private def buildGitMetadata(sourceInfo: InstallSourceInfo, subpath: String): SkillSourceMetadata =
     SkillSourceMetadata(
@@ -425,29 +472,36 @@ object Install:
     targetPath: os.Path,
     isProject: Boolean,
     skipPrompt: Boolean,
-  ): Boolean =
-    if os.exists(targetPath) then
-      if skipPrompt then
+  ): Boolean = {
+    if os.exists(targetPath) then {
+      if skipPrompt then {
         println(s"Overwriting: $skillName (all existing files and folders will be removed)".dim)
         os.remove.all(targetPath)
         true
-      else
-        println(s"\u26a0 All existing files and folders in '$skillName' will be removed if you choose to overwrite.".yellow)
+      } else
         Prompts.sync.use { prompts =>
-          prompts.confirm(s"Skill '$skillName' already exists. Overwrite?".yellow, default = false) match
+          println(
+            s"\u26a0 All existing files and folders in '$skillName' will be removed if you choose to overwrite.".yellow
+          )
+          prompts.confirm(s"Skill '$skillName' already exists. Overwrite?".yellow, default = false) match {
             case Completion.Finished(shouldOverwrite) =>
-              if shouldOverwrite then os.remove.all(targetPath)
+              if shouldOverwrite then os.remove.all(targetPath) else ()
               shouldOverwrite
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
               sys.exit(0)
             case Completion.Fail(CompletionError.Error(_)) =>
               false
+          }
         }
-    else
-      if !isProject && MarketplaceSkills.anthropicMarketplaceSkills.contains(skillName) then
+    } else {
+      if !isProject && MarketplaceSkills.anthropicMarketplaceSkills.contains(skillName) then {
         System.err.println(s"\n\u26a0\ufe0f  Warning: '$skillName' matches an Anthropic marketplace skill".yellow)
         System.err.println("   Installing globally may conflict with Claude Code plugins.".dim)
         System.err.println("   If you re-enable Claude plugins, this will be overwritten.".dim)
         System.err.println("   Recommend: Use --project flag for conflict-free installation.\n".dim)
+      } else ()
       true
+    }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -4,44 +4,50 @@ import aiskills.core.{Agent, SkillLocation}
 import aiskills.core.utils.Skills
 import extras.scala.io.syntax.color.*
 
-object ListCmd:
+object ListCmd {
 
   /** List all installed skills. */
-  def listSkills(): Unit =
+  def listSkills(): Unit = {
     println("Available Skills:\n".bold)
 
     val skills = Skills.findAllSkills()
 
-    if skills.isEmpty then
+    if skills.isEmpty then {
       println("No skills installed.\n")
       println("Install skills:")
-      println(s"  ${"aiskills install anthropics/skills".cyan}                   ${"# Project, universal (default)".dim}")
+      println(
+        s"  ${"aiskills install anthropics/skills".cyan}                   ${"# Project, universal (default)".dim}"
+      )
       println(s"  ${"aiskills install owner/skill --agent claude".cyan}          ${"# Project, Claude".dim}")
       println(s"  ${"aiskills install owner/skill --all-agents".cyan}            ${"# Project, all agents".dim}")
       println(s"  ${"aiskills install owner/skill --global".cyan}                ${"# Global".dim}")
-      return
-
-    val sorted = skills.sortBy { s =>
-      (s.agent.ordinal, if s.location == SkillLocation.Project then 0 else 1, s.name)
-    }
-
-    for skill <- sorted do
-      val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue
-      println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
-      println(s"    ${skill.description.dim}\n")
-
-    val byAgent = skills.groupBy(_.agent)
-    val agentSummary = Agent.all
-      .filter(byAgent.contains)
-      .map { a =>
-        val count = byAgent(a).length
-        s"${a.toString}: $count"
+    } else {
+      val sorted = skills.sortBy { s =>
+        (s.agent.ordinal, if s.location == SkillLocation.Project then 0 else 1, s.name)
       }
-      .mkString(", ")
 
-    val projectCount = skills.count(_.location == SkillLocation.Project)
-    val globalCount = skills.count(_.location == SkillLocation.Global)
+      for skill <- sorted do {
+        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue
+        println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
+        println(s"    ${skill.description.dim}\n")
+      }
 
-    println(s"Summary: $projectCount project, $globalCount global (${skills.length} total)".dim)
-    if byAgent.size > 1 then
-      println(s"  By agent: $agentSummary".dim)
+      val byAgent      = skills.groupBy(_.agent)
+      val agentSummary = Agent
+        .all
+        .filter(byAgent.contains)
+        .map { a =>
+          val count = byAgent(a).length
+          s"${a.toString}: $count"
+        }
+        .mkString(", ")
+
+      val projectCount = skills.count(_.location == SkillLocation.Project)
+      val globalCount  = skills.count(_.location == SkillLocation.Global)
+
+      println(s"Summary: $projectCount project, $globalCount global (${skills.length} total)".dim)
+      if byAgent.size > 1 then println(s"  By agent: $agentSummary".dim)
+      else ()
+    }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
@@ -5,47 +5,50 @@ import aiskills.core.utils.Skills
 import extras.scala.io.syntax.color.*
 import cue4s.*
 
-object Manage:
+object Manage {
 
   /** Interactively manage (remove) installed skills. */
-  def manageSkills(): Unit =
+  def manageSkills(): Unit = {
     val skills = Skills.findAllSkills()
 
-    if skills.isEmpty then
-      println("No skills installed.")
-      return
+    if skills.isEmpty then println("No skills installed.")
+    else {
+      val sorted = skills.sortBy { s =>
+        (s.agent.ordinal, if s.location == SkillLocation.Project then 0 else 1, s.name)
+      }
 
-    val sorted = skills.sortBy { s =>
-      (s.agent.ordinal, if s.location == SkillLocation.Project then 0 else 1, s.name)
-    }
+      val labels = sorted.map { skill =>
+        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})"
+        s"${skill.name.padTo(25, ' ').bold} $locationLabel"
+      }
 
-    val labels = sorted.map { skill =>
-      val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})"
-      s"${skill.name.padTo(25, ' ').bold} $locationLabel"
-    }
-
-    Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skills to remove", labels) match
-        case Completion.Finished(selectedLabels) =>
-          if selectedLabels.isEmpty then
-            println("No skills selected for removal.".yellow)
-          else
-            val selectedIndices = selectedLabels.flatMap { label =>
-              labels.zipWithIndex.find(_._1 == label).map(_._2)
+      Prompts.sync.use { prompts =>
+        prompts.multiChoiceNoneSelected("Select skills to remove", labels) match {
+          case Completion.Finished(selectedLabels) =>
+            if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
+            else {
+              val selectedIndices = selectedLabels.flatMap { label =>
+                labels.zipWithIndex.find(_._1 == label).map(_._2)
+              }
+              for idx <- selectedIndices do {
+                val skill = sorted(idx)
+                os.remove.all(skill.path)
+                println(
+                  s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString})".green
+                )
+              }
+              println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
             }
-            for idx <- selectedIndices do
-              val skill = sorted(idx)
-              os.remove.all(skill.path)
-              println(
-                s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString})".green
-              )
-            println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
 
-        case Completion.Fail(CompletionError.Interrupted) =>
-          println("\n\nCancelled by user".yellow)
-          sys.exit(0)
+          case Completion.Fail(CompletionError.Interrupted) =>
+            println("\n\nCancelled by user".yellow)
+            sys.exit(0)
 
-        case Completion.Fail(CompletionError.Error(msg)) =>
-          System.err.println(s"Error: $msg")
-          sys.exit(1)
+          case Completion.Fail(CompletionError.Error(msg)) =>
+            System.err.println(s"Error: $msg")
+            sys.exit(1)
+        }
+      }
     }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -3,55 +3,69 @@ package aiskills.cli.commands
 import aiskills.core.ReadOptions
 import aiskills.core.utils.{Dirs, SkillNames, Skills}
 
-object Read:
+object Read {
 
   /** Read skill(s) to stdout (for AI agents). */
-  def readSkill(skillNames: List[String], options: ReadOptions = ReadOptions()): Unit =
+  def readSkill(skillNames: List[String], options: ReadOptions = ReadOptions()): Unit = {
     val names = SkillNames.normalizeSkillNames(skillNames)
-    if names.isEmpty then
+    if names.isEmpty then {
       System.err.println("Error: No skill names provided")
       sys.exit(1)
+    } else {
+      val resolved = List.newBuilder[(String, aiskills.core.SkillLocationInfo)]
+      val missing  = List.newBuilder[String]
 
-    val resolved = List.newBuilder[(String, aiskills.core.SkillLocationInfo)]
-    val missing = List.newBuilder[String]
+      for name <- names do {
+        Skills.findSkill(name, options.prefer) match {
+          case Some(skill) => resolved += ((name, skill))
+          case None => missing += name
+        }
+      }
 
-    for name <- names do
-      Skills.findSkill(name, options.prefer) match
-        case Some(skill) => resolved += ((name, skill))
-        case None        => missing += name
+      val missingList = missing.result()
+      if missingList.nonEmpty then {
+        System.err.println(s"Error: Skill(s) not found: ${missingList.mkString(", ")}")
+        System.err.println()
+        System.err.println("Searched:")
+        for (dir, agent, location) <- Dirs.getSearchDirs() do {
+          val scope = location.toString.toLowerCase
+          val label =
+            if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
+            else dir.relativeTo(os.pwd).toString
+          System.err.println(s"  $label ($scope, ${agent.toString})")
+        }
+        System.err.println()
+        System.err.println("Install skills: aiskills install owner/repo")
+        sys.exit(1)
+      } else ()
 
-    val missingList = missing.result()
-    if missingList.nonEmpty then
-      System.err.println(s"Error: Skill(s) not found: ${missingList.mkString(", ")}")
-      System.err.println()
-      System.err.println("Searched:")
-      for (dir, agent, location) <- Dirs.getSearchDirs() do
-        val scope = location.toString.toLowerCase
-        val label = if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
-                    else dir.relativeTo(os.pwd).toString
-        System.err.println(s"  $label ($scope, ${agent.toString})")
-      System.err.println()
-      System.err.println("Install skills: aiskills install owner/repo")
-      sys.exit(1)
+      for (name, skill) <- resolved.result() do {
+        val content = os.read(skill.path)
+        println(s"Reading: $name")
+        println(s"Base directory: ${skill.baseDir}")
+        println()
+        println(content)
+        println()
+        println(s"Skill read: $name")
 
-    for (name, skill) <- resolved.result() do
-      val content = os.read(skill.path)
-      println(s"Reading: $name")
-      println(s"Base directory: ${skill.baseDir}")
-      println()
-      println(content)
-      println()
-      println(s"Skill read: $name")
-
-      // Note alternatives on stderr
-      val allLocations = Skills.findAllSkillLocations(name)
-      if allLocations.length > 1 then
-        val otherDirs = allLocations
-          .filterNot(_._1 == skill.source)
-          .map { case (dir, agent, _) =>
-            val label = if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
-                        else dir.relativeTo(os.pwd).toString
-            s"$label/ (${agent.toString.toLowerCase})"
-          }
-        if otherDirs.nonEmpty then
-          System.err.println(s"Note: '$name' also found in: ${otherDirs.mkString(", ")} (use --prefer <agent>)")
+        // Note alternatives on stderr
+        val allLocations = Skills.findAllSkillLocations(name)
+        if allLocations.length > 1 then {
+          val otherDirs = allLocations
+            .filterNot(_._1 == skill.source)
+            .map {
+              case (dir, agent, _) =>
+                val label =
+                  if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
+                  else dir.relativeTo(os.pwd).toString
+                s"$label/ (${agent.toString.toLowerCase})"
+            }
+          if otherDirs.nonEmpty then System
+            .err
+            .println(s"Note: '$name' also found in: ${otherDirs.mkString(", ")} (use --prefer <agent>)")
+          else ()
+        } else ()
+      }
+    }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -2,19 +2,22 @@ package aiskills.cli.commands
 
 import aiskills.core.utils.Skills
 
-object Remove:
+object Remove {
 
   /** Remove a specific installed skill. */
-  def removeSkill(skillName: String): Unit =
-    val skill = Skills.findSkill(skillName) match
+  def removeSkill(skillName: String): Unit = {
+    val skill = Skills.findSkill(skillName) match {
       case Some(s) => s
       case None =>
         System.err.println(s"Error: Skill '$skillName' not found")
         sys.exit(1)
+    }
 
     os.remove.all(skill.baseDir)
 
-    val scope = skill.location.toString.toLowerCase
+    val scope     = skill.location.toString.toLowerCase
     val agentName = skill.agent.toString
     println(s"\u2705 Removed: $skillName")
     println(s"   From: $scope, $agentName (${skill.source})")
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -5,11 +5,11 @@ import aiskills.core.utils.{AgentsMd, Dirs, Skills}
 import cue4s.*
 import extras.scala.io.syntax.color.*
 
-object Sync:
+object Sync {
 
   /** Sync skills between agent directories. */
   def syncSkills(options: SyncOptions): Unit =
-    (options.from, options.to, options.skillName, options.allAgents) match
+    (options.from, options.to, options.skillName, options.allAgents) match {
       // Interactive mode: no flags provided
       case (None, None, None, false) =>
         interactiveSync(options.yes)
@@ -21,8 +21,9 @@ object Sync:
       // Specific skill, from specified, all agents
       case (Some(from), None, Some(name), true) =>
         val targets = Agent.all.filterNot(_ == from)
-        for target <- targets do
+        for target <- targets do {
           syncSingleSkill(name, from, target, options.yes)
+        }
 
       // All skills from one agent to another
       case (Some(from), Some(to), None, false) =>
@@ -31,8 +32,9 @@ object Sync:
       // All skills from one agent to all others
       case (Some(from), None, None, true) =>
         val targets = Agent.all.filterNot(_ == from)
-        for target <- targets do
+        for target <- targets do {
           syncAllSkills(from, target, options.yes)
+        }
 
       case _ =>
         System.err.println("Error: Invalid flag combination.".red)
@@ -43,149 +45,162 @@ object Sync:
         System.err.println("  aiskills sync --from <agent> --to <agent>                # All skills")
         System.err.println("  aiskills sync --from <agent> --all-agents                # All skills to all")
         sys.exit(1)
+    }
 
-  private def syncSingleSkill(name: String, from: Agent, to: Agent, yes: Boolean): Unit =
-    if from == to then
-      println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
-      return
+  private def syncSingleSkill(name: String, from: Agent, to: Agent, yes: Boolean): Unit = {
+    if from == to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
+    else {
+      // Try project first, then global
+      val sourceSkills = Skills.findSkillsByAgent(from, global = false) ++ Skills.findSkillsByAgent(from, global = true)
+      val skill        = sourceSkills.find(_.name == name)
 
-    // Try project first, then global
-    val sourceSkills = Skills.findSkillsByAgent(from, global = false) ++ Skills.findSkillsByAgent(from, global = true)
-    val skill = sourceSkills.find(_.name == name)
+      skill match {
+        case None =>
+          System.err.println(s"Error: Skill '$name' not found in ${from.toString} directories".red)
+          sys.exit(1)
 
-    skill match
-      case None =>
-        System.err.println(s"Error: Skill '$name' not found in ${from.toString} directories".red)
-        sys.exit(1)
+        case Some(s) =>
+          val isGlobal   = s.location == SkillLocation.Global
+          val targetDir  = Dirs.getSkillsDir(to, global = isGlobal)
+          val targetPath = targetDir / name
 
-      case Some(s) =>
-        val isGlobal = s.location == SkillLocation.Global
-        val targetDir = Dirs.getSkillsDir(to, global = isGlobal)
-        val targetPath = targetDir / name
+          val proceed =
+            if os.exists(targetPath) && !yes then Prompts.sync.use { prompts =>
+              println(
+                s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
+              )
+              prompts.confirm(
+                s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}). Overwrite?".yellow,
+                default = false,
+              ) match {
+                case Completion.Finished(v) =>
+                  if v then os.remove.all(targetPath) else ()
+                  v
+                case Completion.Fail(CompletionError.Interrupted) =>
+                  println("\n\nCancelled by user".yellow)
+                  sys.exit(0)
+                case Completion.Fail(CompletionError.Error(_)) => false
+              }
+            }
+            else if os.exists(targetPath) then {
+              println(s"Overwriting: $name (all existing files and folders will be removed)".dim)
+              os.remove.all(targetPath)
+              true
+            } else
+              true
 
-        if os.exists(targetPath) && !yes then
-          println(s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow)
-          val proceed = Prompts.sync.use { prompts =>
-            prompts.confirm(
-              s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}). Overwrite?".yellow,
-              default = false,
-            ) match
-              case Completion.Finished(v) =>
-                if v then os.remove.all(targetPath)
-                v
-              case Completion.Fail(CompletionError.Interrupted) =>
-                println("\n\nCancelled by user".yellow)
-                sys.exit(0)
-              case Completion.Fail(CompletionError.Error(_)) => false
-          }
-          if !proceed then
+          if proceed then {
+            os.makeDir.all(targetDir)
+            os.copy(s.path, targetPath, replaceExisting = true)
+            println(s"\u2705 Synced: $name (${from.toString} -> ${to.toString})".green)
+
+            AgentsMd.updateAgentsMdForAgent(to, isGlobal)
+          } else
             println(s"Skipped: $name".yellow)
-            return
-        else if os.exists(targetPath) then
-          println(s"Overwriting: $name (all existing files and folders will be removed)".dim)
-          os.remove.all(targetPath)
+      }
+    }
+  }
 
-        os.makeDir.all(targetDir)
-        os.copy(s.path, targetPath, replaceExisting = true)
-        println(s"\u2705 Synced: $name (${from.toString} -> ${to.toString})".green)
+  private def syncAllSkills(from: Agent, to: Agent, yes: Boolean): Unit = {
+    if from == to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
+    else {
+      val sourceSkills =
+        Skills.findSkillsByAgent(from, global = false) ++ Skills.findSkillsByAgent(from, global = true)
 
-        AgentsMd.updateAgentsMdForAgent(to, isGlobal)
+      if sourceSkills.isEmpty then println(s"No skills found in ${from.toString} directories.".yellow)
+      else {
+        println(s"Syncing ${sourceSkills.length} skill(s) from ${from.toString} to ${to.toString}...".dim)
 
-  private def syncAllSkills(from: Agent, to: Agent, yes: Boolean): Unit =
-    if from == to then
-      println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
-      return
+        val synced = sourceSkills.count { s =>
+          val isGlobal   = s.location == SkillLocation.Global
+          val targetDir  = Dirs.getSkillsDir(to, global = isGlobal)
+          val targetPath = targetDir / s.name
 
-    val sourceSkills = Skills.findSkillsByAgent(from, global = false) ++ Skills.findSkillsByAgent(from, global = true)
+          if os.exists(targetPath) && !yes then {
+            println(s"Skipped: ${s.name} (already exists in ${to.toString}, use --yes to overwrite)".dim)
+            false
+          } else {
+            if os.exists(targetPath) then {
+              println(s"Overwriting: ${s.name} (all existing files and folders will be removed)".dim)
+              os.remove.all(targetPath)
+            } else ()
+            os.makeDir.all(targetDir)
+            os.copy(s.path, targetPath, replaceExisting = true)
+            println(s"\u2705 Synced: ${s.name}".green)
+            true
+          }
+        }
 
-    if sourceSkills.isEmpty then
-      println(s"No skills found in ${from.toString} directories.".yellow)
-      return
+        println(s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green)
 
-    println(s"Syncing ${sourceSkills.length} skill(s) from ${from.toString} to ${to.toString}...".dim)
-    var synced = 0
+        // Update AGENTS.md for target if needed
+        AgentsMd.updateAgentsMdForAgent(to, global = false)
+        AgentsMd.updateAgentsMdForAgent(to, global = true)
+      }
+    }
+  }
 
-    for s <- sourceSkills do
-      val isGlobal = s.location == SkillLocation.Global
-      val targetDir = Dirs.getSkillsDir(to, global = isGlobal)
-      val targetPath = targetDir / s.name
-
-      if os.exists(targetPath) && !yes then
-        println(s"Skipped: ${s.name} (already exists in ${to.toString}, use --yes to overwrite)".dim)
-      else
-        if os.exists(targetPath) then
-          println(s"Overwriting: ${s.name} (all existing files and folders will be removed)".dim)
-          os.remove.all(targetPath)
-        os.makeDir.all(targetDir)
-        os.copy(s.path, targetPath, replaceExisting = true)
-        println(s"\u2705 Synced: ${s.name}".green)
-        synced += 1
-
-    println(s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green)
-
-    // Update AGENTS.md for target if needed
-    AgentsMd.updateAgentsMdForAgent(to, global = false)
-    AgentsMd.updateAgentsMdForAgent(to, global = true)
-
-  private def interactiveSync(yes: Boolean): Unit =
+  private def interactiveSync(yes: Boolean): Unit = {
     val allSkills = Skills.findAllSkills()
 
-    if allSkills.isEmpty then
+    if allSkills.isEmpty then {
       println("No skills installed. Install skills first:")
       println(s"  ${"aiskills install anthropics/skills".cyan}")
-      return
+    } else {
+      val grouped = allSkills.groupBy(_.agent)
+      val agents  = Agent.all.filter(grouped.contains)
 
-    val grouped = allSkills.groupBy(_.agent)
-    val agents = Agent.all.filter(grouped.contains)
+      if agents.length < 1 then println("No skills found in any agent directory.".yellow)
+      else {
+        // Step 1: Pick source agent
+        val agentLabels = agents.map { a =>
+          val count = grouped(a).length
+          s"${a.toString.padTo(15, ' ').bold} ($count skill(s))"
+        }
 
-    if agents.length < 1 then
-      println("No skills found in any agent directory.".yellow)
-      return
-
-    // Step 1: Pick source agent
-    val agentLabels = agents.map { a =>
-      val count = grouped(a).length
-      s"${a.toString.padTo(15, ' ').bold} ($count skill(s))"
-    }
-
-    val sourceAgent = Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select source agent (pick one)", agentLabels) match
-        case Completion.Finished(selectedLabels) =>
-          selectedLabels.headOption.flatMap { label =>
-            agents.find(a => label.contains(a.toString))
-          }
-        case Completion.Fail(CompletionError.Interrupted) =>
-          println("\n\nCancelled by user".yellow)
-          sys.exit(0)
-        case Completion.Fail(CompletionError.Error(msg)) =>
-          System.err.println(s"Error: $msg")
-          sys.exit(1)
-    }
-
-    sourceAgent match
-      case None =>
-        println("No agent selected.".yellow)
-        return
-      case Some(from) =>
-        // Step 2: Pick target agents
-        val targetAgents = Agent.all.filterNot(_ == from)
-        val targetLabels = targetAgents.map(_.toString)
-
-        val selectedTargets = Prompts.sync.use { prompts =>
-          prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match
+        val sourceAgent = Prompts.sync.use { prompts =>
+          prompts.multiChoiceNoneSelected("Select source agent (pick one)", agentLabels) match {
             case Completion.Finished(selectedLabels) =>
-              targetAgents.filter(a => selectedLabels.contains(a.toString))
+              selectedLabels.headOption.flatMap { label =>
+                agents.find(a => label.contains(a.toString))
+              }
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
               sys.exit(0)
             case Completion.Fail(CompletionError.Error(msg)) =>
               System.err.println(s"Error: $msg")
               sys.exit(1)
+          }
         }
 
-        if selectedTargets.isEmpty then
-          println("No target agents selected.".yellow)
-          return
+        sourceAgent match {
+          case None =>
+            println("No agent selected.".yellow)
+          case Some(from) =>
+            // Step 2: Pick target agents
+            val targetAgents = Agent.all.filterNot(_ == from)
+            val targetLabels = targetAgents.map(_.toString)
 
-        for target <- selectedTargets do
-          syncAllSkills(from, target, yes)
+            val selectedTargets = Prompts.sync.use { prompts =>
+              prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
+                case Completion.Finished(selectedLabels) =>
+                  targetAgents.filter(a => selectedLabels.contains(a.toString))
+                case Completion.Fail(CompletionError.Interrupted) =>
+                  println("\n\nCancelled by user".yellow)
+                  sys.exit(0)
+                case Completion.Fail(CompletionError.Error(msg)) =>
+                  System.err.println(s"Error: $msg")
+                  sys.exit(1)
+              }
+            }
+
+            if selectedTargets.isEmpty then println("No target agents selected.".yellow)
+            else
+              for target <- selectedTargets do {
+                syncAllSkills(from, target, yes)
+              }
+        }
+      }
+    }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -4,161 +4,185 @@ import aiskills.core.SkillSourceType
 import aiskills.core.utils.{SkillMetadata, SkillNames, Skills}
 import extras.scala.io.syntax.color.*
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
-object Update:
+object Update {
 
   /** Update installed skills from their recorded source metadata. */
-  def updateSkills(skillNames: List[String]): Unit =
+  def updateSkills(skillNames: List[String]): Unit = {
     val requested = SkillNames.normalizeSkillNames(skillNames)
-    val skills = Skills.findAllSkills()
+    val skills    = Skills.findAllSkills()
 
-    if skills.isEmpty then
+    if skills.isEmpty then {
       println("No skills installed.\n")
       println("Install skills:")
       println(s"  ${"aiskills install anthropics/skills".cyan}         ${"# Project (default)".dim}")
       println(s"  ${"aiskills install owner/skill --global".cyan}     ${"# Global (advanced)".dim}")
-      return
+    } else {
+      val targets =
+        if requested.nonEmpty then {
+          val requestedSet = requested.toSet
+          val missing      = requested.filterNot(name => skills.exists(_.name == name))
+          if missing.nonEmpty then println(s"Skipping missing skills: ${missing.mkString(", ")}".yellow)
+          else ()
+          skills.filter(s => requestedSet.contains(s.name))
+        } else
+          skills
 
-    val targets =
-      if requested.nonEmpty then
-        val requestedSet = requested.toSet
-        val missing = requested.filterNot(name => skills.exists(_.name == name))
-        if missing.nonEmpty then
-          println(s"Skipping missing skills: ${missing.mkString(", ")}".yellow)
-        skills.filter(s => requestedSet.contains(s.name))
-      else
-        skills
+      if targets.isEmpty then println("No matching skills to update.".yellow)
+      else {
+        val missingMetadata       = List.newBuilder[String]
+        val missingLocalSource    = List.newBuilder[String]
+        val missingLocalSkillFile = List.newBuilder[String]
+        val missingRepoUrl        = List.newBuilder[String]
+        val missingRepoSkillFile  = List.newBuilder[(String, String)]
+        val cloneFailures         = List.newBuilder[String]
 
-    if targets.isEmpty then
-      println("No matching skills to update.".yellow)
-      return
+        val (updated, skipped) = targets.foldLeft((0, 0)) {
+          case ((upd, skp), skill) =>
+            val metadata = SkillMetadata.readSkillMetadata(skill.path)
+            metadata match {
+              case None =>
+                println(
+                  s"Skipped: ${skill.name} [${skill.agent.toString}] (no source metadata; re-install once to enable updates)".yellow
+                )
+                missingMetadata += skill.name
+                (upd, skp + 1)
 
-    var updated = 0
-    var skipped = 0
-    val missingMetadata = List.newBuilder[String]
-    val missingLocalSource = List.newBuilder[String]
-    val missingLocalSkillFile = List.newBuilder[String]
-    val missingRepoUrl = List.newBuilder[String]
-    val missingRepoSkillFile = List.newBuilder[(String, String)]
-    val cloneFailures = List.newBuilder[String]
+              case Some(meta) if meta.sourceType == SkillSourceType.Local =>
+                val localPath = meta.localPath.map(os.Path(_))
+                localPath match {
+                  case None =>
+                    println(s"Skipped: ${skill.name} (local source missing)".yellow)
+                    missingLocalSource += skill.name
+                    (upd, skp + 1)
+                  case Some(lp) if !os.exists(lp) =>
+                    println(s"Skipped: ${skill.name} (local source missing)".yellow)
+                    missingLocalSource += skill.name
+                    (upd, skp + 1)
+                  case Some(lp) if !os.exists(lp / "SKILL.md") =>
+                    println(s"Skipped: ${skill.name} (SKILL.md missing at local source)".yellow)
+                    missingLocalSkillFile += skill.name
+                    (upd, skp + 1)
+                  case Some(lp) =>
+                    updateSkillFromDir(skill.path, lp)
+                    SkillMetadata.writeSkillMetadata(
+                      skill.path,
+                      meta.copy(installedAt = aiskills.core.utils.isoNow()),
+                    )
+                    println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
+                    (upd + 1, skp)
+                }
 
-    for skill <- targets do
-      val metadata = SkillMetadata.readSkillMetadata(skill.path)
-      metadata match
-        case None =>
-          println(s"Skipped: ${skill.name} [${skill.agent.toString}] (no source metadata; re-install once to enable updates)".yellow)
-          missingMetadata += skill.name
-          skipped += 1
+              case Some(meta) =>
+                meta.repoUrl match {
+                  case None =>
+                    println(s"Skipped: ${skill.name} (missing repo URL metadata)".yellow)
+                    missingRepoUrl += skill.name
+                    (upd, skp + 1)
 
-        case Some(meta) if meta.sourceType == SkillSourceType.Local =>
-          val localPath = meta.localPath.map(os.Path(_))
-          localPath match
-            case None =>
-              println(s"Skipped: ${skill.name} (local source missing)".yellow)
-              missingLocalSource += skill.name
-              skipped += 1
-            case Some(lp) if !os.exists(lp) =>
-              println(s"Skipped: ${skill.name} (local source missing)".yellow)
-              missingLocalSource += skill.name
-              skipped += 1
-            case Some(lp) if !os.exists(lp / "SKILL.md") =>
-              println(s"Skipped: ${skill.name} (SKILL.md missing at local source)".yellow)
-              missingLocalSkillFile += skill.name
-              skipped += 1
-            case Some(lp) =>
-              updateSkillFromDir(skill.path, lp)
-              SkillMetadata.writeSkillMetadata(
-                skill.path,
-                meta.copy(installedAt = aiskills.core.utils.isoNow()),
-              )
-              println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
-              updated += 1
+                  case Some(repoUrl) =>
+                    val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+                    os.makeDir.all(tempDir)
+                    try {
+                      print(s"Updating ${skill.name}...")
+                      Try {
+                        os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
+                          .call(stderr = os.Pipe)
+                      } match {
+                        case Failure(ex) =>
+                          println(s" failed")
+                          val msg = ex.getMessage
+                          if msg.nonEmpty then println(msg.dim) else ()
+                          println(s"Skipped: ${skill.name} (git clone failed)".yellow)
+                          cloneFailures += skill.name
+                          (upd, skp + 1)
 
-        case Some(meta) =>
-          meta.repoUrl match
-            case None =>
-              println(s"Skipped: ${skill.name} (missing repo URL metadata)".yellow)
-              missingRepoUrl += skill.name
-              skipped += 1
+                        case Success(_) =>
+                          val repoDir   = tempDir / "repo"
+                          val subpath   = meta.subpath.filter(s => s.nonEmpty && s != ".")
+                          val sourceDir = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
 
-            case Some(repoUrl) =>
-              val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
-              os.makeDir.all(tempDir)
-              try
-                print(s"Updating ${skill.name}...")
-                Try {
-                  os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
-                    .call(stderr = os.Pipe)
-                } match
-                  case Failure(ex) =>
-                    println(s" failed")
-                    val msg = ex.getMessage
-                    if msg.nonEmpty then println(msg.dim)
-                    println(s"Skipped: ${skill.name} (git clone failed)".yellow)
-                    cloneFailures += skill.name
-                    skipped += 1
+                          if !os.exists(sourceDir / "SKILL.md") then {
+                            println(s" failed")
+                            println(
+                              s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
+                            )
+                            missingRepoSkillFile += ((skill.name, subpath.getOrElse(".")))
+                            (upd, skp + 1)
+                          } else {
+                            updateSkillFromDir(skill.path, sourceDir)
+                            SkillMetadata.writeSkillMetadata(
+                              skill.path,
+                              meta.copy(installedAt = aiskills.core.utils.isoNow()),
+                            )
+                            println(s" done")
+                            println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
+                            (upd + 1, skp)
+                          }
+                      }
+                    } finally
+                      os.remove.all(tempDir)
+                }
+            }
+        }
 
-                  case Success(_) =>
-                    val repoDir = tempDir / "repo"
-                    val subpath = meta.subpath.filter(s => s.nonEmpty && s != ".")
-                    val sourceDir = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
+        println(s"Summary: $updated updated, $skipped skipped (${targets.length} total)".dim)
 
-                    if !os.exists(sourceDir / "SKILL.md") then
-                      println(s" failed")
-                      println(s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow)
-                      missingRepoSkillFile += ((skill.name, subpath.getOrElse(".")))
-                      skipped += 1
-                    else
-                      updateSkillFromDir(skill.path, sourceDir)
-                      SkillMetadata.writeSkillMetadata(
-                        skill.path,
-                        meta.copy(installedAt = aiskills.core.utils.isoNow()),
-                      )
-                      println(s" done")
-                      println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
-                      updated += 1
-              finally
-                os.remove.all(tempDir)
+        val missingMetadataList = missingMetadata.result()
+        if missingMetadataList.nonEmpty then {
+          println(
+            s"Missing source metadata (${missingMetadataList.length}): ${missingMetadataList.mkString(", ")}".yellow
+          )
+          println("Re-install these skills once to enable updates (e.g., `aiskills install <source>`).".dim)
+        } else ()
 
-    println(s"Summary: $updated updated, $skipped skipped (${targets.length} total)".dim)
+        val missingLocalSourceList = missingLocalSource.result()
+        if missingLocalSourceList.nonEmpty then println(
+          s"Local source missing (${missingLocalSourceList.length}): ${missingLocalSourceList.mkString(", ")}".yellow
+        )
+        else ()
 
-    val missingMetadataList = missingMetadata.result()
-    if missingMetadataList.nonEmpty then
-      println(s"Missing source metadata (${missingMetadataList.length}): ${missingMetadataList.mkString(", ")}".yellow)
-      println("Re-install these skills once to enable updates (e.g., `aiskills install <source>`).".dim)
+        val missingLocalSkillFileList = missingLocalSkillFile.result()
+        if missingLocalSkillFileList.nonEmpty then println(
+          s"Local SKILL.md missing (${missingLocalSkillFileList.length}): ${missingLocalSkillFileList.mkString(", ")}".yellow
+        )
+        else ()
 
-    val missingLocalSourceList = missingLocalSource.result()
-    if missingLocalSourceList.nonEmpty then
-      println(s"Local source missing (${missingLocalSourceList.length}): ${missingLocalSourceList.mkString(", ")}".yellow)
+        val missingRepoUrlList = missingRepoUrl.result()
+        if missingRepoUrlList.nonEmpty then println(
+          s"Missing repo URL metadata (${missingRepoUrlList.length}): ${missingRepoUrlList.mkString(", ")}".yellow
+        )
+        else ()
 
-    val missingLocalSkillFileList = missingLocalSkillFile.result()
-    if missingLocalSkillFileList.nonEmpty then
-      println(s"Local SKILL.md missing (${missingLocalSkillFileList.length}): ${missingLocalSkillFileList.mkString(", ")}".yellow)
+        val missingRepoSkillFileList = missingRepoSkillFile.result()
+        if missingRepoSkillFileList.nonEmpty then {
+          val formatted = missingRepoSkillFileList.map((n, s) => s"$n ($s)").mkString(", ")
+          println(s"Repo SKILL.md missing (${missingRepoSkillFileList.length}): $formatted".yellow)
+        } else ()
 
-    val missingRepoUrlList = missingRepoUrl.result()
-    if missingRepoUrlList.nonEmpty then
-      println(s"Missing repo URL metadata (${missingRepoUrlList.length}): ${missingRepoUrlList.mkString(", ")}".yellow)
+        val cloneFailuresList = cloneFailures.result()
+        if cloneFailuresList.nonEmpty then println(
+          s"Clone failed (${cloneFailuresList.length}): ${cloneFailuresList.mkString(", ")}".yellow
+        )
+        else ()
+      }
+    }
+  }
 
-    val missingRepoSkillFileList = missingRepoSkillFile.result()
-    if missingRepoSkillFileList.nonEmpty then
-      val formatted = missingRepoSkillFileList.map((n, s) => s"$n ($s)").mkString(", ")
-      println(s"Repo SKILL.md missing (${missingRepoSkillFileList.length}): $formatted".yellow)
-
-    val cloneFailuresList = cloneFailures.result()
-    if cloneFailuresList.nonEmpty then
-      println(s"Clone failed (${cloneFailuresList.length}): ${cloneFailuresList.mkString(", ")}".yellow)
-
-  private def updateSkillFromDir(targetPath: os.Path, sourceDir: os.Path): Unit =
+  private def updateSkillFromDir(targetPath: os.Path, sourceDir: os.Path): Unit = {
     val targetDir = targetPath / os.up
     os.makeDir.all(targetDir)
 
-    if !isPathInside(targetPath, targetDir) then
+    if !isPathInside(targetPath, targetDir) then {
       System.err.println("Security error: Installation path outside target directory".red)
       sys.exit(1)
-
-    os.remove.all(targetPath)
-    os.copy(sourceDir, targetPath)
+    } else {
+      os.remove.all(targetPath)
+      os.copy(sourceDir, targetPath)
+    }
+  }
 
   private def isPathInside(target: os.Path, parent: os.Path): Boolean =
     target.startsWith(parent)
+}

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
@@ -3,7 +3,7 @@ package aiskills.cli.commands
 import hedgehog.*
 import hedgehog.runner.*
 
-object InstallSpec extends Properties:
+object InstallSpec extends Properties {
 
   override def tests: List[Test] = List(
     // isLocalPath
@@ -47,86 +47,110 @@ object InstallSpec extends Properties:
 
   // isLocalPath tests
   private def testAbsolutePath: Result =
-    Result.all(List(
-      Result.assert(Install.isLocalPath("/absolute/path/to/skill")),
-      Result.assert(Install.isLocalPath("/Users/test/skills")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isLocalPath("/absolute/path/to/skill")),
+        Result.assert(Install.isLocalPath("/Users/test/skills")),
+      )
+    )
 
   private def testRelativePath: Result =
-    Result.all(List(
-      Result.assert(Install.isLocalPath("./relative/path")),
-      Result.assert(Install.isLocalPath("./skill")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isLocalPath("./relative/path")),
+        Result.assert(Install.isLocalPath("./skill")),
+      )
+    )
 
   private def testParentRelative: Result =
-    Result.all(List(
-      Result.assert(Install.isLocalPath("../parent/path")),
-      Result.assert(Install.isLocalPath("../../../deep/path")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isLocalPath("../parent/path")),
+        Result.assert(Install.isLocalPath("../../../deep/path")),
+      )
+    )
 
   private def testHomePath: Result =
-    Result.all(List(
-      Result.assert(Install.isLocalPath("~/skills/my-skill")),
-      Result.assert(Install.isLocalPath("~/.claude/skills")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isLocalPath("~/skills/my-skill")),
+        Result.assert(Install.isLocalPath("~/.claude/skills")),
+      )
+    )
 
   private def testNotGithub: Result =
-    Result.all(List(
-      Result.assert(!Install.isLocalPath("owner/repo")),
-      Result.assert(!Install.isLocalPath("anthropics/skills")),
-      Result.assert(!Install.isLocalPath("owner/repo/skill-path")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Install.isLocalPath("owner/repo")),
+        Result.assert(!Install.isLocalPath("anthropics/skills")),
+        Result.assert(!Install.isLocalPath("owner/repo/skill-path")),
+      )
+    )
 
   private def testNotGitUrl: Result =
-    Result.all(List(
-      Result.assert(!Install.isLocalPath("git@github.com:owner/repo.git")),
-      Result.assert(!Install.isLocalPath("https://github.com/owner/repo")),
-      Result.assert(!Install.isLocalPath("http://github.com/owner/repo")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Install.isLocalPath("git@github.com:owner/repo.git")),
+        Result.assert(!Install.isLocalPath("https://github.com/owner/repo")),
+        Result.assert(!Install.isLocalPath("http://github.com/owner/repo")),
+      )
+    )
 
   private def testNotPlain: Result =
-    Result.all(List(
-      Result.assert(!Install.isLocalPath("skill-name")),
-      Result.assert(!Install.isLocalPath("my-skill")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Install.isLocalPath("skill-name")),
+        Result.assert(!Install.isLocalPath("my-skill")),
+      )
+    )
 
   // isGitUrl tests
   private def testSshUrl: Result =
-    Result.all(List(
-      Result.assert(Install.isGitUrl("git@github.com:owner/repo.git")),
-      Result.assert(Install.isGitUrl("git@gitlab.com:group/project.git")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isGitUrl("git@github.com:owner/repo.git")),
+        Result.assert(Install.isGitUrl("git@gitlab.com:group/project.git")),
+      )
+    )
 
   private def testGitProtocol: Result =
     Result.assert(Install.isGitUrl("git://github.com/owner/repo.git"))
 
   private def testHttpsUrl: Result =
-    Result.all(List(
-      Result.assert(Install.isGitUrl("https://github.com/owner/repo")),
-      Result.assert(Install.isGitUrl("https://github.com/owner/repo.git")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isGitUrl("https://github.com/owner/repo")),
+        Result.assert(Install.isGitUrl("https://github.com/owner/repo.git")),
+      )
+    )
 
   private def testHttpUrl: Result =
     Result.assert(Install.isGitUrl("http://github.com/owner/repo"))
 
   private def testDotGit: Result =
-    Result.all(List(
-      Result.assert(Install.isGitUrl("custom-host.com/repo.git")),
-      Result.assert(Install.isGitUrl("anything.git")),
-    ))
+    Result.all(
+      List(
+        Result.assert(Install.isGitUrl("custom-host.com/repo.git")),
+        Result.assert(Install.isGitUrl("anything.git")),
+      )
+    )
 
   private def testGitUrlNotGithub: Result =
-    Result.all(List(
-      Result.assert(!Install.isGitUrl("owner/repo")),
-      Result.assert(!Install.isGitUrl("anthropics/skills")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Install.isGitUrl("owner/repo")),
+        Result.assert(!Install.isGitUrl("anthropics/skills")),
+      )
+    )
 
   private def testGitUrlNotLocal: Result =
-    Result.all(List(
-      Result.assert(!Install.isGitUrl("/absolute/path")),
-      Result.assert(!Install.isGitUrl("./relative/path")),
-      Result.assert(!Install.isGitUrl("~/home/path")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Install.isGitUrl("/absolute/path")),
+        Result.assert(!Install.isGitUrl("./relative/path")),
+        Result.assert(!Install.isGitUrl("~/home/path")),
+      )
+    )
 
   // expandPath tests
   private def testExpandTilde: Result =
@@ -140,35 +164,45 @@ object InstallSpec extends Properties:
 
   // isPathInside tests
   private def testPathInsideNormal: Result =
-    Result.assert(Install.isPathInside(
-      os.Path("/home/user/.claude/skills/my-skill"),
-      os.Path("/home/user/.claude/skills"),
-    ))
+    Result.assert(
+      Install.isPathInside(
+        os.Path("/home/user/.claude/skills/my-skill"),
+        os.Path("/home/user/.claude/skills"),
+      )
+    )
 
   private def testPathInsideTraversal: Result =
     // os.Path resolves .. automatically
-    Result.assert(!Install.isPathInside(
-      os.Path("/etc/passwd"),
-      os.Path("/home/user/.claude/skills"),
-    ))
+    Result.assert(
+      !Install.isPathInside(
+        os.Path("/etc/passwd"),
+        os.Path("/home/user/.claude/skills"),
+      )
+    )
 
   private def testPathInsideOutside: Result =
-    Result.assert(!Install.isPathInside(
-      os.Path("/etc/passwd"),
-      os.Path("/home/user/.claude/skills"),
-    ))
+    Result.assert(
+      !Install.isPathInside(
+        os.Path("/etc/passwd"),
+        os.Path("/home/user/.claude/skills"),
+      )
+    )
 
   private def testPathInsidePrefixNotChild: Result =
-    Result.assert(!Install.isPathInside(
-      os.Path("/home/user/.claude/skills-evil"),
-      os.Path("/home/user/.claude/skills"),
-    ))
+    Result.assert(
+      !Install.isPathInside(
+        os.Path("/home/user/.claude/skills-evil"),
+        os.Path("/home/user/.claude/skills"),
+      )
+    )
 
   private def testPathInsideNested: Result =
-    Result.assert(Install.isPathInside(
-      os.Path("/home/user/.claude/skills/category/my-skill"),
-      os.Path("/home/user/.claude/skills"),
-    ))
+    Result.assert(
+      Install.isPathInside(
+        os.Path("/home/user/.claude/skills/category/my-skill"),
+        os.Path("/home/user/.claude/skills"),
+      )
+    )
 
   // getRepoName tests
   private def testRepoNameHttps: Result =
@@ -191,18 +225,25 @@ object InstallSpec extends Properties:
     Install.formatSize(1048576) ==== "1.0MB"
 
   // GitHub shorthand parsing
-  private def testGithubOwnerRepo: Result =
+  private def testGithubOwnerRepo: Result = {
     val parts = "anthropics/skills".split("/").toList
-    Result.all(List(
-      parts.length ==== 2,
-      s"https://github.com/${parts(0)}/${parts(1)}" ==== "https://github.com/anthropics/skills",
-    ))
+    Result.all(
+      List(
+        parts.length ==== 2,
+        s"https://github.com/${parts(0)}/${parts(1)}" ==== "https://github.com/anthropics/skills",
+      )
+    )
+  }
 
-  private def testGithubOwnerRepoPath: Result =
+  private def testGithubOwnerRepoPath: Result = {
     val source = "anthropics/skills/document-skills/pdf"
-    val parts = source.split("/").toList
-    Result.all(List(
-      Result.assert(parts.length > 2),
-      s"https://github.com/${parts(0)}/${parts(1)}" ==== "https://github.com/anthropics/skills",
-      parts.drop(2).mkString("/") ==== "document-skills/pdf",
-    ))
+    val parts  = source.split("/").toList
+    Result.all(
+      List(
+        Result.assert(parts.length > 2),
+        s"https://github.com/${parts(0)}/${parts(1)}" ==== "https://github.com/anthropics/skills",
+        parts.drop(2).mkString("/") ==== "document-skills/pdf",
+      )
+    )
+  }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -1,17 +1,19 @@
 package aiskills.core
 
+import cats.syntax.either.*
 import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 
-enum Agent(val projectDirName: String, val globalDirName: String):
+enum Agent(val projectDirName: String, val globalDirName: String) {
   case Universal extends Agent(".agents", ".agents")
-  case Claude    extends Agent(".claude", ".claude")
-  case Cursor    extends Agent(".cursor", ".cursor")
-  case Codex     extends Agent(".codex", ".codex")
-  case Gemini    extends Agent(".gemini", ".gemini")
-  case Copilot   extends Agent(".github", ".copilot")
+  case Claude extends Agent(".claude", ".claude")
+  case Cursor extends Agent(".cursor", ".cursor")
+  case Codex extends Agent(".codex", ".codex")
+  case Gemini extends Agent(".gemini", ".gemini")
+  case Copilot extends Agent(".github", ".copilot")
+}
 
-object Agent:
+object Agent {
   val all: List[Agent] = Agent.values.toList
 
   val allNonUniversal: List[Agent] = all.filterNot(_ == Agent.Universal)
@@ -20,30 +22,34 @@ object Agent:
     all.find(_.toString.equalsIgnoreCase(s))
 
   def needsAgentsMd(agent: Agent): Boolean =
-    agent match
+    agent match {
       case Agent.Universal | Agent.Codex => true
-      case _                             => false
+      case _ => false
+    }
 
   given Encoder[Agent] = Encoder.encodeString.contramap(_.toString.toLowerCase)
 
   given Decoder[Agent] = Decoder.decodeString.emap { s =>
     fromString(s).toRight(s"Invalid Agent: $s. Valid agents: ${all.map(_.toString.toLowerCase).mkString(", ")}")
   }
+}
 
-enum SkillLocation:
+enum SkillLocation {
   case Project, Global
+}
 
-object SkillLocation:
+object SkillLocation {
   given Encoder[SkillLocation] = Encoder.encodeString.contramap {
     case SkillLocation.Project => "project"
-    case SkillLocation.Global  => "global"
+    case SkillLocation.Global => "global"
   }
 
   given Decoder[SkillLocation] = Decoder.decodeString.emap {
-    case "project" => Right(SkillLocation.Project)
-    case "global"  => Right(SkillLocation.Global)
-    case other     => Left(s"Invalid SkillLocation: $other")
+    case "project" => SkillLocation.Project.asRight
+    case "global" => SkillLocation.Global.asRight
+    case other => s"Invalid SkillLocation: $other".asLeft
   }
+}
 
 final case class Skill(
   name: String,
@@ -78,22 +84,24 @@ final case class SkillMetadata(
   context: Option[String] = None,
 )
 
-enum SkillSourceType:
+enum SkillSourceType {
   case Git, GitHub, Local
+}
 
-object SkillSourceType:
+object SkillSourceType {
   given Encoder[SkillSourceType] = Encoder.encodeString.contramap {
-    case SkillSourceType.Git    => "git"
+    case SkillSourceType.Git => "git"
     case SkillSourceType.GitHub => "github"
-    case SkillSourceType.Local  => "local"
+    case SkillSourceType.Local => "local"
   }
 
   given Decoder[SkillSourceType] = Decoder.decodeString.emap {
-    case "git"    => Right(SkillSourceType.Git)
-    case "github" => Right(SkillSourceType.GitHub)
-    case "local"  => Right(SkillSourceType.Local)
-    case other    => Left(s"Invalid SkillSourceType: $other")
+    case "git" => SkillSourceType.Git.asRight
+    case "github" => SkillSourceType.GitHub.asRight
+    case "local" => SkillSourceType.Local.asRight
+    case other => s"Invalid SkillSourceType: $other".asLeft
   }
+}
 
 final case class SkillSourceMetadata(
   source: String,
@@ -104,41 +112,40 @@ final case class SkillSourceMetadata(
   installedAt: String,
 )
 
-object SkillSourceMetadata:
+object SkillSourceMetadata {
   given Encoder[SkillSourceMetadata] = deriveEncoder[SkillSourceMetadata]
   given Decoder[SkillSourceMetadata] = deriveDecoder[SkillSourceMetadata]
+}
 
-sealed trait AiSkillsError:
-  def message: String
+sealed trait AiSkillsError
 
-object AiSkillsError:
-  final case class SkillNotFound(name: String) extends AiSkillsError:
-    def message: String = s"Skill '$name' not found"
+object AiSkillsError {
+  final case class SkillNotFound(name: String) extends AiSkillsError
+  final case class GitCloneError(url: String, detail: String) extends AiSkillsError
+  final case class MetadataParseError(path: os.Path, detail: String) extends AiSkillsError
+  final case class InvalidFrontmatter(path: os.Path) extends AiSkillsError
+  final case class InvalidSource(source: String) extends AiSkillsError
+  final case class PathTraversalError(target: os.Path, parent: os.Path) extends AiSkillsError
+  final case class InvalidOutputPath(path: String) extends AiSkillsError
+  final case class IoError(detail: String) extends AiSkillsError
+  final case class InvalidAgent(name: String) extends AiSkillsError
 
-  final case class GitCloneError(url: String, detail: String) extends AiSkillsError:
-    def message: String = s"Failed to clone repository: $url ($detail)"
-
-  final case class MetadataParseError(path: os.Path, detail: String) extends AiSkillsError:
-    def message: String = s"Failed to parse metadata at $path: $detail"
-
-  final case class InvalidFrontmatter(path: os.Path) extends AiSkillsError:
-    def message: String = s"Invalid SKILL.md (missing YAML frontmatter) at $path"
-
-  final case class InvalidSource(source: String) extends AiSkillsError:
-    def message: String = s"Invalid source format: $source"
-
-  final case class PathTraversalError(target: os.Path, parent: os.Path) extends AiSkillsError:
-    def message: String = s"Security error: Installation path $target outside target directory $parent"
-
-  final case class InvalidOutputPath(path: String) extends AiSkillsError:
-    def message: String = s"Output file must be a markdown file (.md): $path"
-
-  final case class IoError(detail: String) extends AiSkillsError:
-    def message: String = s"I/O error: $detail"
-
-  final case class InvalidAgent(name: String) extends AiSkillsError:
-    def message: String =
-      s"Invalid agent: '$name'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+  extension (error: AiSkillsError) {
+    def message: String = error match {
+      case SkillNotFound(name) => s"Skill '$name' not found"
+      case GitCloneError(url, detail) => s"Failed to clone repository: $url ($detail)"
+      case MetadataParseError(path, detail) => s"Failed to parse metadata at $path: $detail"
+      case InvalidFrontmatter(path) => s"Invalid SKILL.md (missing YAML frontmatter) at $path"
+      case InvalidSource(source) => s"Invalid source format: $source"
+      case PathTraversalError(target, parent) =>
+        s"Security error: Installation path $target outside target directory $parent"
+      case InvalidOutputPath(path) => s"Output file must be a markdown file (.md): $path"
+      case IoError(detail) => s"I/O error: $detail"
+      case InvalidAgent(name) =>
+        s"Invalid agent: '$name'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+    }
+  }
+}
 
 final case class SyncOptions(
   skillName: Option[String] = None,

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
@@ -5,27 +5,30 @@ import aiskills.core.{Agent, Skill}
 import scala.util.matching.Regex
 import scala.xml.{Elem, PrettyPrinter}
 
-object AgentsMd:
+object AgentsMd {
 
   /** Parse skill names currently in AGENTS.md content. */
-  def parseCurrentSkills(content: String): List[String] =
+  def parseCurrentSkills(content: String): List[String] = {
     val skillRegex = """<skill>[\s\S]*?<name>([^<]+)</name>[\s\S]*?</skill>""".r
     skillRegex.findAllMatchIn(content).map(_.group(1).trim).toList
+  }
 
   /** Generate skills XML section for AGENTS.md. */
-  def generateSkillsXml(skills: List[Skill]): String =
+  def generateSkillsXml(skills: List[Skill]): String = {
     val printer = new PrettyPrinter(120, 0)
 
-    val skillTags = skills.map { s =>
-      val skillElem: Elem =
-        <skill>
+    val skillTags = skills
+      .map { s =>
+        val skillElem: Elem =
+          <skill>
           <name>{s.name}</name>
           <description>{s.description}</description>
           <location>{s.location.toString.toLowerCase}</location>
           <agent>{s.agent.toString.toLowerCase}</agent>
         </skill>
-      printer.format(skillElem)
-    }.mkString("\n\n")
+        printer.format(skillElem)
+      }
+      .mkString("\n\n")
 
     s"""<skills-system priority="1">
        |
@@ -55,63 +58,72 @@ object AgentsMd:
        |<!-- SKILLS_TABLE_END -->
        |
        |</skills-system>""".stripMargin
+  }
 
   /** Replace or add skills section in AGENTS.md content. */
-  def replaceSkillsSection(content: String, newSection: String): String =
-    val xmlMarkerStart = "<skills-system"
+  def replaceSkillsSection(content: String, newSection: String): String = {
+    val xmlMarkerStart    = "<skills-system"
     val xmlMarkerStartOld = "<skills_system"
-    val xmlRegex = """<skills[_-]system[^>]*>[\s\S]*?</skills[_-]system>""".r
+    val xmlRegex          = """<skills[_-]system[^>]*>[\s\S]*?</skills[_-]system>""".r
 
-    if content.contains(xmlMarkerStart) || content.contains(xmlMarkerStartOld) then
-      xmlRegex.replaceFirstIn(content, Regex.quoteReplacement(newSection))
-    else
+    if content.contains(xmlMarkerStart) || content
+      .contains(xmlMarkerStartOld) then xmlRegex.replaceFirstIn(content, Regex.quoteReplacement(newSection))
+    else {
       val htmlStart = "<!-- SKILLS_TABLE_START -->"
-      val htmlEnd = "<!-- SKILLS_TABLE_END -->"
+      val htmlEnd   = "<!-- SKILLS_TABLE_END -->"
 
-      if content.contains(htmlStart) then
+      if content.contains(htmlStart) then {
         val innerContent = newSection
           .replaceAll("""<skills[_-]system[^>]*>""", "")
           .replace("</skills-system>", "")
           .replace("</skills_system>", "")
-        val htmlRegex = s"""(?s)${Regex.quote(htmlStart)}[\\s\\S]*?${Regex.quote(htmlEnd)}""".r
+        val htmlRegex    = s"""(?s)${Regex.quote(htmlStart)}[\\s\\S]*?${Regex.quote(htmlEnd)}""".r
         htmlRegex.replaceFirstIn(
           content,
           Regex.quoteReplacement(s"$htmlStart\n$innerContent\n$htmlEnd"),
         )
-      else
+      } else
         content.stripTrailing + "\n\n" + newSection + "\n"
+    }
+  }
 
   /** Remove skills section from AGENTS.md content. */
-  def removeSkillsSection(content: String): String =
-    val xmlMarkerStart = "<skills-system"
+  def removeSkillsSection(content: String): String = {
+    val xmlMarkerStart    = "<skills-system"
     val xmlMarkerStartOld = "<skills_system"
-    val xmlRegex = """<skills[_-]system[^>]*>[\s\S]*?</skills[_-]system>""".r
+    val xmlRegex          = """<skills[_-]system[^>]*>[\s\S]*?</skills[_-]system>""".r
 
-    if content.contains(xmlMarkerStart) || content.contains(xmlMarkerStartOld) then
-      xmlRegex.replaceFirstIn(content, "<!-- Skills section removed -->")
-    else
+    if content.contains(xmlMarkerStart) || content
+      .contains(xmlMarkerStartOld) then xmlRegex.replaceFirstIn(content, "<!-- Skills section removed -->")
+    else {
       val htmlStart = "<!-- SKILLS_TABLE_START -->"
-      val htmlEnd = "<!-- SKILLS_TABLE_END -->"
+      val htmlEnd   = "<!-- SKILLS_TABLE_END -->"
 
-      if content.contains(htmlStart) then
+      if content.contains(htmlStart) then {
         val htmlRegex = s"""(?s)${Regex.quote(htmlStart)}[\\s\\S]*?${Regex.quote(htmlEnd)}""".r
         htmlRegex.replaceFirstIn(
           content,
           Regex.quoteReplacement(s"$htmlStart\n<!-- Skills section removed -->\n$htmlEnd"),
         )
-      else
+      } else
         content
+    }
+  }
 
   /** Update AGENTS.md for agents that need it (e.g., Codex, Universal). */
-  def updateAgentsMdForAgent(agent: Agent, global: Boolean): Unit =
-    if Agent.needsAgentsMd(agent) then
+  def updateAgentsMdForAgent(agent: Agent, global: Boolean): Unit = {
+    if Agent.needsAgentsMd(agent) then {
       val outputPath = if global then os.home / "AGENTS.md" else os.pwd / "AGENTS.md"
-      val skills = Skills.findAllSkills()
-      if skills.nonEmpty then
+      val skills     = Skills.findAllSkills()
+      if skills.nonEmpty then {
         val xml = generateSkillsXml(skills)
-        if os.exists(outputPath) then
+        if os.exists(outputPath) then {
           val content = os.read(outputPath)
           val updated = replaceSkillsSection(content, xml)
           os.write.over(outputPath, updated)
-        else
+        } else
           os.write(outputPath, s"# AGENTS\n\n$xml\n")
+      } else ()
+    } else ()
+  }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -2,44 +2,44 @@ package aiskills.core.utils
 
 import aiskills.core.{Agent, SkillLocation}
 
-object Dirs:
+object Dirs {
 
   /** Get skills directory path for a specific agent. */
   def getSkillsDir(agent: Agent, global: Boolean = false): os.Path =
     if global then os.home / os.RelPath(agent.globalDirName) / "skills"
     else os.pwd / os.RelPath(agent.projectDirName) / "skills"
 
-  /**
-   * Get all searchable skill directories in priority order.
-   * Priority:
-   *   1. Project universal (.agents)
-   *   2. Project agent-specific (alphabetical by agent name)
-   *   3. Global universal (~/.agents)
-   *   4. Global agent-specific (alphabetical by agent name)
-   */
-  def getSearchDirs(): List[(os.Path, Agent, SkillLocation)] =
+  /** Get all searchable skill directories in priority order.
+    * Priority:
+    *   1. Project universal (.agents)
+    *   2. Project agent-specific (alphabetical by agent name)
+    *   3. Global universal (~/.agents)
+    *   4. Global agent-specific (alphabetical by agent name)
+    */
+  def getSearchDirs(): List[(os.Path, Agent, SkillLocation)] = {
     val agentsSorted = Agent.allNonUniversal.sortBy(_.toString)
 
     val projectUniversal = List(
       (os.pwd / os.RelPath(Agent.Universal.projectDirName) / "skills", Agent.Universal, SkillLocation.Project)
     )
-    val projectSpecific = agentsSorted.map(a =>
-      (os.pwd / os.RelPath(a.projectDirName) / "skills", a, SkillLocation.Project)
-    )
-    val globalUniversal = List(
+    val projectSpecific  =
+      agentsSorted.map(a => (os.pwd / os.RelPath(a.projectDirName) / "skills", a, SkillLocation.Project))
+    val globalUniversal  = List(
       (os.home / os.RelPath(Agent.Universal.globalDirName) / "skills", Agent.Universal, SkillLocation.Global)
     )
-    val globalSpecific = agentsSorted.map(a =>
-      (os.home / os.RelPath(a.globalDirName) / "skills", a, SkillLocation.Global)
-    )
+    val globalSpecific   =
+      agentsSorted.map(a => (os.home / os.RelPath(a.globalDirName) / "skills", a, SkillLocation.Global))
 
     projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific
+  }
 
   /** Get search dirs with a preferred agent's directories bumped to the front. */
   def getSearchDirs(prefer: Option[Agent]): List[(os.Path, Agent, SkillLocation)] =
-    prefer match
-      case None            => getSearchDirs()
+    prefer match {
+      case None => getSearchDirs()
       case Some(preferred) =>
-        val all = getSearchDirs()
+        val all                   = getSearchDirs()
         val (preferredDirs, rest) = all.partition(_._2 == preferred)
         preferredDirs ++ rest
+    }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/MarketplaceSkills.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/MarketplaceSkills.scala
@@ -1,6 +1,6 @@
 package aiskills.core.utils
 
-object MarketplaceSkills:
+object MarketplaceSkills {
 
   /** Known skills from Anthropic's marketplace. Used to warn about potential conflicts. */
   val anthropicMarketplaceSkills: Set[String] = Set(
@@ -22,3 +22,4 @@ object MarketplaceSkills:
     "theme-factory",
     "webapp-testing",
   )
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMetadata.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMetadata.scala
@@ -6,24 +6,27 @@ import io.circe.syntax.*
 
 import scala.util.Try
 
-object SkillMetadata:
+object SkillMetadata {
 
   val SkillMetadataFile: String = ".aiskills.json"
 
   /** Read skill source metadata from a skill directory. */
-  def readSkillMetadata(skillDir: os.Path): Option[SkillSourceMetadata] =
+  def readSkillMetadata(skillDir: os.Path): Option[SkillSourceMetadata] = {
     val metadataPath = skillDir / SkillMetadataFile
     if !os.exists(metadataPath) then None
     else
       Try(os.read(metadataPath))
         .toOption
         .flatMap(raw => decode[SkillSourceMetadata](raw).toOption)
+  }
 
   /** Write skill source metadata to a skill directory. */
-  def writeSkillMetadata(skillDir: os.Path, metadata: SkillSourceMetadata): Unit =
+  def writeSkillMetadata(skillDir: os.Path, metadata: SkillSourceMetadata): Unit = {
     val metadataPath = skillDir / SkillMetadataFile
-    val payload = if metadata.installedAt.isEmpty then
-      metadata.copy(installedAt = isoNow())
-    else
-      metadata
+    val payload      =
+      if metadata.installedAt.isEmpty then metadata.copy(installedAt = isoNow())
+      else
+        metadata
     os.write.over(metadataPath, payload.asJson.spaces2)
+  }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillNames.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillNames.scala
@@ -1,6 +1,6 @@
 package aiskills.core.utils
 
-object SkillNames:
+object SkillNames {
 
   /** Normalize skill names: split commas, trim whitespace, deduplicate. */
   def normalizeSkillNames(input: List[String]): List[String] =
@@ -9,3 +9,4 @@ object SkillNames:
       .map(_.trim)
       .filter(_.nonEmpty)
       .distinct
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
@@ -4,26 +4,26 @@ import aiskills.core.{Agent, Skill, SkillLocation, SkillLocationInfo}
 
 import scala.util.Try
 
-object Skills:
+object Skills {
 
   /** Check if a path is a directory (follows symlinks). Returns false for broken symlinks. */
   private def isDirectoryOrSymlinkToDirectory(path: os.Path): Boolean =
     Try(os.isDir(path)).getOrElse(false)
 
   /** Find all installed skills across all agent directories. No deduplication. */
-  def findAllSkills(): List[Skill] =
-    val dirs = Dirs.getSearchDirs()
+  def findAllSkills(): List[Skill] = {
+    val dirs   = Dirs.getSearchDirs()
     val skills = List.newBuilder[Skill]
 
-    for
+    for {
       (dir, agent, location) <- dirs
       if os.exists(dir)
-      entry <- os.list(dir)
+      entry                  <- os.list(dir)
       if isDirectoryOrSymlinkToDirectory(entry)
-      name = entry.last
+      name      = entry.last
       skillPath = entry / "SKILL.md"
       if os.exists(skillPath)
-    do
+    } do {
       val content = os.read(skillPath)
       skills += Skill(
         name = name,
@@ -32,53 +32,65 @@ object Skills:
         agent = agent,
         path = entry,
       )
+    }
 
     skills.result()
+  }
 
   /** Find a specific skill by name. Returns the first match in priority order. */
   def findSkill(skillName: String): Option[SkillLocationInfo] =
     findSkill(skillName, prefer = None)
 
   /** Find a specific skill by name with optional agent preference. */
-  def findSkill(skillName: String, prefer: Option[Agent]): Option[SkillLocationInfo] =
+  def findSkill(skillName: String, prefer: Option[Agent]): Option[SkillLocationInfo] = {
     val dirs = Dirs.getSearchDirs(prefer)
-    dirs.iterator
+    dirs
+      .iterator
       .map { case (dir, agent, location) => (dir / skillName / "SKILL.md", agent, location) }
       .find { case (skillPath, _, _) => os.exists(skillPath) }
-      .map { case (skillPath, agent, location) =>
-        SkillLocationInfo(
-          path = skillPath,
-          baseDir = skillPath / os.up,
-          source = skillPath / os.up / os.up,
-          agent = agent,
-          location = location,
-        )
+      .map {
+        case (skillPath, agent, location) =>
+          SkillLocationInfo(
+            path = skillPath,
+            baseDir = skillPath / os.up,
+            source = skillPath / os.up / os.up,
+            agent = agent,
+            location = location,
+          )
       }
+  }
 
   /** Find all locations where a skill with the given name exists. */
   def findAllSkillLocations(skillName: String): List[(os.Path, Agent, SkillLocation)] =
-    Dirs.getSearchDirs().filter { case (dir, _, _) =>
-      os.exists(dir / skillName / "SKILL.md")
+    Dirs.getSearchDirs().filter {
+      case (dir, _, _) =>
+        os.exists(dir / skillName / "SKILL.md")
     }
 
   /** Find all skills installed for a specific agent. */
-  def findSkillsByAgent(agent: Agent, global: Boolean): List[Skill] =
-    val dir = Dirs.getSkillsDir(agent, global)
+  def findSkillsByAgent(agent: Agent, global: Boolean): List[Skill] = {
+    val dir      = Dirs.getSkillsDir(agent, global)
     val location = if global then SkillLocation.Global else SkillLocation.Project
     if !os.exists(dir) then Nil
     else
       os.list(dir).toList.flatMap { entry =>
         if !isDirectoryOrSymlinkToDirectory(entry) then None
-        else
+        else {
           val skillPath = entry / "SKILL.md"
           if !os.exists(skillPath) then None
-          else
+          else {
             val content = os.read(skillPath)
-            Some(Skill(
-              name = entry.last,
-              description = Yaml.extractYamlField(content, "description"),
-              location = location,
-              agent = agent,
-              path = entry,
-            ))
+            Some(
+              Skill(
+                name = entry.last,
+                description = Yaml.extractYamlField(content, "description"),
+                location = location,
+                agent = agent,
+                path = entry,
+              )
+            )
+          }
+        }
       }
+  }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TimeUtil.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TimeUtil.scala
@@ -2,47 +2,56 @@ package aiskills.core.utils
 
 import java.util.Date
 
+import scala.annotation.tailrec
+
 /** Generate an ISO-8601-like timestamp string, compatible with Scala Native. */
-def isoNow(): String =
-  val now = new Date()
+def isoNow(): String = {
+  val now    = new Date()
   // Date.toISOString is not available, so we format manually
   val millis = now.getTime
-  val secs = millis / 1000
-  val ms = millis % 1000
+  val secs   = millis / 1000
+  val ms     = millis % 1000
 
   // Calculate date/time components from epoch millis
   val totalDays = (secs / 86400).toInt
-  val timeOfDay = (secs % 86400).toInt
-  val hours = timeOfDay / 3600
-  val minutes = (timeOfDay % 3600) / 60
-  val seconds = timeOfDay % 60
+  val timeOfDay = (secs      % 86400).toInt
+  val hours     = timeOfDay / 3600
+  val minutes   = (timeOfDay % 3600) / 60
+  val seconds   = timeOfDay  % 60
 
   // Compute year/month/day from days since epoch (1970-01-01)
-  var y = 1970
-  var remaining = totalDays
-  while
-    val daysInYear = if isLeapYear(y) then 366 else 365
-    remaining >= daysInYear
-  do
-    val daysInYear = if isLeapYear(y) then 366 else 365
-    remaining -= daysInYear
-    y += 1
+  val (y, daysAfterYear) = computeYear(1970, totalDays)
 
   val monthDays =
     if isLeapYear(y) then Array(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
     else Array(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 
-  var m = 0
-  while m < 12 && remaining >= monthDays(m) do
-    remaining -= monthDays(m)
-    m += 1
+  val (m, daysAfterMonth) = computeMonth(0, daysAfterYear, monthDays)
 
-  val day = remaining + 1
+  val day   = daysAfterMonth + 1
   val month = m + 1
 
   f"$y%04d-$month%02d-$day%02d" +
     f"T$hours%02d:$minutes%02d:$seconds%02d" +
     f".$ms%03dZ"
+}
+
+@tailrec
+private def computeYear(year: Int, remainingDays: Int): (Int, Int) = {
+  val daysInYear = if isLeapYear(year) then 366 else 365
+  if remainingDays >= daysInYear then computeYear(year + 1, remainingDays - daysInYear)
+  else (year, remainingDays)
+}
+
+@tailrec
+private def computeMonth(month: Int, remainingDays: Int, monthDays: Array[Int]): (Int, Int) = {
+  if month < 12 && remainingDays >= monthDays(month) then computeMonth(
+    month + 1,
+    remainingDays - monthDays(month),
+    monthDays
+  )
+  else (month, remainingDays)
+}
 
 private def isLeapYear(y: Int): Boolean =
   (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
@@ -2,17 +2,19 @@ package aiskills.core.utils
 
 import scala.util.matching.Regex
 
-object Yaml:
+object Yaml {
 
   private val fieldPattern: String => Regex =
     field => s"""(?m)^${Regex.quote(field)}:\\s*(.+?)$$""".r
 
   /** Extract a single field value from YAML frontmatter. */
   def extractYamlField(content: String, field: String): String =
-    fieldPattern(field).findFirstMatchIn(content) match
+    fieldPattern(field).findFirstMatchIn(content) match {
       case Some(m) => m.group(1).trim
-      case None    => ""
+      case None => ""
+    }
 
   /** Check if content starts with YAML frontmatter delimiter. */
   def hasValidFrontmatter(content: String): Boolean =
     content.trim.startsWith("---")
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
@@ -4,7 +4,7 @@ import hedgehog.*
 import hedgehog.runner.*
 import io.circe.syntax.*
 
-object AgentSpec extends Properties:
+object AgentSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("fromString: valid lowercase", testFromStringLowercase),
@@ -23,28 +23,34 @@ object AgentSpec extends Properties:
   )
 
   private def testFromStringLowercase: Result =
-    Result.all(List(
-      Agent.fromString("universal") ==== Some(Agent.Universal),
-      Agent.fromString("claude") ==== Some(Agent.Claude),
-      Agent.fromString("cursor") ==== Some(Agent.Cursor),
-      Agent.fromString("codex") ==== Some(Agent.Codex),
-      Agent.fromString("gemini") ==== Some(Agent.Gemini),
-      Agent.fromString("copilot") ==== Some(Agent.Copilot),
-    ))
+    Result.all(
+      List(
+        Agent.fromString("universal") ==== Some(Agent.Universal),
+        Agent.fromString("claude") ==== Some(Agent.Claude),
+        Agent.fromString("cursor") ==== Some(Agent.Cursor),
+        Agent.fromString("codex") ==== Some(Agent.Codex),
+        Agent.fromString("gemini") ==== Some(Agent.Gemini),
+        Agent.fromString("copilot") ==== Some(Agent.Copilot),
+      )
+    )
 
   private def testFromStringMixedCase: Result =
-    Result.all(List(
-      Agent.fromString("Claude") ==== Some(Agent.Claude),
-      Agent.fromString("CURSOR") ==== Some(Agent.Cursor),
-      Agent.fromString("Universal") ==== Some(Agent.Universal),
-    ))
+    Result.all(
+      List(
+        Agent.fromString("Claude") ==== Some(Agent.Claude),
+        Agent.fromString("CURSOR") ==== Some(Agent.Cursor),
+        Agent.fromString("Universal") ==== Some(Agent.Universal),
+      )
+    )
 
   private def testFromStringInvalid: Result =
-    Result.all(List(
-      Agent.fromString("invalid") ==== None,
-      Agent.fromString("") ==== None,
-      Agent.fromString("vscode") ==== None,
-    ))
+    Result.all(
+      List(
+        Agent.fromString("invalid") ==== None,
+        Agent.fromString("") ==== None,
+        Agent.fromString("vscode") ==== None,
+      )
+    )
 
   private def testUniversalProjectDir: Result =
     Agent.Universal.projectDirName ==== ".agents"
@@ -56,10 +62,12 @@ object AgentSpec extends Properties:
     Agent.Claude.projectDirName ==== ".claude"
 
   private def testCopilotAsymmetry: Result =
-    Result.all(List(
-      Agent.Copilot.projectDirName ==== ".github",
-      Agent.Copilot.globalDirName ==== ".copilot",
-    ))
+    Result.all(
+      List(
+        Agent.Copilot.projectDirName ==== ".github",
+        Agent.Copilot.globalDirName ==== ".copilot",
+      )
+    )
 
   private def testAllCount: Result =
     Agent.all.length ==== 6
@@ -71,24 +79,29 @@ object AgentSpec extends Properties:
     Result.assert(!Agent.allNonUniversal.contains(Agent.Universal))
 
   private def testNeedsAgentsMd: Result =
-    Result.all(List(
-      Result.assert(Agent.needsAgentsMd(Agent.Universal)),
-      Result.assert(Agent.needsAgentsMd(Agent.Codex)),
-    ))
+    Result.all(
+      List(
+        Result.assert(Agent.needsAgentsMd(Agent.Universal)),
+        Result.assert(Agent.needsAgentsMd(Agent.Codex)),
+      )
+    )
 
   private def testDoesNotNeedAgentsMd: Result =
-    Result.all(List(
-      Result.assert(!Agent.needsAgentsMd(Agent.Claude)),
-      Result.assert(!Agent.needsAgentsMd(Agent.Cursor)),
-      Result.assert(!Agent.needsAgentsMd(Agent.Gemini)),
-      Result.assert(!Agent.needsAgentsMd(Agent.Copilot)),
-    ))
+    Result.all(
+      List(
+        Result.assert(!Agent.needsAgentsMd(Agent.Claude)),
+        Result.assert(!Agent.needsAgentsMd(Agent.Cursor)),
+        Result.assert(!Agent.needsAgentsMd(Agent.Gemini)),
+        Result.assert(!Agent.needsAgentsMd(Agent.Copilot)),
+      )
+    )
 
   private def testEncoderDecoderRoundTrip: Result =
     Result.all(
       Agent.all.map { agent =>
-        val json = agent.asJson
+        val json    = agent.asJson
         val decoded = json.as[Agent]
         decoded ==== Right(agent)
       }
     )
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentsMdSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentsMdSpec.scala
@@ -4,7 +4,7 @@ import aiskills.core.{Agent, Skill, SkillLocation}
 import hedgehog.*
 import hedgehog.runner.*
 
-object AgentsMdSpec extends Properties:
+object AgentsMdSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("generateSkillsXml: generates valid XML for skills", testGenerateXml),
@@ -30,37 +30,48 @@ object AgentsMdSpec extends Properties:
     Skill("xlsx", "Spreadsheet editing", SkillLocation.Global, Agent.Universal, os.home / "path" / "to" / "xlsx"),
   )
 
-  private def testGenerateXml: Result =
+  private def testGenerateXml: Result = {
     val xml = AgentsMd.generateSkillsXml(sampleSkills)
-    Result.all(List(
-      Result.assert(xml.contains("""<skills-system priority="1">""")),
-      Result.assert(xml.contains("<name>pdf</name>")),
-      Result.assert(xml.contains("<description>PDF manipulation</description>")),
-      Result.assert(xml.contains("<location>project</location>")),
-      Result.assert(xml.contains("<name>xlsx</name>")),
-      Result.assert(xml.contains("<description>Spreadsheet editing</description>")),
-      Result.assert(xml.contains("<location>global</location>")),
-      Result.assert(xml.contains("</skills-system>")),
-    ))
+    Result.all(
+      List(
+        Result.assert(xml.contains("""<skills-system priority="1">""")),
+        Result.assert(xml.contains("<name>pdf</name>")),
+        Result.assert(xml.contains("<description>PDF manipulation</description>")),
+        Result.assert(xml.contains("<location>project</location>")),
+        Result.assert(xml.contains("<name>xlsx</name>")),
+        Result.assert(xml.contains("<description>Spreadsheet editing</description>")),
+        Result.assert(xml.contains("<location>global</location>")),
+        Result.assert(xml.contains("</skills-system>")),
+      )
+    )
+  }
 
-  private def testUsageInstructions: Result =
-    val xml = AgentsMd.generateSkillsXml(List(
-      Skill("test", "Test skill", SkillLocation.Project, Agent.Claude, os.pwd / "path"),
-    ))
-    Result.all(List(
-      Result.assert(xml.contains("<usage>")),
-      Result.assert(xml.contains("aiskills read")),
-      Result.assert(xml.contains("</usage>")),
-    ))
+  private def testUsageInstructions: Result = {
+    val xml = AgentsMd.generateSkillsXml(
+      List(
+        Skill("test", "Test skill", SkillLocation.Project, Agent.Claude, os.pwd / "path"),
+      )
+    )
+    Result.all(
+      List(
+        Result.assert(xml.contains("<usage>")),
+        Result.assert(xml.contains("aiskills read")),
+        Result.assert(xml.contains("</usage>")),
+      )
+    )
+  }
 
-  private def testEmptySkills: Result =
+  private def testEmptySkills: Result = {
     val xml = AgentsMd.generateSkillsXml(Nil)
-    Result.all(List(
-      Result.assert(xml.contains("<available-skills>")),
-      Result.assert(xml.contains("</available-skills>")),
-    ))
+    Result.all(
+      List(
+        Result.assert(xml.contains("<available-skills>")),
+        Result.assert(xml.contains("</available-skills>")),
+      )
+    )
+  }
 
-  private def testParseSkills: Result =
+  private def testParseSkills: Result = {
     val content =
       """# AGENTS.md
         |
@@ -78,20 +89,24 @@ object AgentsMdSpec extends Properties:
         |</skills-system>""".stripMargin
 
     val skills = AgentsMd.parseCurrentSkills(content)
-    Result.all(List(
-      Result.assert(skills.contains("pdf")),
-      Result.assert(skills.contains("xlsx")),
-      skills.length ==== 2,
-    ))
+    Result.all(
+      List(
+        Result.assert(skills.contains("pdf")),
+        Result.assert(skills.contains("xlsx")),
+        skills.length ==== 2,
+      )
+    )
+  }
 
   private def testParseEmpty: Result =
     AgentsMd.parseCurrentSkills("# AGENTS.md\n\nNo skills here.").length ==== 0
 
-  private def testParseMalformed: Result =
+  private def testParseMalformed: Result = {
     val skills = AgentsMd.parseCurrentSkills("<skill><name>broken")
     Result.assert(skills.isEmpty)
+  }
 
-  private def testReplaceXml: Result =
+  private def testReplaceXml: Result = {
     val content =
       """# AGENTS.md
         |
@@ -102,14 +117,17 @@ object AgentsMdSpec extends Properties:
         |Other content""".stripMargin
 
     val newSection = """<skills-system priority="1">NEW CONTENT</skills-system>"""
-    val result = AgentsMd.replaceSkillsSection(content, newSection)
-    Result.all(List(
-      Result.assert(result.contains("NEW CONTENT")),
-      Result.assert(!result.contains("OLD CONTENT")),
-      Result.assert(result.contains("Other content")),
-    ))
+    val result     = AgentsMd.replaceSkillsSection(content, newSection)
+    Result.all(
+      List(
+        Result.assert(result.contains("NEW CONTENT")),
+        Result.assert(!result.contains("OLD CONTENT")),
+        Result.assert(result.contains("Other content")),
+      )
+    )
+  }
 
-  private def testReplaceHtml: Result =
+  private def testReplaceHtml: Result = {
     val content =
       """# AGENTS.md
         |
@@ -120,22 +138,28 @@ object AgentsMdSpec extends Properties:
         |Footer""".stripMargin
 
     val newSection = "<skills-system>NEW SKILLS</skills-system>"
-    val result = AgentsMd.replaceSkillsSection(content, newSection)
-    Result.all(List(
-      Result.assert(result.contains("NEW SKILLS")),
-      Result.assert(!result.contains("OLD SKILLS")),
-    ))
+    val result     = AgentsMd.replaceSkillsSection(content, newSection)
+    Result.all(
+      List(
+        Result.assert(result.contains("NEW SKILLS")),
+        Result.assert(!result.contains("OLD SKILLS")),
+      )
+    )
+  }
 
-  private def testAppend: Result =
-    val content = "# AGENTS.md\n\nSome content."
+  private def testAppend: Result = {
+    val content    = "# AGENTS.md\n\nSome content."
     val newSection = "<skills-system>SKILLS</skills-system>"
-    val result = AgentsMd.replaceSkillsSection(content, newSection)
-    Result.all(List(
-      Result.assert(result.contains("Some content.")),
-      Result.assert(result.contains("<skills-system>SKILLS</skills-system>")),
-    ))
+    val result     = AgentsMd.replaceSkillsSection(content, newSection)
+    Result.all(
+      List(
+        Result.assert(result.contains("Some content.")),
+        Result.assert(result.contains("<skills-system>SKILLS</skills-system>")),
+      )
+    )
+  }
 
-  private def testRemoveXml: Result =
+  private def testRemoveXml: Result = {
     val content =
       """# AGENTS.md
         |
@@ -146,16 +170,20 @@ object AgentsMdSpec extends Properties:
         |Footer""".stripMargin
 
     val result = AgentsMd.removeSkillsSection(content)
-    Result.all(List(
-      Result.assert(!result.contains("Skills content")),
-      Result.assert(result.contains("Footer")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!result.contains("Skills content")),
+        Result.assert(result.contains("Footer")),
+      )
+    )
+  }
 
-  private def testRemoveNone: Result =
+  private def testRemoveNone: Result = {
     val content = "# AGENTS.md\n\nNo skills."
     AgentsMd.removeSkillsSection(content) ==== content
+  }
 
-  private def testXmlEscaping: Result =
+  private def testXmlEscaping: Result = {
     val skills = List(
       Skill(
         "test & <demo>",
@@ -165,19 +193,22 @@ object AgentsMdSpec extends Properties:
         os.pwd / "path",
       ),
     )
-    val xml = AgentsMd.generateSkillsXml(skills)
-    Result.all(List(
-      Result.assert(xml.contains("&amp;")),
-      Result.assert(xml.contains("&lt;")),
-      Result.assert(xml.contains("&gt;")),
-      Result.assert(!xml.contains("<demo>")),
-      Result.assert(!xml.contains("<special>")),
-      Result.assert(xml.contains("test &amp; &lt;demo&gt;")),
-      Result.assert(xml.contains("&quot;")),
-      Result.assert(xml.contains("Handles &quot;quotes&quot; &amp; &lt;special&gt; chars")),
-    ))
+    val xml    = AgentsMd.generateSkillsXml(skills)
+    Result.all(
+      List(
+        Result.assert(xml.contains("&amp;")),
+        Result.assert(xml.contains("&lt;")),
+        Result.assert(xml.contains("&gt;")),
+        Result.assert(!xml.contains("<demo>")),
+        Result.assert(!xml.contains("<special>")),
+        Result.assert(xml.contains("test &amp; &lt;demo&gt;")),
+        Result.assert(xml.contains("&quot;")),
+        Result.assert(xml.contains("Handles &quot;quotes&quot; &amp; &lt;special&gt; chars")),
+      )
+    )
+  }
 
-  private def testReplaceOldFormat: Result =
+  private def testReplaceOldFormat: Result = {
     val content =
       """# AGENTS.md
         |
@@ -188,15 +219,18 @@ object AgentsMdSpec extends Properties:
         |Other content""".stripMargin
 
     val newSection = """<skills-system priority="1">NEW CONTENT</skills-system>"""
-    val result = AgentsMd.replaceSkillsSection(content, newSection)
-    Result.all(List(
-      Result.assert(result.contains("NEW CONTENT")),
-      Result.assert(!result.contains("OLD CONTENT")),
-      Result.assert(result.contains("Other content")),
-      Result.assert(!result.contains("skills_system")),
-    ))
+    val result     = AgentsMd.replaceSkillsSection(content, newSection)
+    Result.all(
+      List(
+        Result.assert(result.contains("NEW CONTENT")),
+        Result.assert(!result.contains("OLD CONTENT")),
+        Result.assert(result.contains("Other content")),
+        Result.assert(!result.contains("skills_system")),
+      )
+    )
+  }
 
-  private def testRemoveOldFormat: Result =
+  private def testRemoveOldFormat: Result = {
     val content =
       """# AGENTS.md
         |
@@ -207,13 +241,16 @@ object AgentsMdSpec extends Properties:
         |Footer""".stripMargin
 
     val result = AgentsMd.removeSkillsSection(content)
-    Result.all(List(
-      Result.assert(!result.contains("Skills content")),
-      Result.assert(result.contains("Footer")),
-      Result.assert(!result.contains("skills_system")),
-    ))
+    Result.all(
+      List(
+        Result.assert(!result.contains("Skills content")),
+        Result.assert(result.contains("Footer")),
+        Result.assert(!result.contains("skills_system")),
+      )
+    )
+  }
 
-  private def testParseKebabCase: Result =
+  private def testParseKebabCase: Result = {
     val content =
       """# AGENTS.md
         |
@@ -227,14 +264,21 @@ object AgentsMdSpec extends Properties:
         |</skills-system>""".stripMargin
 
     val skills = AgentsMd.parseCurrentSkills(content)
-    Result.all(List(
-      Result.assert(skills.contains("pdf")),
-      skills.length ==== 1,
-    ))
+    Result.all(
+      List(
+        Result.assert(skills.contains("pdf")),
+        skills.length ==== 1,
+      )
+    )
+  }
 
-  private def testAgentElement: Result =
+  private def testAgentElement: Result = {
     val xml = AgentsMd.generateSkillsXml(sampleSkills)
-    Result.all(List(
-      Result.assert(xml.contains("<agent>claude</agent>")),
-      Result.assert(xml.contains("<agent>universal</agent>")),
-    ))
+    Result.all(
+      List(
+        Result.assert(xml.contains("<agent>claude</agent>")),
+        Result.assert(xml.contains("<agent>universal</agent>")),
+      )
+    )
+  }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -4,7 +4,7 @@ import aiskills.core.{Agent, SkillLocation}
 import hedgehog.*
 import hedgehog.runner.*
 
-object DirsSpec extends Properties:
+object DirsSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("getSkillsDir: project Universal uses .agents", testProjectUniversal),
@@ -50,59 +50,71 @@ object DirsSpec extends Properties:
   private def testProjectGemini: Result =
     Dirs.getSkillsDir(Agent.Gemini) ==== (os.pwd / ".gemini" / "skills")
 
-  private def testSearchDirsCount: Result =
+  private def testSearchDirsCount: Result = {
     val dirs = Dirs.getSearchDirs()
     dirs.length ==== 12
+  }
 
-  private def testSearchDirsOrder: Result =
+  private def testSearchDirsOrder: Result = {
     val dirs = Dirs.getSearchDirs()
     // 1. Project universal
     // 2-6. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini)
     // 7. Global universal
     // 8-12. Global agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini)
-    Result.all(List(
-      // Project universal
-      dirs(0) ==== ((os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project)),
-      // Project agent-specific (alphabetical)
-      dirs(1)._2 ==== Agent.Claude,
-      dirs(2)._2 ==== Agent.Codex,
-      dirs(3)._2 ==== Agent.Copilot,
-      dirs(4)._2 ==== Agent.Cursor,
-      dirs(5)._2 ==== Agent.Gemini,
-      // All project dirs are Project location
-      Result.assert(dirs.take(6).forall(_._3 == SkillLocation.Project)),
-      // Global universal
-      dirs(6) ==== ((os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global)),
-      // Global agent-specific (alphabetical)
-      dirs(7)._2 ==== Agent.Claude,
-      dirs(8)._2 ==== Agent.Codex,
-      dirs(9)._2 ==== Agent.Copilot,
-      dirs(10)._2 ==== Agent.Cursor,
-      dirs(11)._2 ==== Agent.Gemini,
-      // All global dirs are Global location
-      Result.assert(dirs.drop(6).forall(_._3 == SkillLocation.Global)),
-    ))
+    Result.all(
+      List(
+        // Project universal
+        dirs(0) ==== ((os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project)),
+        // Project agent-specific (alphabetical)
+        dirs(1)._2 ==== Agent.Claude,
+        dirs(2)._2 ==== Agent.Codex,
+        dirs(3)._2 ==== Agent.Copilot,
+        dirs(4)._2 ==== Agent.Cursor,
+        dirs(5)._2 ==== Agent.Gemini,
+        // All project dirs are Project location
+        Result.assert(dirs.take(6).forall(_._3 == SkillLocation.Project)),
+        // Global universal
+        dirs(6) ==== ((os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global)),
+        // Global agent-specific (alphabetical)
+        dirs(7)._2 ==== Agent.Claude,
+        dirs(8)._2 ==== Agent.Codex,
+        dirs(9)._2 ==== Agent.Copilot,
+        dirs(10)._2 ==== Agent.Cursor,
+        dirs(11)._2 ==== Agent.Gemini,
+        // All global dirs are Global location
+        Result.assert(dirs.drop(6).forall(_._3 == SkillLocation.Global)),
+      )
+    )
+  }
 
-  private def testSearchDirsFirst: Result =
-    val dirs = Dirs.getSearchDirs()
+  private def testSearchDirsFirst: Result = {
+    val dirs                    = Dirs.getSearchDirs()
     val (path, agent, location) = dirs.head
-    Result.all(List(
-      path ==== (os.pwd / ".agents" / "skills"),
-      agent ==== Agent.Universal,
-      location ==== SkillLocation.Project,
-    ))
+    Result.all(
+      List(
+        path ==== (os.pwd / ".agents" / "skills"),
+        agent ==== Agent.Universal,
+        location ==== SkillLocation.Project,
+      )
+    )
+  }
 
-  private def testSearchDirsPrefer: Result =
-    val dirs = Dirs.getSearchDirs(Some(Agent.Cursor))
+  private def testSearchDirsPrefer: Result = {
+    val dirs                       = Dirs.getSearchDirs(Some(Agent.Cursor))
     // Cursor dirs should be first
     val (firstPath, firstAgent, _) = dirs.head
-    Result.all(List(
-      firstAgent ==== Agent.Cursor,
-      // Should still have 12 dirs
-      dirs.length ==== 12,
-    ))
+    Result.all(
+      List(
+        firstAgent ==== Agent.Cursor,
+        // Should still have 12 dirs
+        dirs.length ==== 12,
+      )
+    )
+  }
 
-  private def testSearchDirsPreferNone: Result =
-    val defaultDirs = Dirs.getSearchDirs()
+  private def testSearchDirsPreferNone: Result = {
+    val defaultDirs    = Dirs.getSearchDirs()
     val preferNoneDirs = Dirs.getSearchDirs(None)
     defaultDirs ==== preferNoneDirs
+  }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillMetadataSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillMetadataSpec.scala
@@ -4,7 +4,7 @@ import aiskills.core.{SkillSourceMetadata, SkillSourceType}
 import hedgehog.*
 import hedgehog.runner.*
 
-object SkillMetadataSpec extends Properties:
+object SkillMetadataSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("writes and reads metadata", testWriteAndRead),
@@ -12,10 +12,11 @@ object SkillMetadataSpec extends Properties:
     example("returns None for invalid JSON", testInvalidJson),
   )
 
-  private def withTempDir[A](f: os.Path => A): A =
+  private def withTempDir[A](f: os.Path => A): A = {
     val tempDir = os.temp.dir(prefix = "aiskills-metadata-test-")
     try f(tempDir)
     finally os.remove.all(tempDir)
+  }
 
   private def testWriteAndRead: Result =
     withTempDir { tempDir =>
@@ -30,14 +31,19 @@ object SkillMetadataSpec extends Properties:
       SkillMetadata.writeSkillMetadata(tempDir, payload)
       val read = SkillMetadata.readSkillMetadata(tempDir)
 
-      Result.all(List(
-        Result.assert(read.isDefined),
-        read.get.source ==== payload.source,
-        read.get.sourceType ==== payload.sourceType,
-        read.get.repoUrl ==== payload.repoUrl,
-        read.get.subpath ==== payload.subpath,
-        read.get.installedAt ==== payload.installedAt,
-      ))
+      read match {
+        case Some(r) =>
+          Result.all(
+            List(
+              r.source ==== payload.source,
+              r.sourceType ==== payload.sourceType,
+              r.repoUrl ==== payload.repoUrl,
+              r.subpath ==== payload.subpath,
+              r.installedAt ==== payload.installedAt,
+            )
+          )
+        case None => Result.failure.log("Expected Some but got None")
+      }
     }
 
   private def testMissing: Result =
@@ -50,3 +56,4 @@ object SkillMetadataSpec extends Properties:
       os.write(tempDir / SkillMetadata.SkillMetadataFile, "{not-json")
       Result.assert(SkillMetadata.readSkillMetadata(tempDir).isEmpty)
     }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillNamesSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillNamesSpec.scala
@@ -3,7 +3,7 @@ package aiskills.core.utils
 import hedgehog.*
 import hedgehog.runner.*
 
-object SkillNamesSpec extends Properties:
+object SkillNamesSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("splits comma-separated names", testSplitComma),
@@ -27,3 +27,4 @@ object SkillNamesSpec extends Properties:
 
   private def testEmpty: Result =
     SkillNames.normalizeSkillNames(List.empty) ==== List.empty
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillsSpec.scala
@@ -3,7 +3,7 @@ package aiskills.core.utils
 import hedgehog.*
 import hedgehog.runner.*
 
-object SkillsSpec extends Properties:
+object SkillsSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("findAllSkills: finds regular directory skills", testFindRegular),
@@ -21,10 +21,10 @@ object SkillsSpec extends Properties:
     example("findSkill: returns first match in priority order", testFindPriority),
   )
 
-  private def withTestDirs[A](f: (os.Path, os.Path) => A): A =
-    val testRoot = os.temp.dir(prefix = "aiskills-test-")
+  private def withTestDirs[A](f: (os.Path, os.Path) => A): A = {
+    val testRoot      = os.temp.dir(prefix = "aiskills-test-")
     val projectSkills = testRoot / "project" / ".claude" / "skills"
-    val globalSkills = testRoot / "global" / ".claude" / "skills"
+    val globalSkills  = testRoot / "global" / ".claude" / "skills"
     os.makeDir.all(projectSkills)
     os.makeDir.all(globalSkills)
 
@@ -34,10 +34,13 @@ object SkillsSpec extends Properties:
     // For unit testing, we test the helper functions directly
     try f(projectSkills, globalSkills)
     finally os.remove.all(testRoot)
+  }
 
   private def createSkill(
-    baseDir: os.Path, skillName: String, description: String //= "Test skill"
-  ): Unit =
+    baseDir: os.Path,
+    skillName: String,
+    description: String // = "Test skill"
+  ): Unit = {
     val skillDir = baseDir / skillName
     os.makeDir.all(skillDir)
     os.write(
@@ -51,13 +54,14 @@ object SkillsSpec extends Properties:
          |
          |This is a test skill.""".stripMargin,
     )
+  }
 
   private def createSymlinkedSkill(
     skillsDir: os.Path,
     targetDir: os.Path,
     skillName: String,
-    description: String //= "Symlinked test skill",
-  ): Unit =
+    description: String // = "Symlinked test skill",
+  ): Unit = {
     val actualSkillDir = targetDir / skillName
     os.makeDir.all(actualSkillDir)
     os.write(
@@ -72,6 +76,7 @@ object SkillsSpec extends Properties:
          |This is a symlinked test skill.""".stripMargin,
     )
     os.symlink(skillsDir / skillName, actualSkillDir)
+  }
 
   // Note: These tests exercise the skill creation/reading logic directly
   // since we cannot easily mock getSearchDirs without DI.
@@ -81,8 +86,8 @@ object SkillsSpec extends Properties:
     withTestDirs { (projectSkills, _) =>
       createSkill(projectSkills, "regular-skill", "A regular skill")
       val skillPath = projectSkills / "regular-skill" / "SKILL.md"
-      val content = os.read(skillPath)
-      val desc = Yaml.extractYamlField(content, "description")
+      val content   = os.read(skillPath)
+      val desc      = Yaml.extractYamlField(content, "description")
       desc ==== "A regular skill"
     }
 
@@ -92,10 +97,12 @@ object SkillsSpec extends Properties:
       os.makeDir.all(targetDir)
       createSymlinkedSkill(globalSkills, targetDir, "symlinked-skill", "A symlinked skill")
       val skillPath = globalSkills / "symlinked-skill" / "SKILL.md"
-      Result.all(List(
-        Result.assert(os.exists(skillPath)),
-        Yaml.extractYamlField(os.read(skillPath), "description") ==== "A symlinked skill",
-      ))
+      Result.all(
+        List(
+          Result.assert(os.exists(skillPath)),
+          Yaml.extractYamlField(os.read(skillPath), "description") ==== "A symlinked skill",
+        )
+      )
     }
 
   private def testFindBoth: Result =
@@ -104,10 +111,12 @@ object SkillsSpec extends Properties:
       val targetDir = globalSkills / os.up / "symlink-targets"
       os.makeDir.all(targetDir)
       createSymlinkedSkill(globalSkills, targetDir, "symlinked-skill", "Symlinked")
-      Result.all(List(
-        Result.assert(os.exists(projectSkills / "regular-skill" / "SKILL.md")),
-        Result.assert(os.exists(globalSkills / "symlinked-skill" / "SKILL.md")),
-      ))
+      Result.all(
+        List(
+          Result.assert(os.exists(projectSkills / "regular-skill" / "SKILL.md")),
+          Result.assert(os.exists(globalSkills / "symlinked-skill" / "SKILL.md")),
+        )
+      )
     }
 
   private def testBrokenSymlink: Result =
@@ -124,11 +133,13 @@ object SkillsSpec extends Properties:
       createSkill(globalSkills, "duplicate-skill", "Global version")
       // Both should exist independently
       val projectContent = os.read(projectSkills / "duplicate-skill" / "SKILL.md")
-      val globalContent = os.read(globalSkills / "duplicate-skill" / "SKILL.md")
-      Result.all(List(
-        Yaml.extractYamlField(projectContent, "description") ==== "Project version",
-        Yaml.extractYamlField(globalContent, "description") ==== "Global version",
-      ))
+      val globalContent  = os.read(globalSkills / "duplicate-skill" / "SKILL.md")
+      Result.all(
+        List(
+          Yaml.extractYamlField(projectContent, "description") ==== "Project version",
+          Yaml.extractYamlField(globalContent, "description") ==== "Global version",
+        )
+      )
     }
 
   private def testNoSkillMd: Result =
@@ -143,10 +154,12 @@ object SkillsSpec extends Properties:
     withTestDirs { (projectSkills, _) =>
       os.write(projectSkills / "file.txt", "Just a file")
       createSkill(projectSkills, "actual-skill", "Real skill")
-      Result.all(List(
-        Result.assert(!os.isDir(projectSkills / "file.txt")),
-        Result.assert(os.exists(projectSkills / "actual-skill" / "SKILL.md")),
-      ))
+      Result.all(
+        List(
+          Result.assert(!os.isDir(projectSkills / "file.txt")),
+          Result.assert(os.exists(projectSkills / "actual-skill" / "SKILL.md")),
+        )
+      )
     }
 
   private def testEmpty: Result =
@@ -161,10 +174,12 @@ object SkillsSpec extends Properties:
     withTestDirs { (projectSkills, _) =>
       createSkill(projectSkills, "my-skill", "My skill description")
       val skillPath = projectSkills / "my-skill" / "SKILL.md"
-      Result.all(List(
-        Result.assert(os.exists(skillPath)),
-        Result.assert(skillPath.toString.contains("my-skill/SKILL.md")),
-      ))
+      Result.all(
+        List(
+          Result.assert(os.exists(skillPath)),
+          Result.assert(skillPath.toString.contains("my-skill/SKILL.md")),
+        )
+      )
     }
 
   private def testFindSymlinkedByName: Result =
@@ -189,3 +204,4 @@ object SkillsSpec extends Properties:
       val projectContent = os.read(projectSkills / "shared-skill" / "SKILL.md")
       Yaml.extractYamlField(projectContent, "description") ==== "Project"
     }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/YamlSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/YamlSpec.scala
@@ -3,7 +3,7 @@ package aiskills.core.utils
 import hedgehog.*
 import hedgehog.runner.*
 
-object YamlSpec extends Properties:
+object YamlSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("extractYamlField: should extract field from YAML frontmatter", testExtractField),
@@ -18,7 +18,7 @@ object YamlSpec extends Properties:
     example("hasValidFrontmatter: should return false for empty content", testEmptyContent),
   )
 
-  private def testExtractField: Result =
+  private def testExtractField: Result = {
     val content =
       """---
         |name: test-skill
@@ -27,20 +27,24 @@ object YamlSpec extends Properties:
         |
         |Content""".stripMargin
 
-    Result.all(List(
-      Yaml.extractYamlField(content, "name") ==== "test-skill",
-      Yaml.extractYamlField(content, "description") ==== "Test description",
-    ))
+    Result.all(
+      List(
+        Yaml.extractYamlField(content, "name") ==== "test-skill",
+        Yaml.extractYamlField(content, "description") ==== "Test description",
+      )
+    )
+  }
 
-  private def testMissingField: Result =
+  private def testMissingField: Result = {
     val content =
       """---
         |name: test-skill
         |---""".stripMargin
 
     Yaml.extractYamlField(content, "missing") ==== ""
+  }
 
-  private def testMultilineDesc: Result =
+  private def testMultilineDesc: Result = {
     val content =
       """---
         |name: test
@@ -48,8 +52,9 @@ object YamlSpec extends Properties:
         |---""".stripMargin
 
     Yaml.extractYamlField(content, "description") ==== "First line"
+  }
 
-  private def testNonGreedy: Result =
+  private def testNonGreedy: Result = {
     val content =
       """---
         |name: skill-name
@@ -58,20 +63,23 @@ object YamlSpec extends Properties:
         |---""".stripMargin
 
     val name = Yaml.extractYamlField(content, "name")
-    Result.all(List(
-      name ==== "skill-name",
-      Result.assert(!name.contains("description")),
-    ))
+    Result.all(
+      List(
+        name ==== "skill-name",
+        Result.assert(!name.contains("description")),
+      )
+    )
+  }
 
-  private def testReDoS: Result =
+  private def testReDoS: Result = {
     val content = s"---\nname: ${"a" * 1000}\n---"
-    val start = System.currentTimeMillis()
-    val _ = Yaml.extractYamlField(content, "name")
-//    println(s"name=$name")
+    val start   = System.currentTimeMillis()
+    val _       = Yaml.extractYamlField(content, "name")
     val elapsed = System.currentTimeMillis() - start
     Result.assert(elapsed < 100)
+  }
 
-  private def testSpecialChars: Result =
+  private def testSpecialChars: Result = {
     val content =
       """---
         |name: skill-with-special_chars.v2
@@ -79,8 +87,9 @@ object YamlSpec extends Properties:
         |---""".stripMargin
 
     Yaml.extractYamlField(content, "name") ==== "skill-with-special_chars.v2"
+  }
 
-  private def testColonsInValues: Result =
+  private def testColonsInValues: Result = {
     val content =
       """---
         |name: my-skill
@@ -89,8 +98,9 @@ object YamlSpec extends Properties:
 
     val desc = Yaml.extractYamlField(content, "description")
     Result.assert(desc.contains("URL:"))
+  }
 
-  private def testValidFrontmatter: Result =
+  private def testValidFrontmatter: Result = {
     val content =
       """---
         |name: test
@@ -99,9 +109,11 @@ object YamlSpec extends Properties:
         |Content""".stripMargin
 
     Result.assert(Yaml.hasValidFrontmatter(content))
+  }
 
   private def testMissingFrontmatter: Result =
     Result.assert(!Yaml.hasValidFrontmatter("No frontmatter here"))
 
   private def testEmptyContent: Result =
     Result.assert(!Yaml.hasValidFrontmatter(""))
+}


### PR DESCRIPTION
# Refactor: Apply Scala 3 brace syntax, remove mutable state, and improve code style across all modules

- Convert all source and test files from Scala 3 braceless/indentation syntax to explicit brace syntax for enums, objects, classes, methods, match expressions, for-comprehensions, and if/else blocks
- Replace mutable variables (`var`) with immutable alternatives using `foldLeft`, `count`, and extracted `val` computations in Install, Update, and Sync commands
- Remove all `return` statements, restructuring control flow with if/else expressions instead
- Extract `parseGitSource` helper method from `resolveSource` in Install to eliminate mutable `repoUrl` and `skillSubpath` variables
- Replace while loops in `TimeUtil.isoNow` with `@tailrec` functions (`computeYear`, `computeMonth`)
- Use cats syntax extensions (`asRight`/`asLeft`) for Decoder instances in Types.scala instead of explicit `Right`/`Left` constructors
- Sort import statements alphabetically (e.g. `Failure, Success, Try` instead of `Try, Success, Failure`)
- Align `val` declarations with consistent spacing for readability
- Improve test in SkillMetadataSpec to pattern match on `Some`/`None` instead of using unsafe `.get`
- Refactor `AiSkillsError` to keep the error ADT data-only and centralize message rendering
  - Move `message` generation out of each error case class into a single `AiSkillsError` extension method. Keep the sealed error hierarchy focused on carrying data while preserving the existing user-facing messages.
  - Reduce repeated method implementations across error types and make future message updates easier to maintain in one place.