### PR TITLE
Close #21: Interactive Agent (`--agent`) & Location (`--global`) Selection for `install` Command

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -48,16 +48,16 @@ object Main {
           |
           |Accepts GitHub shorthand (owner/repo), a specific skill path
           |(owner/repo/skill-name), a full Git URL (HTTPS or SSH), or a local
-          |directory path. By default skills are installed into the project-local
-          |.agents/skills directory for the universal agent.
+          |directory path. If no --agent is given, an interactive prompt lets
+          |you choose the target agent(s) and location.
           |
           |Examples:
-          |  aiskills install anthropics/skills                     # All skills from a GitHub repo (project, universal)
-          |  aiskills install anthropics/skills/commit              # Single skill by path
-          |  aiskills install owner/repo --global                   # Install globally (~/.agents/skills)
-          |  aiskills install owner/repo --agent universal          # Install into .agents/skills (default)
-          |  aiskills install owner/repo --agent claude             # Install into .claude/skills
-          |  aiskills install owner/repo --agent cursor             # Install into .cursor/skills
+          |  aiskills install anthropics/skills                     # Interactive agent & location selection
+          |  aiskills install anthropics/skills/commit              # Single skill by path (interactive)
+          |  aiskills install owner/repo --global                   # Install globally (interactive agent selection)
+          |  aiskills install owner/repo --agent universal          # Install into .agents/skills (project)
+          |  aiskills install owner/repo --agent claude             # Install into .claude/skills (project)
+          |  aiskills install owner/repo --agent cursor             # Install into .cursor/skills (project)
           |  aiskills install owner/repo --agent claude --global    # Install globally (~/.claude/skills)
           |  aiskills install owner/repo --all-agents               # Install into all agent directories
           |  aiskills install owner/repo --all-agents --global      # Install globally for all agents
@@ -76,21 +76,23 @@ object Main {
             s"Target agent (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             short = "a",
           )
-          .withDefault("universal")
+          .orNone
         val allAgents = Opts.flag("all-agents", "Install to all agent directories").orFalse
         val yes       = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
         (source, global, agent, allAgents, yes).mapN { (src, g, a, all, y) =>
-          Agent.fromString(a) match {
-            case Some(agentEnum) =>
-              Install.installSkill(src, InstallOptions(global = g, agent = agentEnum, allAgents = all, yes = y))
-            case None =>
-              System
-                .err
-                .println(
-                  s"Error: Invalid agent '$a'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
-                )
-              sys.exit(1)
+          val agentOpt: Option[Agent] = a.flatMap { agentStr =>
+            Agent.fromString(agentStr) match {
+              case Some(agentEnum) => Some(agentEnum)
+              case None =>
+                System
+                  .err
+                  .println(
+                    s"Error: Invalid agent '$agentStr'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                  )
+                sys.exit(1)
+            }
           }
+          Install.installSkill(src, InstallOptions(global = g, agent = agentOpt, allAgents = all, yes = y))
         }
       }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -60,11 +60,78 @@ object Install {
     else if bytes < 1024 * 1024 then f"${bytes / 1024.0}%.1fKB"
     else f"${bytes / (1024.0 * 1024.0)}%.1fMB"
 
+  /** Resolve agents and location from options, prompting interactively when not specified. */
+  private def resolveAgentsAndLocation(options: InstallOptions): (List[Agent], Boolean) = {
+    if options.allAgents then (Agent.all, !options.global)
+    else
+      options.agent match {
+        case Some(a) => (List(a), !options.global)
+        case None =>
+          val agents    = promptForAgents()
+          val isProject = if options.global then false else promptForLocation()
+          (agents, isProject)
+      }
+  }
+
+  private def promptForAgents(): List[Agent] = {
+    val agentLabels = Agent.all.map(_.toString)
+
+    aiskills.cli.SigintHandler.install()
+    val result = Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels) match {
+        case Completion.Finished(selectedLabels) =>
+          val selected = Agent.all.filter(a => selectedLabels.contains(a.toString))
+          if selected.isEmpty then {
+            println("No agents selected. Installation cancelled.".yellow)
+            Left(0)
+          } else Right(selected)
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          Left(0)
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          Left(1)
+      }
+    }
+    result match {
+      case Left(code) => throw SkillInstallException(code) // scalafix:ok DisableSyntax.throw
+      case Right(agents) => agents
+    }
+  }
+
+  private def promptForLocation(): Boolean = {
+    val locationLabels = List("project", "global")
+
+    aiskills.cli.SigintHandler.install()
+    val result = Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select install location", locationLabels) match {
+        case Completion.Finished(selectedLabels) =>
+          selectedLabels.headOption match {
+            case Some(label) => Right(label === "project")
+            case None =>
+              println("No location selected. Defaulting to project.".yellow)
+              Right(true)
+          }
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          Left(0)
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          Left(1)
+      }
+    }
+    result match {
+      case Left(code) => throw SkillInstallException(code) // scalafix:ok DisableSyntax.throw
+      case Right(isProject) => isProject
+    }
+  }
+
   /** Install skill from local path, GitHub, or Git URL. */
   def installSkill(source: String, options: InstallOptions): Unit = {
     aiskills.cli.TempDirCleanup.ensureAtexitRegistered()
-    val agents    = if options.allAgents then Agent.all else List(options.agent)
-    val isProject = !options.global
+
+    // Resolve agents and location (interactive if not specified) before cloning
+    val (agents, isProject) = resolveAgentsAndLocation(options)
 
     // Resolve source once
     val resolvedSource = resolveSource(source)
@@ -87,11 +154,8 @@ object Install {
         println(s"Installing from: ${source.cyan}")
         println(s"Location: $location")
         if agents.length <= 1 then {
-          if isProject then println(
-            s"Default install is project-local (./$folder). Use --global for ~/$globalFolder.".dim
-          )
-          else
-            println(s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim)
+          if !isProject then println(s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim)
+          else ()
         } else ()
         println()
 

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -77,7 +77,7 @@ final case class SkillLocationInfo(
 
 final case class InstallOptions(
   global: Boolean,
-  agent: Agent,
+  agent: Option[Agent],
   allAgents: Boolean,
   yes: Boolean,
 )


### PR DESCRIPTION
# Close #21: Interactive Agent (`--agent`) & Location (`--global`) Selection for `install` Command

Remove default (universal, project) for `aiskills install` and use interactive prompts instead

When `--agent` is not given, the `install` command now launches interactive prompts (via `cue4s`) to let the user select target agent(s) and install location (`project/global`) before cloning the repository.

- Change `InstallOptions.agent` from `Agent` to `Option[Agent]`
- Change `--agent` CLI option from `.withDefault("universal")` to `.orNone`
- Add `resolveAgentsAndLocation` to route between interactive prompts and direct flag values based on what's provided
- Add `promptForAgents` using `multiChoiceNoneSelected` for agent selection
- Add `promptForLocation` using `multiChoiceNoneSelected` for project/global
- Move agent/location resolution before `resolveSource` so no clone is wasted if the user cancels at the prompt
- Remove "Default install is project-local" hint since user now explicitly chooses
- Update help text and examples to reflect interactive behavior