### PR TITLE
Close #35: Add `agent` and `scope` selection for the `list` command

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -2,7 +2,7 @@ package aiskills.cli
 
 import cats.syntax.all.*
 import com.monovore.decline.*
-import aiskills.core.{Agent, InstallOptions, ReadOptions, SyncOptions}
+import aiskills.core.{Agent, InstallOptions, ListOptions, ReadOptions, SyncOptions}
 import aiskills.cli.commands.*
 import aiskills.info.AiSkillsInfo
 
@@ -31,16 +31,55 @@ object Main {
 
       val listCommand = Opts.subcommand(
         "list",
-        """List all installed skills
+        """List installed skills
           |
-          |Shows all skills across all agents and locations (project + global),
-          |grouped by agent with a summary count.
+          |Shows installed skills with optional filtering by location and agent.
+          |Without flags, an interactive prompt lets you choose scope and agents.
           |
           |Examples:
-          |  aiskills list                  # Show all installed skills
+          |  aiskills list                              # Interactive scope & agent selection
+          |  aiskills list --project                    # Project skills, all agents
+          |  aiskills list --global                     # Global skills, all agents
+          |  aiskills list --agent claude               # Both scopes, Claude only
+          |  aiskills list --agent claude,cursor         # Both scopes, Claude + Cursor
+          |  aiskills list --agent claude --project      # Project skills, Claude only
+          |  aiskills list --all-agents                  # Both scopes, all agents (no prompt)
+          |  aiskills list --all-agents --global         # Global skills, all agents
           |""".stripMargin,
       ) {
-        Opts.unit.map(_ => ListCmd.listSkills())
+        val project   = Opts.flag("project", "Show project skills only", short = "p").orFalse
+        val global    = Opts.flag("global", "Show global skills only", short = "g").orFalse
+        val agent     = Opts
+          .option[String](
+            "agent",
+            s"Filter by agent (comma-separated: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            short = "a",
+          )
+          .orNone
+        val allAgents = Opts.flag("all-agents", "Show skills for all agents (skip agent prompt)").orFalse
+        (project, global, agent, allAgents).mapN { (p, g, a, all) =>
+          if p && g then {
+            System.err.println("Error: Cannot use both --project and --global. Omit both to show all.")
+            sys.exit(1)
+          } else ()
+          if a.isDefined && all then {
+            System.err.println("Error: Cannot use both --agent and --all-agents. Use one or the other.")
+            sys.exit(1)
+          } else ()
+          val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
+            aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
+              case Right(agents) => agents
+              case Left(invalid) =>
+                System
+                  .err
+                  .println(
+                    s"Error: Invalid agent '$invalid'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                  )
+                sys.exit(1)
+            }
+          }
+          ListCmd.listSkills(ListOptions(project = p, global = g, agent = parsedAgents, allAgents = all))
+        }
       }
 
       val installCommand = Opts.subcommand(

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -1,19 +1,44 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, SkillLocation}
+import aiskills.core.{Agent, ListOptions, Skill, SkillLocation}
 import aiskills.core.utils.{Dirs, Skills}
 import cats.syntax.all.*
 import extras.scala.io.syntax.color.*
+import cue4s.*
 
 object ListCmd {
 
-  /** List all installed skills. */
-  def listSkills(): Unit = {
-    println("Available Skills:\n".bold)
+  /** List installed skills, optionally filtered by scope and agent. */
+  def listSkills(options: ListOptions): Unit = {
+    val hasAnyFlag = options.project || options.global || options.agent.isDefined || options.allAgents
+    if hasAnyFlag then listWithFlags(options)
+    else listInteractive()
+  }
 
-    val skills = Skills.findAllSkills()
+  private def listWithFlags(options: ListOptions): Unit = {
+    val locations: List[SkillLocation] =
+      if options.project then List(SkillLocation.Project)
+      else if options.global then List(SkillLocation.Global)
+      else List(SkillLocation.Project, SkillLocation.Global)
 
-    if skills.isEmpty then {
+    val agents: List[Agent] =
+      if options.allAgents then Agent.all
+      else options.agent.getOrElse(Agent.all)
+
+    val skills = for {
+      agent    <- agents
+      location <- locations
+      skill    <- Skills.findSkillsByAgent(agent, location)
+    } yield skill
+
+    if skills.isEmpty then printEmptyFiltered(agents, locations)
+    else displaySkills(skills)
+  }
+
+  private def listInteractive(): Unit = {
+    val allSkills = Skills.findAllSkills()
+
+    if allSkills.isEmpty then {
       println("No skills installed.\n")
       println("Install skills:")
       println(
@@ -23,34 +48,122 @@ object ListCmd {
       println(s"  ${"aiskills install owner/skill --all-agents".cyan}            ${"# Project, all agents".dim}")
       println(s"  ${"aiskills install owner/skill --global".cyan}                ${"# Global".dim}")
     } else {
-      val sorted = skills.sortBy { s =>
-        (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
+      promptForScope() match {
+        case Left(code) => sys.exit(code)
+        case Right(locations) =>
+          val skillsInScope = allSkills.filter(s => locations.contains(s.location))
+
+          if skillsInScope.isEmpty then {
+            val scopeLabel = locations.map(_.toString.toLowerCase).mkString(" and ")
+            println(s"No skills found in $scopeLabel scope.".yellow)
+          } else {
+            val agentsWithCounts = Agent
+              .all
+              .flatMap { agent =>
+                val count = skillsInScope.count(_.agent === agent)
+                if count > 0 then (agent, count).some else none
+              }
+
+            promptForAgents(agentsWithCounts) match {
+              case Left(code) => sys.exit(code)
+              case Right(selectedAgents) =>
+                if selectedAgents.isEmpty then println("No agents selected.".yellow)
+                else {
+                  val filtered = skillsInScope.filter(s => selectedAgents.contains(s.agent))
+                  if filtered.isEmpty then println("No skills found for the selected agents.".yellow)
+                  else displaySkills(filtered)
+                }
+            }
+          }
       }
-
-      for skill <- sorted do {
-        val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
-        val locationLabel =
-          s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
-        println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
-        println(s"    ${skill.description.dim}\n")
-      }
-
-      val byAgent      = skills.groupBy(_.agent)
-      val agentSummary = Agent
-        .all
-        .filter(byAgent.contains)
-        .map { a =>
-          val count = byAgent(a).length
-          s"${a.toString}: $count"
-        }
-        .mkString(", ")
-
-      val projectCount = skills.count(_.location === SkillLocation.Project)
-      val globalCount  = skills.count(_.location === SkillLocation.Global)
-
-      println(s"Summary: $projectCount project, $globalCount global (${skills.length} total)".dim)
-      if byAgent.size > 1 then println(s"  By agent: $agentSummary".dim)
-      else ()
     }
+  }
+
+  private def promptForScope(): Either[Int, List[SkillLocation]] = {
+    val options = List("project", "global", "both")
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("Select scope", options) match {
+        case Completion.Finished(selected) =>
+          selected match {
+            case "project" => List(SkillLocation.Project).asRight
+            case "global" => List(SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+          }
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+    val labels = agentsWithCounts.map { (agent, count) =>
+      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+    }
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select agent(s)", labels) match {
+        case Completion.Finished(selectedLabels) =>
+          val selected = agentsWithCounts
+            .filter { (agent, _) =>
+              selectedLabels.exists(_.contains(agent.toString))
+            }
+            .map(_._1)
+          selected.asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def printEmptyFiltered(agents: List[Agent], locations: List[SkillLocation]): Unit =
+    for {
+      agent    <- agents
+      location <- locations
+    } do {
+      val pathLabel  = Dirs.displaySkillsDir(agent, location)
+      val scopeLabel = location.toString.toLowerCase
+      println(s"No skills found for the given filter ($scopeLabel, ${agent.toString}): $pathLabel".yellow)
+    }
+
+  private def displaySkills(skills: List[Skill]): Unit = {
+    println("Available Skills:\n".bold)
+
+    val sorted = skills.sortBy { s =>
+      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
+    }
+
+    for skill <- sorted do {
+      val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+      val locationLabel =
+        s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
+      println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
+      println(s"    ${skill.description.dim}\n")
+    }
+
+    val byAgent      = skills.groupBy(_.agent)
+    val agentSummary = Agent
+      .all
+      .filter(byAgent.contains)
+      .map { a =>
+        val count = byAgent(a).length
+        s"${a.toString}: $count"
+      }
+      .mkString(", ")
+
+    val projectCount = skills.count(_.location === SkillLocation.Project)
+    val globalCount  = skills.count(_.location === SkillLocation.Global)
+
+    println(s"Summary: $projectCount project, $globalCount global (${skills.length} total)".dim)
+    if byAgent.size > 1 then println(s"  By agent: $agentSummary".dim)
+    else ()
   }
 }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -86,6 +86,13 @@ final case class ReadOptions(
   prefer: Option[Agent],
 )
 
+final case class ListOptions(
+  project: Boolean,
+  global: Boolean,
+  agent: Option[List[Agent]],
+  allAgents: Boolean,
+)
+
 final case class SkillMetadata(
   name: String,
   description: String,

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentNames.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/AgentNames.scala
@@ -1,0 +1,20 @@
+package aiskills.core.utils
+
+import aiskills.core.Agent
+import cats.syntax.all.*
+
+object AgentNames {
+
+  /** Parse comma-separated agent names. Returns Left(firstInvalidName) on failure. */
+  def parseAgentNames(input: String): Either[String, List[Agent]] = {
+    val names            = input.split(",").toList.map(_.trim).filter(_.nonEmpty).distinct
+    val (invalid, valid) = names.partitionMap { name =>
+      Agent.fromString(name) match {
+        case Some(agent) => agent.asRight
+        case None => name.asLeft
+      }
+    }
+    if invalid.nonEmpty then invalid.head.asLeft
+    else valid.asRight
+  }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentNamesSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/AgentNamesSpec.scala
@@ -1,0 +1,43 @@
+package aiskills.core.utils
+
+import aiskills.core.Agent
+import hedgehog.*
+import hedgehog.runner.*
+
+object AgentNamesSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("parses single agent", testSingleAgent),
+    example("parses comma-separated agents", testCommaSeparated),
+    example("trims whitespace", testTrimWhitespace),
+    example("deduplicates agents", testDedup),
+    example("is case insensitive", testCaseInsensitive),
+    example("returns Left for invalid agent", testInvalidAgent),
+    example("returns Left for mixed valid and invalid", testMixedValidInvalid),
+    example("returns empty list for empty string", testEmptyString),
+  )
+
+  private def testSingleAgent: Result =
+    AgentNames.parseAgentNames("claude") ==== Right(List(Agent.Claude))
+
+  private def testCommaSeparated: Result =
+    AgentNames.parseAgentNames("claude,cursor") ==== Right(List(Agent.Claude, Agent.Cursor))
+
+  private def testTrimWhitespace: Result =
+    AgentNames.parseAgentNames(" claude , cursor ") ==== Right(List(Agent.Claude, Agent.Cursor))
+
+  private def testDedup: Result =
+    AgentNames.parseAgentNames("claude,claude") ==== Right(List(Agent.Claude))
+
+  private def testCaseInsensitive: Result =
+    AgentNames.parseAgentNames("Claude,CURSOR") ==== Right(List(Agent.Claude, Agent.Cursor))
+
+  private def testInvalidAgent: Result =
+    AgentNames.parseAgentNames("invalid") ==== Left("invalid")
+
+  private def testMixedValidInvalid: Result =
+    AgentNames.parseAgentNames("claude,bogus") ==== Left("bogus")
+
+  private def testEmptyString: Result =
+    AgentNames.parseAgentNames("") ==== Right(List.empty)
+}


### PR DESCRIPTION
# Close #35: Add `agent` and `scope` selection for the `list` command

Add `--project`, `--global`, `--agent`, and `--all-agents` filtering to `list` command with interactive mode

Add scope and agent filtering parameters to the `list` command. When no flags are provided, an interactive mode guides the user through scope selection (`project`/`global`/`both`) via single-choice prompt, then agent selection via multi-choice prompt showing only agents that have skills in the chosen scope with skill counts.

With flags, skills are filtered directly:
- `--project` / `-p` and `--global` / `-g` filter by location scope (mutually exclusive; omit both for all)
- `--agent` / `-a` accepts comma-separated agent names (e.g. `claude,cursor`)
- `--all-agents` explicitly selects all agents without prompting
- Conflicting flag combinations (`--project --global` or `--agent --all-agents`) produce clear error messages

When filters match no skills, a filter-aware message is shown per agent/location combination with the corresponding directory path.

New files:
- `AgentNames.parseAgentNames` utility for parsing comma-separated agent name strings with validation
- `AgentNamesSpec` with 8 test cases covering parsing, trimming, deduplication, case insensitivity, and error handling

Modified files:
- `Types.scala`: added `ListOptions` case class
- `Main.scala`: replaced parameterless `list` subcommand with flag definitions and conflict validation
- `ListCmd.scala`: rewritten with `listWithFlags`, `listInteractive`, and extracted `displaySkills` methods