### PR TITLE
Refine CLI argument defaults and scope XML syntax suppression

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -223,8 +223,7 @@ object Main {
     name: String,
     header: String,
     main: Opts[Unit],
-    helpFlag: Boolean = true,
-    version: String = ""
+    version: String,
   ): Command[Unit] = {
 
     val showVersion =
@@ -234,7 +233,7 @@ object Main {
           .flag("version", "Print the version number and exit.", visibility = Visibility.Partial)
           .map(_ => System.err.println(version))
 
-    Command(name, header, helpFlag)(showVersion.orElse(main))
+    Command(name, header, helpFlag = true)(showVersion.orElse(main))
   }
 
   def main(args: Array[String]): Unit =

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -6,7 +6,7 @@ import aiskills.core.utils.{Dirs, SkillNames, Skills}
 object Read {
 
   /** Read skill(s) to stdout (for AI agents). */
-  def readSkill(skillNames: List[String], options: ReadOptions = ReadOptions()): Unit = {
+  def readSkill(skillNames: List[String], options: ReadOptions): Unit = {
     val names = SkillNames.normalizeSkillNames(skillNames)
     if names.isEmpty then {
       System.err.println("Error: No skill names provided")

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
@@ -19,13 +19,15 @@ object AgentsMd {
 
     val skillTags = skills
       .map { s =>
+        // scalafix:off DisableSyntax.noXml
         val skillElem: Elem =
           <skill>
-          <name>{s.name}</name>
-          <description>{s.description}</description>
-          <location>{s.location.toString.toLowerCase}</location>
-          <agent>{s.agent.toString.toLowerCase}</agent>
-        </skill>
+            <name>{s.name}</name>
+            <description>{s.description}</description>
+            <location>{s.location.toString.toLowerCase}</location>
+            <agent>{s.agent.toString.toLowerCase}</agent>
+          </skill>
+        // scalafix:on
         printer.format(skillElem)
       }
       .mkString("\n\n")

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -5,7 +5,7 @@ import aiskills.core.{Agent, SkillLocation}
 object Dirs {
 
   /** Get skills directory path for a specific agent. */
-  def getSkillsDir(agent: Agent, global: Boolean = false): os.Path =
+  def getSkillsDir(agent: Agent, global: Boolean): os.Path =
     if global then os.home / os.RelPath(agent.globalDirName) / "skills"
     else os.pwd / os.RelPath(agent.projectDirName) / "skills"
 


### PR DESCRIPTION
# Refine CLI argument defaults and scope XML syntax suppression

- Remove implicit default arguments from `Main.command`, `Read.readSkill`, and `Dirs.getSkillsDir` so callers must provide `version`, `options`, and `global` explicitly, while keeping `helpFlag` fixed to `true` at the command construction site.
- Add a scoped `DisableSyntax.noXml` scalafix suppression around the XML literal in `AgentsMd` and reformat that block without changing the generated output.