### PR TITLE
Close #16: There should be only one project version source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,25 @@ env:
 
 jobs:
 
-  build:
+  release-version-check:
     if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Check release version"
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PROJECT_VERSION=$(cat version.sbt | tr '\n' ' ' | sed -n 's/.*version[[:space:]]*:=[[:space:]]*"\([^"]*\)".*/\1/p')
+          echo "Tag version: ${TAG_VERSION}"
+          echo "Project version: ${PROJECT_VERSION}"
+          if [ "${TAG_VERSION}" != "${PROJECT_VERSION}" ]; then
+            echo "::error::Tag version '${TAG_VERSION}' does not match project version '${PROJECT_VERSION}' in version.sbt"
+            exit 1
+          fi
+
+  build:
+    needs: release-version-check
 
     runs-on: ${{ matrix.os.value }}
     strategy:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import scala.scalanative.build.*
 
 ThisBuild / scalaVersion := props.ScalaVersion
 ThisBuild / organization := props.Org
-ThisBuild / version := props.ProjectVersion
 
 lazy val aiSkills = project
   .in(file("."))
@@ -19,6 +18,15 @@ lazy val aiSkills = project
   .aggregate(core, cli)
 
 lazy val core = module("core")
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    /* Build Info { */
+    buildInfoKeys := List[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoObject := "AiSkillsInfo",
+    buildInfoPackage := "aiskills.info",
+    buildInfoOptions += BuildInfoOption.ToJson,
+    /* } Build Info */
+  )
   .settings(
     libraryDependencies ++= Seq(
       libs.osLib.value,
@@ -65,8 +73,6 @@ lazy val props = new {
 
   val Org     = "io.kevinlee"
   val OrgName = "Kevin's Code"
-
-  val ProjectVersion = "0.1.1"
 
   val OsLibVersion = "0.11.8"
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -4,6 +4,7 @@ import cats.syntax.all.*
 import com.monovore.decline.*
 import aiskills.core.{Agent, InstallOptions, ReadOptions, SyncOptions}
 import aiskills.cli.commands.*
+import aiskills.info.AiSkillsInfo
 
 object Main {
 
@@ -25,7 +26,7 @@ object Main {
                |  aiskills remove commit                        # Remove a skill
                |  aiskills manage                               # Interactive removal
                |""".stripMargin,
-    version = "0.1.1",
+    version = AiSkillsInfo.version,
     main = {
 
       val listCommand = Opts.subcommand(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,9 @@
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.10")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
+
 val sbtDevOopsVersion = "3.5.0"
+
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "0.1.2-SNAPSHOT"


### PR DESCRIPTION
# Close #16: There should be only one project version source

- Now, the project version is handled by `sbt-buildinfo`
- It's not set in `version.sbt`, and it is also set in `AiSkillsInfo.version` by `sbt-buildinfo`.
- Also update `release.yml` to have a pre-build job for the release version check