### PR TITLE
Add GitHub Actions workflows for build, checks, and release automation

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,76 @@
+name: "[Scala Native] Build All"
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+env:
+  GH_JAVA_VERSION: "21"
+  GH_JAVA_DISTRIBUTION: "temurin"
+  GH_SBT_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  PROJECT_NAME: "ai-skills"
+  NATIVE_BIN_NAME: "aiskills"
+
+jobs:
+
+  native-build:
+    runs-on: ${{ matrix.os.value }}
+    strategy:
+      matrix:
+        os:
+          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
+          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
+          - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.GH_JAVA_VERSION }}
+          distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: "Install LLVM and Clang (Ubuntu)"
+        if: startsWith(matrix.os.value, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libstdc++-12-dev
+
+      - name: "Scala Native Build on ${{ matrix.os.name }} - ${{ github.run_number }}"
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+          APP_BIN_NAME: ${{ env.NATIVE_BIN_NAME }}${{ matrix.os.bin-suffix }}
+        run: |
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          sbt \
+            -v \
+            clean \
+            test \
+            cli/nativeLink
+
+          NATIVE_BIN_DIR=$(ls -d modules/${{ env.PROJECT_NAME }}-cli/target/scala-*/)
+          echo "NATIVE_BIN_DIR=${NATIVE_BIN_DIR}"
+
+          echo "ls -lGh ${NATIVE_BIN_DIR}"
+          ls -lGh "${NATIVE_BIN_DIR}"
+
+          echo "mv ${NATIVE_BIN_DIR}${{ env.NATIVE_BIN_NAME }} ${NATIVE_BIN_DIR}${APP_BIN_NAME}"
+          mv "${NATIVE_BIN_DIR}${{ env.NATIVE_BIN_NAME }}" "${NATIVE_BIN_DIR}${APP_BIN_NAME}"
+
+          echo "ls -lGh ${NATIVE_BIN_DIR}"
+          ls -lGh "${NATIVE_BIN_DIR}"
+
+          "${NATIVE_BIN_DIR}${APP_BIN_NAME}" --version
+          "${NATIVE_BIN_DIR}${APP_BIN_NAME}" --help

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: "Build All"
+
+on:
+  push:
+    branches:
+      - "**"
+
+  pull_request:
+    branches:
+      - main
+
+env:
+  GH_JAVA_VERSION: "21"
+  GH_JAVA_DISTRIBUTION: "temurin"
+  GH_SBT_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.GH_JAVA_VERSION }}
+          distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: "[Push] Build All - ${{ github.run_number }}"
+        if: github.event_name == 'push'
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "[BEFORE]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          export CURRENT_BRANCH_NAME="${CURRENT_BRANCH_NAME#refs/heads/}"
+          echo " [AFTER]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "Push #${PUSH_NUMBER}"
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          java -version
+          sbt \
+            -v \
+            clean \
+            test
+
+      - name: "[PR] Build All - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
+        if: github.event_name == 'pull_request'
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.base_ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "Pull request to the '${CURRENT_BRANCH_NAME}' branch"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "PR #${PR_NUMBER}"
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          java -version
+          sbt \
+            -v \
+            clean \
+            test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,77 @@
+name: "Check All"
+
+on:
+  push:
+    branches:
+      - "**"
+
+  pull_request:
+    branches:
+      - main
+
+env:
+  GH_SBT_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms4G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+
+jobs:
+
+  build-and-check:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        scala:
+          - { name: "Scala", java-version: "21", java-distribution: "temurin" }
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.scala.java-version }}
+          distribution: ${{ matrix.scala.java-distribution }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: "[Push] Check All for ${{ matrix.scala.name }} - ${{ github.run_number }}"
+        if: github.event_name == 'push'
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "[BEFORE]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          export CURRENT_BRANCH_NAME="${CURRENT_BRANCH_NAME#refs/heads/}"
+          echo " [AFTER]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "Push #${PUSH_NUMBER}"
+          java -version
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          sbt \
+            +scalafmtCheckAll \
+            "+scalafixAll --check"
+            
+
+      - name: "[PR] Check All for ${{ matrix.scala.name }} - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
+        if: github.event_name == 'pull_request'
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.base_ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "Pull request to the '${CURRENT_BRANCH_NAME}' branch"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "PR #${PR_NUMBER}"
+          java -version
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          sbt \
+            +scalafmtCheckAll \
+            "+scalafixAll --check"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  GH_JAVA_VERSION: "21"
+  GH_JAVA_DISTRIBUTION: "temurin"
+  GH_SBT_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms2G -XX:MaxMetaspaceSize=2G -Xmx8G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  PROJECT_NAME: "ai-skills"
+  NATIVE_BIN_NAME: "aiskills"
+
+jobs:
+  gh-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.GH_JAVA_VERSION }}
+          distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: sbt GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "Run] sbt GitHub release"
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          sbt \
+            devOopsGitHubRelease
+
+  native-gh-release:
+    needs: gh-release
+    runs-on: ${{ matrix.os.value }}
+    strategy:
+      matrix:
+        os:
+          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
+          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
+          - { name: "macOS 14 Apple Silicon", value: "macos-14",         bin-suffix: "-macos-14-arm64" }
+          - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.GH_JAVA_VERSION }}
+          distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: "Install LLVM and Clang (Ubuntu)"
+        if: startsWith(matrix.os.value, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libstdc++-12-dev
+
+      - name: "Scala Native Build and Upload on ${{ matrix.os.name }} - ${{ github.run_number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+          APP_BIN_NAME: ${{ env.NATIVE_BIN_NAME }}${{ matrix.os.bin-suffix }}
+        run: |
+          echo "JVM_OPTS=${JVM_OPTS}"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          sbt \
+            -v \
+            clean \
+            test \
+            cli/nativeLink
+          
+          NATIVE_BIN_DIR=$(ls -d modules/${{ env.PROJECT_NAME }}-cli/target/scala-*/)
+          echo "NATIVE_BIN_DIR=${NATIVE_BIN_DIR}"
+
+          echo "ls -lGh ${NATIVE_BIN_DIR}"
+          ls -lGh "${NATIVE_BIN_DIR}"
+
+          echo "mv ${NATIVE_BIN_DIR}${{ env.NATIVE_BIN_NAME }} ${NATIVE_BIN_DIR}${APP_BIN_NAME}"
+          mv "${NATIVE_BIN_DIR}${{ env.NATIVE_BIN_NAME }}" "${NATIVE_BIN_DIR}${APP_BIN_NAME}"
+
+          echo "ls -lGh ${NATIVE_BIN_DIR}"
+          ls -lGh "${NATIVE_BIN_DIR}"
+
+          "${NATIVE_BIN_DIR}${APP_BIN_NAME}" --version
+          "${NATIVE_BIN_DIR}${APP_BIN_NAME}" --help
+
+          sbt \
+            devOopsGitHubReleaseUploadArtifacts

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,14 @@ ThisBuild / version := props.ProjectVersion
 
 lazy val aiSkills = project
   .in(file("."))
+  .enablePlugins(DevOopsGitHubReleasePlugin)
   .settings(
     name := props.ProjectName,
+    /* GitHub Release { */
+    devOopsPackagedArtifacts := List(
+      s"modules/${props.ProjectName}-cli/target/scala-*/${props.ProjectName.replace("-", "")}-*",
+    ),
+    /* } GitHub Release */
   )
   .settings(noPublish)
   .aggregate(core, cli)


### PR DESCRIPTION
# Add GitHub Actions workflows for build, checks, and release automation

Add CI workflows for regular builds, formatting/scalafix checks, Scala Native builds, and tagged releases.

Configure GitHub Actions to:
- run `sbt clean test` on pushes and pull requests
- run `+scalafmtCheckAll` and `+scalafixAll --check` as a dedicated checks workflow
- build Scala Native binaries on Ubuntu x86_64, Ubuntu ARM64, and Apple Silicon macOS runners
- publish releases for version tags and upload native artifacts to GitHub Releases

Update `build.sbt` to enable `DevOopsGitHubReleasePlugin` and declare the packaged CLI artifacts so the release workflow can discover and upload the generated binaries.