### PR TITLE
Close #31: Use just-spinner in places where the task takes some time to process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val cli = module("cli")
       libs.decline.value,
       libs.cue4s.value,
       libs.extrasScalaIo.value,
+      libs.justSpinnerCore.value,
       libs.tests.hedgehogCore.value,
       libs.tests.hedgehogRunner.value,
       libs.tests.hedgehogSbt.value,
@@ -90,6 +91,8 @@ lazy val props = new {
 
   val ScalaXmlVersion = "2.4.0"
 
+  val JustSpinnerVersion = "0.1.0"
+
   val licenses = List(License.MIT)
 }
 
@@ -111,6 +114,8 @@ lazy val libs = new {
   lazy val extrasScalaIo = Def.setting("io.kevinlee" %%% "extras-scala-io" % props.ExtrasVersion)
 
   lazy val scalaXml = Def.setting("org.scala-lang.modules" %%% "scala-xml" % props.ScalaXmlVersion)
+
+  lazy val justSpinnerCore = Def.setting("io.kevinlee" %%% "just-spinner-core" % props.JustSpinnerVersion)
 
   lazy val tests = new {
     lazy val hedgehogCore = Def.setting("qa.hedgehog" %%% "hedgehog-core" % props.HedgehogVersion % Test)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -8,6 +8,8 @@ import cue4s.*
 
 import OverwritePrompt.{BulkDecision, OverwriteChoice}
 
+import just.spinner.*
+
 import scala.util.{Failure, Success, Try}
 
 object Install {
@@ -254,13 +256,20 @@ object Install {
         localRoot = none[os.Path],
       )
 
-      print("Cloning repository...")
+      val spinner = Spinner.createDefaultSideEffect(
+        SpinnerConfig
+          .default
+          .withText("Cloning repository...")
+          .withColor(Color.cyan)
+          .withIndent(2),
+      )
+      val _       = spinner.start()
       Try {
         os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
           .call(stderr = os.Pipe)
       } match {
         case Failure(ex) =>
-          println(" failed")
+          val _   = spinner.fail(Some("Clone failed"))
           val msg = ex.getMessage
           if msg.nonEmpty then println(msg.dim) else ()
           println("\nTip: For private repos, ensure git SSH keys or credentials are configured".yellow)
@@ -268,7 +277,7 @@ object Install {
           aiskills.cli.TempDirCleanup.unregister()
           throw SkillInstallException(1) // scalafix:ok DisableSyntax.throw
         case Success(_) =>
-          println(" done")
+          val _ = spinner.succeed(Some("Repository cloned"))
       }
 
       ResolvedSource.Git(tempDir / "repo", repoUrl, skillSubpath, sourceInfo)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -5,6 +5,8 @@ import aiskills.core.utils.{SkillMetadata, SkillNames, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 
+import just.spinner.*
+
 import scala.util.{Failure, Success, Try}
 
 object Update {
@@ -89,13 +91,20 @@ object Update {
                     os.makeDir.all(tempDir)
                     aiskills.cli.TempDirCleanup.register(tempDir)
                     try {
-                      print(s"Updating ${skill.name}...")
+                      val spinner = Spinner.createDefaultSideEffect(
+                        SpinnerConfig
+                          .default
+                          .withText(s"Updating ${skill.name}...")
+                          .withColor(Color.cyan)
+                          .withIndent(2),
+                      )
+                      val _       = spinner.start()
                       Try {
                         os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
                           .call(stderr = os.Pipe)
                       } match {
                         case Failure(ex) =>
-                          println(s" failed")
+                          val _   = spinner.fail(Some(s"Clone failed: ${skill.name}"))
                           val msg = ex.getMessage
                           if msg.nonEmpty then println(msg.dim) else ()
                           println(s"Skipped: ${skill.name} (git clone failed)".yellow)
@@ -108,11 +117,11 @@ object Update {
                           val sourceDir = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
 
                           if !os.exists(sourceDir / "SKILL.md") then {
-                            println(s" failed")
+                            val _ = spinner.fail(Some(s"Failed: ${skill.name}"))
                             println(
                               s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
                             )
-                            missingRepoSkillFile += ((skill.name, subpath.getOrElse(".")))
+                            missingRepoSkillFile += skill.name -> subpath.getOrElse(".")
                             (upd, skp + 1)
                           } else {
                             updateSkillFromDir(skill.path, sourceDir)
@@ -120,8 +129,7 @@ object Update {
                               skill.path,
                               meta.copy(installedAt = aiskills.core.utils.isoNow()),
                             )
-                            println(s" done")
-                            println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
+                            val _ = spinner.succeed(Some(s"Updated: ${skill.name} [${skill.agent.toString}]"))
                             (upd + 1, skp)
                           }
                       }


### PR DESCRIPTION
# Close #31: Use just-spinner in places where the task takes some time to process

Add `just-spinner` for animated terminal feedback during git clone operations

- Add `just-spinner-core` 0.1.0 as a dependency to the cli module and replace static `print("Cloning repository...")`/`print("Updating ...")` messages with animated terminal spinners in the `install` and `update` commands.

- `Install.scala`: spinner with `succeed("Repository cloned")` / `fail("Clone failed")` around the git clone call during source resolution.
- `Update.scala`: per-skill spinner with `succeed("Updated: ...")`  / `fail("Clone failed: ...")` around each git clone call inside the update loop.

The spinner automatically detects non-interactive terminals (CI, piped output) and falls back to a single static line.