### PR TITLE
Fix #29: The available skill list in `AGENTS.md` added during installation is not cleaned when the skills are removed by `remove` or `manage`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
@@ -1,7 +1,7 @@
 package aiskills.cli.commands
 
 import aiskills.core.SkillLocation
-import aiskills.core.utils.Skills
+import aiskills.core.utils.{AgentsMd, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 import cue4s.*
@@ -32,13 +32,17 @@ object Manage {
               val selectedIndices = selectedLabels.flatMap { label =>
                 labels.zipWithIndex.find(_._1 === label).map(_._2)
               }
-              for idx <- selectedIndices do {
-                val skill = sorted(idx)
+              val removedSkills   = selectedIndices.map(sorted(_))
+              for skill <- removedSkills do {
                 os.remove.all(skill.path)
                 println(
                   s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString})".green
                 )
               }
+
+              val agentLocationPairs = removedSkills.map(s => (s.agent, s.location)).distinct
+              for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+
               println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
             }
             Right(())

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -1,6 +1,6 @@
 package aiskills.cli.commands
 
-import aiskills.core.utils.Skills
+import aiskills.core.utils.{AgentsMd, Skills}
 
 object Remove {
 
@@ -14,6 +14,8 @@ object Remove {
     }
 
     os.remove.all(skill.baseDir)
+
+    AgentsMd.updateAgentsMdForAgent(skill.agent, skill.location)
 
     val scope     = skill.location.toString.toLowerCase
     val agentName = skill.agent.toString

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentsMd.scala
@@ -1,6 +1,7 @@
 package aiskills.core.utils
 
 import aiskills.core.{Agent, Skill, SkillLocation}
+import cats.syntax.all.*
 
 import scala.util.matching.Regex
 import scala.xml.{Elem, PrettyPrinter}
@@ -96,17 +97,14 @@ object AgentsMd {
     val xmlRegex          = """<skills[_-]system[^>]*>[\s\S]*?</skills[_-]system>""".r
 
     if content.contains(xmlMarkerStart) || content
-      .contains(xmlMarkerStartOld) then xmlRegex.replaceFirstIn(content, "<!-- Skills section removed -->")
+      .contains(xmlMarkerStartOld) then xmlRegex.replaceFirstIn(content, "").replaceAll("""\n{3,}""", "\n\n").strip
     else {
       val htmlStart = "<!-- SKILLS_TABLE_START -->"
       val htmlEnd   = "<!-- SKILLS_TABLE_END -->"
 
       if content.contains(htmlStart) then {
         val htmlRegex = s"""(?s)${Regex.quote(htmlStart)}[\\s\\S]*?${Regex.quote(htmlEnd)}""".r
-        htmlRegex.replaceFirstIn(
-          content,
-          Regex.quoteReplacement(s"$htmlStart\n<!-- Skills section removed -->\n$htmlEnd"),
-        )
+        htmlRegex.replaceFirstIn(content, "").replaceAll("""\n{3,}""", "\n\n").strip
       } else
         content
     }
@@ -119,7 +117,7 @@ object AgentsMd {
         case SkillLocation.Global => os.home / "AGENTS.md"
         case SkillLocation.Project => os.pwd / "AGENTS.md"
       }
-      val skills     = Skills.findAllSkills()
+      val skills     = Skills.findAllSkills().filter(_.location === location)
       if skills.nonEmpty then {
         val xml = generateSkillsXml(skills)
         if os.exists(outputPath) then {
@@ -128,6 +126,10 @@ object AgentsMd {
           os.write.over(outputPath, updated)
         } else
           os.write(outputPath, s"# AGENTS\n\n$xml\n")
+      } else if os.exists(outputPath) then {
+        val content = os.read(outputPath)
+        val updated = removeSkillsSection(content)
+        os.write.over(outputPath, updated)
       } else ()
     } else ()
   }

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentsMdSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentsMdSpec.scala
@@ -23,6 +23,7 @@ object AgentsMdSpec extends Properties {
     example("removeSkillsSection: removes old skills_system format", testRemoveOldFormat),
     example("parseCurrentSkills: parses skills from kebab-case tags", testParseKebabCase),
     example("generateSkillsXml: includes agent element", testAgentElement),
+    example("removeSkillsSection: cleans up generated skills XML after last skill removal", testRemoveAfterLastSkill),
   )
 
   private val sampleSkills = List(
@@ -278,6 +279,24 @@ object AgentsMdSpec extends Properties {
       List(
         Result.assert(xml.contains("<agent>claude</agent>")),
         Result.assert(xml.contains("<agent>universal</agent>")),
+      )
+    )
+  }
+
+  private def testRemoveAfterLastSkill: Result = {
+    val skillsXml       = AgentsMd.generateSkillsXml(
+      List(Skill("pdf", "PDF manipulation", SkillLocation.Project, Agent.Claude, os.pwd / "path" / "to" / "pdf"))
+    )
+    val agentsMdContent = s"# AGENTS\n\n$skillsXml\n\nSome other content."
+    val cleaned         = AgentsMd.removeSkillsSection(agentsMdContent)
+    Result.all(
+      List(
+        Result.assert(!cleaned.contains("<skills-system")),
+        Result.assert(!cleaned.contains("<available-skills>")),
+        Result.assert(!cleaned.contains("<name>pdf</name>")),
+        Result.assert(!cleaned.contains("<!-- Skills section removed -->")),
+        Result.assert(cleaned.contains("Some other content.")),
+        Result.assert(cleaned.contains("# AGENTS")),
       )
     )
   }


### PR DESCRIPTION
# Fix #29: The available skill list in `AGENTS.md` added during installation is not cleaned when the skills are removed by `remove` or `manage`.

Update `AGENTS.md` when skills are removed via `remove` or `manage`

- Add `AgentsMd.updateAgentsMdForAgent` call in `Remove` after deleting the skill directory so AGENTS.md is regenerated without the removed skill.
- Add `AgentsMd.updateAgentsMdForAgent` calls in `Manage` after all selected skills are deleted, once per distinct (agent, location) pair.
- Fix `updateAgentsMdForAgent` to filter skills by location so project-level AGENTS.md only lists project skills and global-level `AGENTS.md` only lists global skills. Previously `findAllSkills()` returned skills across all agents and locations, polluting AGENTS.md with unrelated entries.
- Fix `updateAgentsMdForAgent` to call `removeSkillsSection` when no skills remain for the given location, instead of doing nothing and leaving stale XML in `AGENTS.md`.
- Change `removeSkillsSection` to fully remove the `<skills-system>` block rather than replacing it with a `<!-- Skills section removed -->` comment, which was left behind when a skill was re-installed.
- Add `testRemoveAfterLastSkill` test in `AgentsMdSpec`.