### PR TITLE
Close #37: `--agent` param in the `install` command should support multiple agents

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -97,6 +97,7 @@ object Main {
           |  aiskills install owner/repo --global                   # Install globally (interactive agent selection)
           |  aiskills install owner/repo --agent universal          # Install into .agents/skills (project)
           |  aiskills install owner/repo --agent claude             # Install into .claude/skills (project)
+          |  aiskills install owner/repo --agent claude,cursor      # Install into Claude + Cursor (project)
           |  aiskills install owner/repo --agent cursor             # Install into .cursor/skills (project)
           |  aiskills install owner/repo --agent claude --global    # Install globally (~/.claude/skills)
           |  aiskills install owner/repo --all-agents               # Install into all agent directories
@@ -113,26 +114,30 @@ object Main {
         val agent     = Opts
           .option[String](
             "agent",
-            s"Target agent (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            s"Target agent (comma-separated: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             short = "a",
           )
           .orNone
         val allAgents = Opts.flag("all-agents", "Install to all agent directories").orFalse
         val yes       = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
         (source, global, agent, allAgents, yes).mapN { (src, g, a, all, y) =>
-          val agentOpt: Option[Agent] = a.flatMap { agentStr =>
-            Agent.fromString(agentStr) match {
-              case Some(agentEnum) => Some(agentEnum)
-              case None =>
+          if a.isDefined && all then {
+            System.err.println("Error: Cannot use both --agent and --all-agents. Use one or the other.")
+            sys.exit(1)
+          } else ()
+          val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
+            aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
+              case Right(agents) => agents
+              case Left(invalid) =>
                 System
                   .err
                   .println(
-                    s"Error: Invalid agent '$agentStr'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                    s"Error: Invalid agent '$invalid'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
                   )
                 sys.exit(1)
             }
           }
-          Install.installSkill(src, InstallOptions(global = g, agent = agentOpt, allAgents = all, yes = y))
+          Install.installSkill(src, InstallOptions(global = g, agent = parsedAgents, allAgents = all, yes = y))
         }
       }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -69,7 +69,7 @@ object Install {
     if options.allAgents then (Agent.all, !options.global)
     else
       options.agent match {
-        case Some(a) => (List(a), !options.global)
+        case Some(agents) => (agents, !options.global)
         case None =>
           val agents    = promptForAgents()
           val isProject = if options.global then false else promptForLocation(agents)

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -77,7 +77,7 @@ final case class SkillLocationInfo(
 
 final case class InstallOptions(
   global: Boolean,
-  agent: Option[Agent],
+  agent: Option[List[Agent]],
   allAgents: Boolean,
   yes: Boolean,
 )


### PR DESCRIPTION
# Close #37: `--agent` param in the `install` command should support multiple agents

Add multi-agent param support for `install` command (e.g. `--agent claude,cursor`)

The `install` command's `--agent` flag previously accepted only a single agent name. This change brings it to feature parity with the list command by supporting comma-separated agent names.

- Change `InstallOptions.agent` type from `Option[Agent]` to `Option[List[Agent]]`
- Use `AgentNames.parseAgentNames` for comma-separated parsing and validation, reusing the same utility already used by the `list` command
- Add `--agent` / `--all-agents` mutual exclusion validation with a clear error message, matching the list command's behavior
- Update `--agent` `help` text to indicate comma-separated support
- Add multi-agent example to install command `help` text
- Simplify `resolveAgentsAndLocation` to use the agent list directly instead of wrapping a single agent in `List()`