### PR TITLE
Remove ANSI color formatting from interactive selection labels

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -384,7 +384,7 @@ object Install {
     val skillsToInstall: List[SkillInfo] =
       if !options.yes && skillInfos.length > 1 then {
         val labels = skillInfos.map { info =>
-          s"${info.skillName.padTo(25, ' ').bold} ${formatSize(info.size).dim}"
+          s"${info.skillName.padTo(25, ' ')} ${formatSize(info.size)}"
         }
 
         Prompts.sync.use { prompts =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
@@ -19,7 +19,7 @@ object Manage {
 
       val labels = sorted.map { skill =>
         val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})"
-        s"${skill.name.padTo(25, ' ').bold} $locationLabel"
+        s"${skill.name.padTo(25, ' ')} $locationLabel"
       }
 
       Prompts.sync.use { prompts =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -155,7 +155,7 @@ object Sync {
         // Step 1: Pick source agent
         val agentLabels = agents.map { a =>
           val count = grouped(a).length
-          s"${a.toString.padTo(15, ' ').bold} ($count skill(s))"
+          s"${a.toString.padTo(15, ' ')} ($count skill(s))"
         }
 
         val sourceAgent = Prompts.sync.use { prompts =>


### PR DESCRIPTION
# Remove ANSI color formatting from interactive selection labels

- The `.bold` and `.dim` color extensions on selection labels passed to cue4s `Prompts` caused rendering issues in interactive multi-choice menus.
- Remove these ANSI formatting calls from the label strings in `Install`, `Manage`, and `Sync` commands so the interactive prompts display cleanly.