### PR TITLE
Close #17: Add Windsurf skill support with `.windsurf/skills/` (project) and `~/.codeium/windsurf/skills/` (global)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Built with Scala 3 and Scala Native — compiles to a standalone binary with no 
 
 ## Supported Agents
 
-| Agent                   | Project Dir       | Global Dir           |
-|-------------------------|-------------------|----------------------|
-| **Universal** (default) | `.agents/skills/` | `~/.agents/skills/`  |
-| **Claude**              | `.claude/skills/` | `~/.claude/skills/`  |
-| **Cursor**              | `.cursor/skills/` | `~/.cursor/skills/`  |
-| **Codex**               | `.codex/skills/`  | `~/.codex/skills/`   |
-| **Gemini**              | `.gemini/skills/` | `~/.gemini/skills/`  |
-| **Copilot**             | `.github/skills/` | `~/.copilot/skills/` |
+| Agent                   | Project Dir         | Global Dir                    |
+|-------------------------|---------------------|-------------------------------|
+| **Universal** (default) | `.agents/skills/`   | `~/.agents/skills/`           |
+| **Claude**              | `.claude/skills/`   | `~/.claude/skills/`           |
+| **Cursor**              | `.cursor/skills/`   | `~/.cursor/skills/`           |
+| **Codex**               | `.codex/skills/`    | `~/.codex/skills/`            |
+| **Gemini**              | `.gemini/skills/`   | `~/.gemini/skills/`           |
+| **Windsurf**            | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| **Copilot**             | `.github/skills/`   | `~/.copilot/skills/`          |
 
 ## Install
 
@@ -145,7 +146,7 @@ Options:
 
 | Flag                   | Description                                                                          |
 |------------------------|--------------------------------------------------------------------------------------|
-| `-a`, `--agent <name>` | Target agent (universal, claude, cursor, codex, gemini, copilot). Default: universal |
+| `-a`, `--agent <name>` | Target agent (universal, claude, cursor, codex, gemini, windsurf, copilot). Default: universal |
 | `--all-agents`         | Install to all agent directories                                                     |
 | `-g`, `--global`       | Install globally instead of project-local                                            |
 | `-y`, `--yes`          | Skip interactive selection, install all skills found                                 |
@@ -237,20 +238,22 @@ Instructions and context for the AI agent...
 
 Skills are searched in the following directories, in priority order:
 
-| Priority | Path                  | Scope              |
-|----------|-----------------------|--------------------|
-| 1        | `./.agents/skills/`   | Project universal  |
-| 2        | `./.claude/skills/`   | Project Claude     |
-| 3        | `./.codex/skills/`    | Project Codex      |
-| 4        | `./.github/skills/`   | Project Copilot    |
-| 5        | `./.cursor/skills/`   | Project Cursor     |
-| 6        | `./.gemini/skills/`   | Project Gemini     |
-| 7        | `~/.agents/skills/`   | Global universal   |
-| 8        | `~/.claude/skills/`   | Global Claude      |
-| 9        | `~/.codex/skills/`    | Global Codex       |
-| 10       | `~/.copilot/skills/`  | Global Copilot     |
-| 11       | `~/.cursor/skills/`   | Global Cursor      |
-| 12       | `~/.gemini/skills/`   | Global Gemini      |
+| Priority | Path                            | Scope              |
+|----------|---------------------------------|--------------------|
+| 1        | `./.agents/skills/`             | Project universal  |
+| 2        | `./.claude/skills/`             | Project Claude     |
+| 3        | `./.codex/skills/`              | Project Codex      |
+| 4        | `./.github/skills/`             | Project Copilot    |
+| 5        | `./.cursor/skills/`             | Project Cursor     |
+| 6        | `./.gemini/skills/`             | Project Gemini     |
+| 7        | `./.windsurf/skills/`           | Project Windsurf   |
+| 8        | `~/.agents/skills/`             | Global universal   |
+| 9        | `~/.claude/skills/`             | Global Claude      |
+| 10       | `~/.codex/skills/`              | Global Codex       |
+| 11       | `~/.copilot/skills/`            | Global Copilot     |
+| 12       | `~/.cursor/skills/`             | Global Cursor      |
+| 13       | `~/.gemini/skills/`             | Global Gemini      |
+| 14       | `~/.codeium/windsurf/skills/`   | Global Windsurf    |
 
 Skills in multiple directories are all shown by `list`. For `read`, the first match by priority is used (override with `--prefer`).
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -12,7 +12,7 @@ object Main {
     header = """Universal skills loader for AI coding agents
                |
                |Manage reusable prompt skills for Claude, Cursor, Codex, Gemini,
-               |Copilot, and other AI coding agents. Skills are markdown files
+               |Windsurf, Copilot, and other AI coding agents. Skills are markdown files
                |(SKILL.md) that can be installed from GitHub repos, Git URLs, or
                |local directories.
                |

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -10,6 +10,7 @@ enum Agent(val projectDirName: String, val globalDirName: String) {
   case Cursor extends Agent(".cursor", ".cursor")
   case Codex extends Agent(".codex", ".codex")
   case Gemini extends Agent(".gemini", ".gemini")
+  case Windsurf extends Agent(".windsurf", ".codeium/windsurf")
   case Copilot extends Agent(".github", ".copilot")
 }
 

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
@@ -14,11 +14,11 @@ object AgentSpec extends Properties {
     example("Universal: globalDirName is .agents", testUniversalGlobalDir),
     example("Claude: projectDirName is .claude", testClaudeProjectDir),
     example("Copilot: asymmetric dirs (.github project, .copilot global)", testCopilotAsymmetry),
-    example("all: has 6 agents", testAllCount),
-    example("allNonUniversal: has 5 agents", testAllNonUniversalCount),
+    example("all: has 7 agents", testAllCount),
+    example("allNonUniversal: has 6 agents", testAllNonUniversalCount),
     example("allNonUniversal: excludes Universal", testAllNonUniversalExcludes),
     example("needsAgentsMd: true for Universal and Codex", testNeedsAgentsMd),
-    example("needsAgentsMd: false for Claude, Cursor, Gemini, Copilot", testDoesNotNeedAgentsMd),
+    example("needsAgentsMd: false for Claude, Cursor, Gemini, Windsurf, Copilot", testDoesNotNeedAgentsMd),
     example("Encoder/Decoder: round-trip", testEncoderDecoderRoundTrip),
   )
 
@@ -30,6 +30,7 @@ object AgentSpec extends Properties {
         Agent.fromString("cursor") ==== Some(Agent.Cursor),
         Agent.fromString("codex") ==== Some(Agent.Codex),
         Agent.fromString("gemini") ==== Some(Agent.Gemini),
+        Agent.fromString("windsurf") ==== Some(Agent.Windsurf),
         Agent.fromString("copilot") ==== Some(Agent.Copilot),
       )
     )
@@ -70,10 +71,10 @@ object AgentSpec extends Properties {
     )
 
   private def testAllCount: Result =
-    Agent.all.length ==== 6
+    Agent.all.length ==== 7
 
   private def testAllNonUniversalCount: Result =
-    Agent.allNonUniversal.length ==== 5
+    Agent.allNonUniversal.length ==== 6
 
   private def testAllNonUniversalExcludes: Result =
     Result.assert(!Agent.allNonUniversal.contains(Agent.Universal))
@@ -92,6 +93,7 @@ object AgentSpec extends Properties {
         Result.assert(!Agent.needsAgentsMd(Agent.Claude)),
         Result.assert(!Agent.needsAgentsMd(Agent.Cursor)),
         Result.assert(!Agent.needsAgentsMd(Agent.Gemini)),
+        Result.assert(!Agent.needsAgentsMd(Agent.Windsurf)),
         Result.assert(!Agent.needsAgentsMd(Agent.Copilot)),
       )
     )

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -16,7 +16,9 @@ object DirsSpec extends Properties {
     example("getSkillsDir: project Cursor uses .cursor", testProjectCursor),
     example("getSkillsDir: project Codex uses .codex", testProjectCodex),
     example("getSkillsDir: project Gemini uses .gemini", testProjectGemini),
-    example("getSearchDirs: returns 12 dirs", testSearchDirsCount),
+    example("getSkillsDir: project Windsurf uses .windsurf", testProjectWindsurf),
+    example("getSkillsDir: global Windsurf uses .codeium/windsurf (asymmetric)", testGlobalWindsurf),
+    example("getSearchDirs: returns 14 dirs", testSearchDirsCount),
     example("getSearchDirs: correct priority order", testSearchDirsOrder),
     example("getSearchDirs: first is project universal", testSearchDirsFirst),
     example("getSearchDirs: prefer reorders correctly", testSearchDirsPrefer),
@@ -50,17 +52,23 @@ object DirsSpec extends Properties {
   private def testProjectGemini: Result =
     Dirs.getSkillsDir(Agent.Gemini, global = false) ==== (os.pwd / ".gemini" / "skills")
 
+  private def testProjectWindsurf: Result =
+    Dirs.getSkillsDir(Agent.Windsurf, global = false) ==== (os.pwd / ".windsurf" / "skills")
+
+  private def testGlobalWindsurf: Result =
+    Dirs.getSkillsDir(Agent.Windsurf, global = true) ==== (os.home / ".codeium" / "windsurf" / "skills")
+
   private def testSearchDirsCount: Result = {
     val dirs = Dirs.getSearchDirs()
-    dirs.length ==== 12
+    dirs.length ==== 14
   }
 
   private def testSearchDirsOrder: Result = {
     val dirs = Dirs.getSearchDirs()
     // 1. Project universal
-    // 2-6. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini)
-    // 7. Global universal
-    // 8-12. Global agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini)
+    // 2-7. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini, Windsurf)
+    // 8. Global universal
+    // 9-14. Global agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini, Windsurf)
     Result.all(
       List(
         // Project universal
@@ -71,18 +79,20 @@ object DirsSpec extends Properties {
         dirs(3)._2 ==== Agent.Copilot,
         dirs(4)._2 ==== Agent.Cursor,
         dirs(5)._2 ==== Agent.Gemini,
+        dirs(6)._2 ==== Agent.Windsurf,
         // All project dirs are Project location
-        Result.assert(dirs.take(6).forall(_._3 == SkillLocation.Project)),
+        Result.assert(dirs.take(7).forall(_._3 == SkillLocation.Project)),
         // Global universal
-        dirs(6) ==== ((os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global)),
+        dirs(7) ==== ((os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global)),
         // Global agent-specific (alphabetical)
-        dirs(7)._2 ==== Agent.Claude,
-        dirs(8)._2 ==== Agent.Codex,
-        dirs(9)._2 ==== Agent.Copilot,
-        dirs(10)._2 ==== Agent.Cursor,
-        dirs(11)._2 ==== Agent.Gemini,
+        dirs(8)._2 ==== Agent.Claude,
+        dirs(9)._2 ==== Agent.Codex,
+        dirs(10)._2 ==== Agent.Copilot,
+        dirs(11)._2 ==== Agent.Cursor,
+        dirs(12)._2 ==== Agent.Gemini,
+        dirs(13)._2 ==== Agent.Windsurf,
         // All global dirs are Global location
-        Result.assert(dirs.drop(6).forall(_._3 == SkillLocation.Global)),
+        Result.assert(dirs.drop(7).forall(_._3 == SkillLocation.Global)),
       )
     )
   }
@@ -106,8 +116,8 @@ object DirsSpec extends Properties {
     Result.all(
       List(
         firstAgent ==== Agent.Cursor,
-        // Should still have 12 dirs
-        dirs.length ==== 12,
+        // Should still have 14 dirs
+        dirs.length ==== 14,
       )
     )
   }


### PR DESCRIPTION
# Close #17: Add Windsurf skill support with `.windsurf/skills/` (project) and `~/.codeium/windsurf/skills/` (global)

Add Windsurf as the 7th supported agent. Windsurf (Cognition, formerly Codeium) now fully supports the `SKILL.md` standard. The global directory uses Windsurf's native path `~/.codeium/windsurf/skills/` (asymmetric, like Copilot's `.github` vs `.copilot`).

- Add `Agent.Windsurf` enum case with `.windsurf` project dir and `.codeium/windsurf` global dir
- Update search directory count from 12 to 14 with correct priority ordering
- Windsurf does not need `AGENTS.md` auto-generation
- Update CLI header, README supported agents table, skill directories priority table, and changelog
- Update all related tests (agent count, fromString, needsAgentsMd, directory order assertions)