### PR TITLE
Fix #11: `aiskills --version` prints out the version in `stderr` not `stdout`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -231,7 +231,7 @@ object Main {
       else
         Opts
           .flag("version", "Print the version number and exit.", visibility = Visibility.Partial)
-          .map(_ => System.err.println(version))
+          .map(_ => println(version))
 
     Command(name, header, helpFlag = true)(showVersion.orElse(main))
   }


### PR DESCRIPTION
Fix #11: `aiskills --version` prints out the version in `stderr` not `stdout`