### PR TITLE
Update CI workflows to add macOS 26 and remove macOS 14

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -24,9 +24,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
-          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
+          - { name: "macOS 26 Apple Silicon", value: "macOS-26",         bin-suffix: "-macos-26-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
+          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
-          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
-          - { name: "macOS 14 Apple Silicon", value: "macos-14",         bin-suffix: "-macos-14-arm64" }
+          - { name: "macOS 26 Apple Silicon", value: "macOS-26",         bin-suffix: "-macos-26-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+          - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
+          - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
# Update CI workflows to add macOS 26 and remove macOS 14

- Add macOS 26 Apple Silicon build target to `build-native.yml`
- Replace macOS 14 with macOS 26 Apple Silicon in `release.yml`
- Keep macOS 15 Apple Silicon in both workflows