### PR TITLE
Close #27: `install` command should ask users if they want to `overwrite`, `skip`, `overwrite all` or `skip all` when the skills to be installed already exist

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -6,6 +6,8 @@ import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 import cue4s.*
 
+import OverwritePrompt.{BulkDecision, OverwriteChoice}
+
 import scala.util.{Failure, Success, Try}
 
 object Install {
@@ -497,26 +499,88 @@ object Install {
     if skillsToInstall.nonEmpty then {
       val isProject = targetDir.startsWith(os.pwd)
 
-      val installedCount = skillsToInstall.count { info =>
-        if warnIfConflict(info.skillName, info.targetPath, isProject, options.yes) then {
-          os.makeDir.all(targetDir)
-          if !isPathInside(info.targetPath, targetDir) then {
-            System.err.println("Security error: Installation path outside target directory".red)
-            false
-          } else {
-            os.copy(info.skillDir, info.targetPath, replaceExisting = true)
-            SkillMetadata.writeSkillMetadata(
-              info.targetPath,
-              buildMetadataFromSource(sourceInfo, info.skillDir, repoDir),
-            )
-            println(s"\u2705 Installed: ${info.skillName}".green)
-            true
-          }
-        } else {
-          println(s"Skipped: ${info.skillName}".yellow)
-          false
+      val (installedCount, _) =
+        skillsToInstall.foldLeft((0, BulkDecision.Undecided: BulkDecision)) {
+          case ((count, bulk), info) =>
+            def doInstall(): Int = {
+              if os.exists(info.targetPath) then {
+                println(s"Overwriting: ${info.skillName} (all existing files and folders will be removed)".dim)
+                os.remove.all(info.targetPath)
+              } else ()
+              os.makeDir.all(targetDir)
+              if !isPathInside(info.targetPath, targetDir) then {
+                System.err.println("Security error: Installation path outside target directory".red)
+                count
+              } else {
+                os.copy(info.skillDir, info.targetPath, replaceExisting = true)
+                SkillMetadata.writeSkillMetadata(
+                  info.targetPath,
+                  buildMetadataFromSource(sourceInfo, info.skillDir, repoDir),
+                )
+                println(s"\u2705 Installed: ${info.skillName}".green)
+                count + 1
+              }
+            }
+
+            if !os.exists(info.targetPath) then {
+              // No conflict — check marketplace warning and install
+              if !isProject && MarketplaceSkills.anthropicMarketplaceSkills.contains(info.skillName) then {
+                System
+                  .err
+                  .println(
+                    s"\n\u26a0\ufe0f  Warning: '${info.skillName}' matches an Anthropic marketplace skill".yellow
+                  )
+                System.err.println("   Installing globally may conflict with Claude Code plugins.".dim)
+                System.err.println("   If you re-enable Claude plugins, this will be overwritten.".dim)
+                System.err.println("   Recommend: Use --project flag for conflict-free installation.\n".dim)
+              } else ()
+              os.makeDir.all(targetDir)
+              if !isPathInside(info.targetPath, targetDir) then {
+                System.err.println("Security error: Installation path outside target directory".red)
+                (count, bulk)
+              } else {
+                os.copy(info.skillDir, info.targetPath, replaceExisting = true)
+                SkillMetadata.writeSkillMetadata(
+                  info.targetPath,
+                  buildMetadataFromSource(sourceInfo, info.skillDir, repoDir),
+                )
+                println(s"\u2705 Installed: ${info.skillName}".green)
+                (count + 1, bulk)
+              }
+            } else if options.yes then (doInstall(), bulk)
+            else
+              bulk match {
+                case BulkDecision.OverwriteAll =>
+                  (doInstall(), bulk)
+
+                case BulkDecision.SkipAll =>
+                  println(s"Skipped: ${info.skillName}".yellow)
+                  (count, bulk)
+
+                case BulkDecision.Undecided =>
+                  OverwritePrompt.askOverwriteChoice(
+                    info.skillName,
+                    s"Skill '${info.skillName}' already exists. What would you like to do?",
+                  ) match {
+                    case Left(code) =>
+                      throw SkillInstallException(code) // scalafix:ok DisableSyntax.throw
+
+                    case Right(OverwriteChoice.Yes) =>
+                      (doInstall(), BulkDecision.Undecided)
+
+                    case Right(OverwriteChoice.No) =>
+                      println(s"Skipped: ${info.skillName}".yellow)
+                      (count, BulkDecision.Undecided)
+
+                    case Right(OverwriteChoice.YesToAll) =>
+                      (doInstall(), BulkDecision.OverwriteAll)
+
+                    case Right(OverwriteChoice.NoToAll) =>
+                      println(s"Skipped: ${info.skillName}".yellow)
+                      (count, BulkDecision.SkipAll)
+                  }
+              }
         }
-      }
 
       println(s"\n\u2705 Installation complete: $installedCount skill(s) installed".green)
     } else ()

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/OverwritePrompt.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/OverwritePrompt.scala
@@ -1,0 +1,51 @@
+package aiskills.cli.commands
+
+import cats.syntax.all.*
+import cue4s.*
+import extras.scala.io.syntax.color.*
+
+object OverwritePrompt {
+
+  enum OverwriteChoice {
+    case Yes
+    case No
+    case YesToAll
+    case NoToAll
+  }
+
+  enum BulkDecision {
+    case Undecided
+    case OverwriteAll
+    case SkipAll
+  }
+
+  def askOverwriteChoice(
+    skillName: String,
+    promptMessage: String,
+  ): Either[Int, OverwriteChoice] = {
+    val options = List(
+      "Yes          — Overwrite this skill",
+      "No           — Skip this skill",
+      "Yes to all   — Overwrite all remaining conflicts",
+      "No to all    — Skip all remaining conflicts",
+    )
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      println(
+        s"\u26a0 All existing files and folders in '$skillName' will be removed if you choose to overwrite.".yellow
+      )
+      prompts.singleChoice(promptMessage.yellow, options) match {
+        case Completion.Finished(selected) =>
+          if selected.startsWith("Yes to all") then OverwriteChoice.YesToAll.asRight[Int]
+          else if selected.startsWith("No to all") then OverwriteChoice.NoToAll.asRight[Int]
+          else if selected.startsWith("Yes") then OverwriteChoice.Yes.asRight[Int]
+          else OverwriteChoice.No.asRight[Int]
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft[OverwriteChoice]
+        case Completion.Fail(CompletionError.Error(_)) =>
+          OverwriteChoice.No.asRight[Int]
+      }
+    }
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -6,20 +6,9 @@ import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
 
+import OverwritePrompt.{BulkDecision, OverwriteChoice}
+
 object Sync {
-
-  private enum OverwriteChoice {
-    case Yes
-    case No
-    case YesToAll
-    case NoToAll
-  }
-
-  private enum BulkDecision {
-    case Undecided
-    case OverwriteAll
-    case SkipAll
-  }
 
   /** Sync skills between agent directories. */
   def syncSkills(options: SyncOptions): Unit =
@@ -121,40 +110,6 @@ object Sync {
     }
   }
 
-  private def askOverwriteChoice(
-    skillName: String,
-    toAgent: Agent,
-    location: SkillLocation,
-  ): Either[Int, OverwriteChoice] = {
-    val options = List(
-      "Yes          — Overwrite this skill",
-      "No           — Skip this skill",
-      "Yes to all   — Overwrite all remaining conflicts",
-      "No to all    — Skip all remaining conflicts",
-    )
-    aiskills.cli.SigintHandler.install()
-    Prompts.sync.use { prompts =>
-      println(
-        s"\u26a0 All existing files and folders in '$skillName' will be removed if you choose to overwrite.".yellow
-      )
-      prompts.singleChoice(
-        s"Skill '$skillName' already exists in ${toAgent.toString} (${location.toString.toLowerCase}). What would you like to do?".yellow,
-        options,
-      ) match {
-        case Completion.Finished(selected) =>
-          if selected.startsWith("Yes to all") then OverwriteChoice.YesToAll.asRight[Int]
-          else if selected.startsWith("No to all") then OverwriteChoice.NoToAll.asRight[Int]
-          else if selected.startsWith("Yes") then OverwriteChoice.Yes.asRight[Int]
-          else OverwriteChoice.No.asRight[Int]
-        case Completion.Fail(CompletionError.Interrupted) =>
-          println("\n\nCancelled by user".yellow)
-          0.asLeft[OverwriteChoice]
-        case Completion.Fail(CompletionError.Error(_)) =>
-          OverwriteChoice.No.asRight[Int]
-      }
-    }
-  }
-
   private def syncAllSkills(from: Agent, to: Agent, yes: Boolean): Unit = {
     if from === to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
     else {
@@ -198,7 +153,10 @@ object Sync {
                     (count, bulk)
 
                   case BulkDecision.Undecided =>
-                    askOverwriteChoice(s.name, to, s.location) match {
+                    OverwritePrompt.askOverwriteChoice(
+                      s.name,
+                      s"Skill '${s.name}' already exists in ${to.toString} (${s.location.toString.toLowerCase}). What would you like to do?",
+                    ) match {
                       case Left(code) => sys.exit(code)
 
                       case Right(OverwriteChoice.Yes) =>


### PR DESCRIPTION
# Close #27: `install` command should ask users if they want to `overwrite`, `skip`, `overwrite all` or `skip all` when the skills to be installed already exist

Add `overwrite/skip all` prompt to `install` command for multiple skills

The `install` command previously only offered a binary `Yes`/`No` prompt when a skill already existed at the target. When installing multiple skills from a repo, users had to answer individually for each conflict.

This change adds the same 4-option prompt (`Yes` / `No` / `Yes to all` / `No to all`) that the `sync` command already had, with bulk decision tracking so a "Yes to all" or "No to all" choice applies to all remaining conflicts.

- Extract `OverwriteChoice`, `BulkDecision` `enum`s and `askOverwriteChoice` into a shared `OverwritePrompt` object, parameterized with a prompt message string so both `install` and `sync` can provide context-specific messages
- Refactor `installFromRepo` to use `foldLeft` with `BulkDecision` state tracking instead of `count` with `warnIfConflict`
- Update `Sync` to import from the shared `OverwritePrompt` instead of defining its own private copies
- Single-skill install paths remain unchanged (binary `Yes`/`No`)