### PR TITLE
Fix the cursor disappearance issue when cancelling with Ctrl+C in interactive CLI prompts

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -236,7 +236,8 @@ object Main {
     Command(name, header, helpFlag = true)(showVersion.orElse(main))
   }
 
-  def main(args: Array[String]): Unit =
+  def main(args: Array[String]): Unit = {
+    SigintHandler.install()
     command.parse(PlatformApp.ambientArgs.getOrElse(args.toSeq), sys.env) match {
       case Left(help) =>
         System.err.println(renderHelp(help))
@@ -244,6 +245,7 @@ object Main {
         else ()
       case Right(_) => ()
     }
+  }
 
   private val renderHelp: Help => String = {
     // There's a bug in HelpFormat.autoColors

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/SigintHandler.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/SigintHandler.scala
@@ -1,0 +1,66 @@
+package aiskills.cli
+
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+object SigintHandler {
+
+  /** Install a SIGINT handler that restores the terminal cursor before exiting.
+    *
+    * This must be called before any interactive prompt that hides the cursor (e.g. cue4s Prompts).
+    * It should also be re-installed after any subprocess invocation (e.g. os.proc.call) which may
+    * reset the signal disposition.
+    */
+  def install(): Unit = {
+    import scala.scalanative.posix.signal
+    import scala.scalanative.posix.unistd
+    import scala.scalanative.libc.stdlib
+
+    val handler: CFuncPtr1[CInt, Unit] =
+      CFuncPtr1.fromScalaFunction[CInt, Unit] { (sig: CInt) =>
+        // ESC[?25h = show cursor (6), \r = go to col 0 (1), ESC[J = erase from cursor to end of screen (3) = 10 bytes
+        val cur = stackalloc[Byte](10)
+        cur(0) = 0x1b.toByte // ESC
+        cur(1) = '['.toByte
+        cur(2) = '?'.toByte
+        cur(3) = '2'.toByte
+        cur(4) = '5'.toByte
+        cur(5) = 'h'.toByte
+        cur(6) = '\r'.toByte
+        cur(7) = 0x1b.toByte // ESC
+        cur(8) = '['.toByte
+        cur(9) = 'J'.toByte
+        val _   = unistd.write(1, cur, 10.toUSize)
+
+        if sig == 2 then { // SIGINT
+          // "\nCancelled by Ctrl+C\n" = 21 bytes
+          val msg = stackalloc[Byte](21)
+          msg(0) = '\n'.toByte
+          msg(1) = 'C'.toByte
+          msg(2) = 'a'.toByte
+          msg(3) = 'n'.toByte
+          msg(4) = 'c'.toByte
+          msg(5) = 'e'.toByte
+          msg(6) = 'l'.toByte
+          msg(7) = 'l'.toByte
+          msg(8) = 'e'.toByte
+          msg(9) = 'd'.toByte
+          msg(10) = ' '.toByte
+          msg(11) = 'b'.toByte
+          msg(12) = 'y'.toByte
+          msg(13) = ' '.toByte
+          msg(14) = 'C'.toByte
+          msg(15) = 't'.toByte
+          msg(16) = 'r'.toByte
+          msg(17) = 'l'.toByte
+          msg(18) = '+'.toByte
+          msg(19) = 'C'.toByte
+          msg(20) = '\n'.toByte
+          val _   = unistd.write(1, msg, 21.toUSize)
+        } else ()
+
+        stdlib.exit(128 + sig)
+      }
+    val _                              = signal.signal(signal.SIGINT, handler)
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -387,25 +387,30 @@ object Install {
           s"${info.skillName.padTo(25, ' ')} ${formatSize(info.size)}"
         }
 
-        Prompts.sync.use { prompts =>
+        aiskills.cli.SigintHandler.install()
+        val result = Prompts.sync.use { prompts =>
           prompts.multiChoiceAllSelected("Select skills to install", labels) match {
             case Completion.Finished(selectedLabels) =>
               if selectedLabels.isEmpty then {
                 println("No skills selected. Installation cancelled.".yellow)
-                Nil
+                Right(Nil)
               } else
-                skillInfos.filter { info =>
+                Right(skillInfos.filter { info =>
                   selectedLabels.exists(_.contains(info.skillName))
-                }
+                })
 
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
-              sys.exit(0)
+              Left(0)
 
             case Completion.Fail(CompletionError.Error(msg)) =>
               System.err.println(s"Error: $msg")
-              sys.exit(1)
+              Left(1)
           }
+        }
+        result match {
+          case Left(code) => sys.exit(code)
+          case Right(list) => list
         }
       } else
         skillInfos
@@ -478,22 +483,28 @@ object Install {
         println(s"Overwriting: $skillName (all existing files and folders will be removed)".dim)
         os.remove.all(targetPath)
         true
-      } else
-        Prompts.sync.use { prompts =>
+      } else {
+        aiskills.cli.SigintHandler.install()
+        val result = Prompts.sync.use { prompts =>
           println(
             s"\u26a0 All existing files and folders in '$skillName' will be removed if you choose to overwrite.".yellow
           )
           prompts.confirm(s"Skill '$skillName' already exists. Overwrite?".yellow, default = false) match {
             case Completion.Finished(shouldOverwrite) =>
               if shouldOverwrite then os.remove.all(targetPath) else ()
-              shouldOverwrite
+              Right(shouldOverwrite)
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
-              sys.exit(0)
+              Left(0)
             case Completion.Fail(CompletionError.Error(_)) =>
-              false
+              Right(false)
           }
         }
+        result match {
+          case Left(code) => sys.exit(code)
+          case Right(v) => v
+        }
+      }
     } else {
       if !isProject && MarketplaceSkills.anthropicMarketplaceSkills.contains(skillName) then {
         System.err.println(s"\n\u26a0\ufe0f  Warning: '$skillName' matches an Anthropic marketplace skill".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
@@ -22,7 +22,8 @@ object Manage {
         s"${skill.name.padTo(25, ' ')} $locationLabel"
       }
 
-      Prompts.sync.use { prompts =>
+      aiskills.cli.SigintHandler.install()
+      val result = Prompts.sync.use { prompts =>
         prompts.multiChoiceNoneSelected("Select skills to remove", labels) match {
           case Completion.Finished(selectedLabels) =>
             if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
@@ -39,15 +40,20 @@ object Manage {
               }
               println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
             }
+            Right(())
 
           case Completion.Fail(CompletionError.Interrupted) =>
             println("\n\nCancelled by user".yellow)
-            sys.exit(0)
+            Left(0)
 
           case Completion.Fail(CompletionError.Error(msg)) =>
             System.err.println(s"Error: $msg")
-            sys.exit(1)
+            Left(1)
         }
+      }
+      result match {
+        case Left(code) => sys.exit(code)
+        case Right(()) => ()
       }
     }
   }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -65,24 +65,30 @@ object Sync {
           val targetPath = targetDir / name
 
           val proceed =
-            if os.exists(targetPath) && !yes then Prompts.sync.use { prompts =>
-              println(
-                s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
-              )
-              prompts.confirm(
-                s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}). Overwrite?".yellow,
-                default = false,
-              ) match {
-                case Completion.Finished(v) =>
-                  if v then os.remove.all(targetPath) else ()
-                  v
-                case Completion.Fail(CompletionError.Interrupted) =>
-                  println("\n\nCancelled by user".yellow)
-                  sys.exit(0)
-                case Completion.Fail(CompletionError.Error(_)) => false
+            if os.exists(targetPath) && !yes then {
+              aiskills.cli.SigintHandler.install()
+              val result = Prompts.sync.use { prompts =>
+                println(
+                  s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
+                )
+                prompts.confirm(
+                  s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}). Overwrite?".yellow,
+                  default = false,
+                ) match {
+                  case Completion.Finished(v) =>
+                    if v then os.remove.all(targetPath) else ()
+                    Right(v)
+                  case Completion.Fail(CompletionError.Interrupted) =>
+                    println("\n\nCancelled by user".yellow)
+                    Left(0)
+                  case Completion.Fail(CompletionError.Error(_)) => Right(false)
+                }
               }
-            }
-            else if os.exists(targetPath) then {
+              result match {
+                case Left(code) => sys.exit(code)
+                case Right(v) => v
+              }
+            } else if os.exists(targetPath) then {
               println(s"Overwriting: $name (all existing files and folders will be removed)".dim)
               os.remove.all(targetPath)
               true
@@ -158,18 +164,25 @@ object Sync {
           s"${a.toString.padTo(15, ' ')} ($count skill(s))"
         }
 
-        val sourceAgent = Prompts.sync.use { prompts =>
-          prompts.multiChoiceNoneSelected("Select source agent (pick one)", agentLabels) match {
-            case Completion.Finished(selectedLabels) =>
-              selectedLabels.headOption.flatMap { label =>
-                agents.find(a => label.contains(a.toString))
-              }
-            case Completion.Fail(CompletionError.Interrupted) =>
-              println("\n\nCancelled by user".yellow)
-              sys.exit(0)
-            case Completion.Fail(CompletionError.Error(msg)) =>
-              System.err.println(s"Error: $msg")
-              sys.exit(1)
+        val sourceAgent = {
+          aiskills.cli.SigintHandler.install()
+          val result = Prompts.sync.use { prompts =>
+            prompts.multiChoiceNoneSelected("Select source agent (pick one)", agentLabels) match {
+              case Completion.Finished(selectedLabels) =>
+                Right(selectedLabels.headOption.flatMap { label =>
+                  agents.find(a => label.contains(a.toString))
+                })
+              case Completion.Fail(CompletionError.Interrupted) =>
+                println("\n\nCancelled by user".yellow)
+                Left(0)
+              case Completion.Fail(CompletionError.Error(msg)) =>
+                System.err.println(s"Error: $msg")
+                Left(1)
+            }
+          }
+          result match {
+            case Left(code) => sys.exit(code)
+            case Right(v) => v
           }
         }
 
@@ -181,16 +194,23 @@ object Sync {
             val targetAgents = Agent.all.filterNot(_ == from)
             val targetLabels = targetAgents.map(_.toString)
 
-            val selectedTargets = Prompts.sync.use { prompts =>
-              prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
-                case Completion.Finished(selectedLabels) =>
-                  targetAgents.filter(a => selectedLabels.contains(a.toString))
-                case Completion.Fail(CompletionError.Interrupted) =>
-                  println("\n\nCancelled by user".yellow)
-                  sys.exit(0)
-                case Completion.Fail(CompletionError.Error(msg)) =>
-                  System.err.println(s"Error: $msg")
-                  sys.exit(1)
+            val selectedTargets = {
+              aiskills.cli.SigintHandler.install()
+              val result = Prompts.sync.use { prompts =>
+                prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
+                  case Completion.Finished(selectedLabels) =>
+                    Right(targetAgents.filter(a => selectedLabels.contains(a.toString)))
+                  case Completion.Fail(CompletionError.Interrupted) =>
+                    println("\n\nCancelled by user".yellow)
+                    Left(0)
+                  case Completion.Fail(CompletionError.Error(msg)) =>
+                    System.err.println(s"Error: $msg")
+                    Left(1)
+                }
+              }
+              result match {
+                case Left(code) => sys.exit(code)
+                case Right(v) => v
               }
             }
 


### PR DESCRIPTION
# Fix the cursor disappearance issue when cancelling with Ctrl+C in interactive CLI prompts

Handle Ctrl+C cleanly in interactive CLI prompts

- Add a Scala Native `SigintHandler` that restores the terminal cursor, clears the prompt area, and exits with the expected signal status when the user presses Ctrl+C.
- Install the handler at CLI startup and before each `Prompts.sync.use` call so interactive install, manage, and sync flows recover cleanly even if signal handling was reset.
- Refactor prompt result handling to return values first and call `sys.exit` only after prompt resources are released, avoiding abrupt exits from inside prompt callbacks.