### PR TITLE
ai-skills v0.1.1

### DIFF
--- a/changelogs/0.1.1.md
+++ b/changelogs/0.1.1.md
@@ -1,0 +1,6 @@
+## [0.1.1](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am2) - 2026-03-26
+
+## Bug Fixed
+
+* Fixed: `aiskills --version` prints out the version in `stderr` not `stdout` (#11)
+* Fixed: Temporary folders created during installation are not automatically removed if installation fails or is cancelled (#13)


### PR DESCRIPTION
# ai-skills v0.1.1
## [0.1.1](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am2) - 2026-03-26

## Bug Fixed

* Fixed: `aiskills --version` prints out the version in `stderr` not `stdout` (#11)
* Fixed: Temporary folders created during installation are not automatically removed if installation fails or is cancelled (#13)
