### PR TITLE
Close #33: Add path to the agent location - Show actual file system paths in skill and agent location displays

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -72,7 +72,7 @@ object Install {
         case Some(a) => (List(a), !options.global)
         case None =>
           val agents    = promptForAgents()
-          val isProject = if options.global then false else promptForLocation()
+          val isProject = if options.global then false else promptForLocation(agents)
           (agents, isProject)
       }
   }
@@ -103,15 +103,20 @@ object Install {
     }
   }
 
-  private def promptForLocation(): Boolean = {
-    val locationLabels = List("project", "global")
+  private def promptForLocation(agents: List[Agent]): Boolean = {
+    val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
+    val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
+    val locationLabels = List(
+      s"project ($projectPaths)",
+      s"global  ($globalPaths)",
+    )
 
     aiskills.cli.SigintHandler.install()
     val result = Prompts.sync.use { prompts =>
       prompts.multiChoiceNoneSelected("Select install location", locationLabels) match {
         case Completion.Finished(selectedLabels) =>
           selectedLabels.headOption match {
-            case Some(label) => Right(label === "project")
+            case Some(label) => Right(label.startsWith("project"))
             case None =>
               println("No location selected. Defaulting to project.".yellow)
               Right(true)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -1,7 +1,7 @@
 package aiskills.cli.commands
 
 import aiskills.core.{Agent, SkillLocation}
-import aiskills.core.utils.Skills
+import aiskills.core.utils.{Dirs, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 
@@ -28,7 +28,9 @@ object ListCmd {
       }
 
       for skill <- sorted do {
-        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue
+        val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+        val locationLabel =
+          s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
         println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
         println(s"    ${skill.description.dim}\n")
       }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Manage.scala
@@ -1,7 +1,7 @@
 package aiskills.cli.commands
 
 import aiskills.core.SkillLocation
-import aiskills.core.utils.{AgentsMd, Skills}
+import aiskills.core.utils.{AgentsMd, Dirs, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 import cue4s.*
@@ -19,7 +19,8 @@ object Manage {
       }
 
       val labels = sorted.map { skill =>
-        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})"
+        val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
         s"${skill.name.padTo(25, ' ')} $locationLabel"
       }
 
@@ -35,8 +36,9 @@ object Manage {
               val removedSkills   = selectedIndices.map(sorted(_))
               for skill <- removedSkills do {
                 os.remove.all(skill.path)
+                val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
                 println(
-                  s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString})".green
+                  s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
                 )
               }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -74,8 +74,9 @@ object Sync {
                 println(
                   s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
                 )
+                val pathLabel = Dirs.displaySkillsDir(to, s.location)
                 prompts.confirm(
-                  s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}). Overwrite?".yellow,
+                  s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}): $pathLabel. Overwrite?".yellow,
                   default = false,
                 ) match {
                   case Completion.Finished(v) =>
@@ -153,9 +154,10 @@ object Sync {
                     (count, bulk)
 
                   case BulkDecision.Undecided =>
+                    val pathLabel = Dirs.displaySkillsDir(to, s.location)
                     OverwritePrompt.askOverwriteChoice(
                       s.name,
-                      s"Skill '${s.name}' already exists in ${to.toString} (${s.location.toString.toLowerCase}). What would you like to do?",
+                      s"Skill '${s.name}' already exists in ${to.toString} (${s.location.toString.toLowerCase}): $pathLabel. What would you like to do?",
                     ) match {
                       case Left(code) => sys.exit(code)
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -1,7 +1,7 @@
 package aiskills.cli.commands
 
 import aiskills.core.SkillSourceType
-import aiskills.core.utils.{SkillMetadata, SkillNames, Skills}
+import aiskills.core.utils.{Dirs, SkillMetadata, SkillNames, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
 
@@ -48,8 +48,9 @@ object Update {
             val metadata = SkillMetadata.readSkillMetadata(skill.path)
             metadata match {
               case None =>
+                val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
                 println(
-                  s"Skipped: ${skill.name} [${skill.agent.toString}] (no source metadata; re-install once to enable updates)".yellow
+                  s"Skipped: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel (no source metadata; re-install once to enable updates)".yellow
                 )
                 missingMetadata += skill.name
                 (upd, skp + 1)
@@ -75,7 +76,10 @@ object Update {
                       skill.path,
                       meta.copy(installedAt = aiskills.core.utils.isoNow()),
                     )
-                    println(s"\u2705 Updated: ${skill.name} [${skill.agent.toString}]".green)
+                    val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
+                    println(
+                      s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
+                    )
                     (upd + 1, skp)
                 }
 
@@ -129,7 +133,12 @@ object Update {
                               skill.path,
                               meta.copy(installedAt = aiskills.core.utils.isoNow()),
                             )
-                            val _ = spinner.succeed(Some(s"Updated: ${skill.name} [${skill.agent.toString}]"))
+                            val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
+                            val _         = spinner.succeed(
+                              Some(
+                                s"Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
+                              )
+                            )
                             (upd + 1, skp)
                           }
                       }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -12,6 +12,16 @@ object Dirs {
       case SkillLocation.Project => os.pwd / os.RelPath(agent.projectDirName) / "skills"
     }
 
+  /** Display-friendly skills directory path for a given agent and location.
+    * Project example: ".agents/skills"
+    * Global example: "~/.agents/skills"
+    */
+  def displaySkillsDir(agent: Agent, location: SkillLocation): String =
+    location match {
+      case SkillLocation.Project => s"${agent.projectDirName}/skills"
+      case SkillLocation.Global => s"~/${agent.globalDirName}/skills"
+    }
+
   /** Get all searchable skill directories in priority order.
     * Priority:
     *   1. Project universal (.agents)

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -19,6 +19,14 @@ object DirsSpec extends Properties {
     example("getSkillsDir: project Gemini uses .gemini", testProjectGemini),
     example("getSkillsDir: project Windsurf uses .windsurf", testProjectWindsurf),
     example("getSkillsDir: global Windsurf uses .codeium/windsurf (asymmetric)", testGlobalWindsurf),
+    example("displaySkillsDir: project Universal", testDisplayProjectUniversal),
+    example("displaySkillsDir: global Universal", testDisplayGlobalUniversal),
+    example("displaySkillsDir: project Claude", testDisplayProjectClaude),
+    example("displaySkillsDir: global Claude", testDisplayGlobalClaude),
+    example("displaySkillsDir: project Windsurf", testDisplayProjectWindsurf),
+    example("displaySkillsDir: global Windsurf (asymmetric)", testDisplayGlobalWindsurf),
+    example("displaySkillsDir: project Copilot", testDisplayProjectCopilot),
+    example("displaySkillsDir: global Copilot (asymmetric)", testDisplayGlobalCopilot),
     example("getSearchDirs: returns 14 dirs", testSearchDirsCount),
     example("getSearchDirs: correct priority order", testSearchDirsOrder),
     example("getSearchDirs: first is project universal", testSearchDirsFirst),
@@ -59,6 +67,30 @@ object DirsSpec extends Properties {
   private def testGlobalWindsurf: Result =
     Dirs.getSkillsDir(Agent.Windsurf, SkillLocation.Global) ==== (os.home / ".codeium" / "windsurf" / "skills")
 
+  private def testDisplayProjectUniversal: Result =
+    Dirs.displaySkillsDir(Agent.Universal, SkillLocation.Project) ==== ".agents/skills"
+
+  private def testDisplayGlobalUniversal: Result =
+    Dirs.displaySkillsDir(Agent.Universal, SkillLocation.Global) ==== "~/.agents/skills"
+
+  private def testDisplayProjectClaude: Result =
+    Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Project) ==== ".claude/skills"
+
+  private def testDisplayGlobalClaude: Result =
+    Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Global) ==== "~/.claude/skills"
+
+  private def testDisplayProjectWindsurf: Result =
+    Dirs.displaySkillsDir(Agent.Windsurf, SkillLocation.Project) ==== ".windsurf/skills"
+
+  private def testDisplayGlobalWindsurf: Result =
+    Dirs.displaySkillsDir(Agent.Windsurf, SkillLocation.Global) ==== "~/.codeium/windsurf/skills"
+
+  private def testDisplayProjectCopilot: Result =
+    Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Project) ==== ".github/skills"
+
+  private def testDisplayGlobalCopilot: Result =
+    Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Global) ==== "~/.copilot/skills"
+
   private def testSearchDirsCount: Result = {
     val dirs = Dirs.getSearchDirs()
     dirs.length ==== 14
@@ -73,7 +105,7 @@ object DirsSpec extends Properties {
     Result.all(
       List(
         // Project universal
-        dirs(0) ==== ((os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project)),
+        dirs(0) ==== (os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project),
         // Project agent-specific (alphabetical)
         dirs(1)._2 ==== Agent.Claude,
         dirs(2)._2 ==== Agent.Codex,
@@ -84,7 +116,7 @@ object DirsSpec extends Properties {
         // All project dirs are Project location
         Result.assert(dirs.take(7).forall(_._3 === SkillLocation.Project)),
         // Global universal
-        dirs(7) ==== ((os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global)),
+        dirs(7) ==== (os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global),
         // Global agent-specific (alphabetical)
         dirs(8)._2 ==== Agent.Claude,
         dirs(9)._2 ==== Agent.Codex,


### PR DESCRIPTION
# Close #33: Add path to the agent location - Show actual file system paths in skill and agent location displays

Add `Dirs.displaySkillsDir` utility that returns display-friendly relative paths (e.g. `.agents/skills` for project, `~/.claude/skills` for global).

- `list`: append path after location label (e.g. `(project, Universal): .agents/skills`)
- `manage`: show path in multi-choice labels and removal confirmation
- `sync`: include path in overwrite prompts
- `update`: show location and path instead of just agent name in brackets
- `install`: show agent directory paths in location prompt (e.g. `project (.agents, .claude)` / `global (~/.agents, ~/.claude)`)
- Add 8 tests for `displaySkillsDir` covering symmetric and asymmetric agents