### PR TITLE
ai-skills v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,174 @@
+## [1.0.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am3) - 2026-03-29
+
+## New Features
+
+### Add Windsurf support (#17)
+  
+Now Windsurf supports [SKILLS](https://docs.windsurf.com/windsurf/cascade/skills) so `ai-skills` supports Windsurf.
+
+#### Supported Agents
+
+| Agent                | Project Dir             | Global Dir                        |
+|----------------------|-------------------------|-----------------------------------|
+| Universal  (default) | `.agents/skills/`       | `~/.agents/skills/`               |
+| Claude               | `.claude/skills/`       | `~/.claude/skills/`               |
+| Cursor               | `.cursor/skills/`       | `~/.cursor/skills/`               |
+| Codex                | `.codex/skills/`        | `~/.codex/skills/`                |
+| Gemini               | `.gemini/skills/`       | `~/.gemini/skills/`               |
+| **Windsurf**  🎉🎂🍾 | **`.windsurf/skills/`** | **`~/.codeium/windsurf/skills/`** |
+| Copilot              | `.github/skills/`       | `~/.copilot/skills/`              |
+
+## Improvements
+
+### Interactive Agent (`--agent`) & Location (`--global`) Selection for `install` Command (#21)
+
+#### Old Behavioral Specification
+The old behavior when `--agent` and `--global` are missing when running `install` like
+```bash
+aiskills install anthropics/skills
+```
+it uses the default agent and location, which are `universal` and `project` respectively. So it will be installed at the current project folder (i.e. `.agents/skills`).
+
+#### New Behavioral Specification
+
+Removed: the default `(universal, project)` for `aiskills install` when `--agent` and `--global` are not given. Instead, launch interactive prompts (using [cue4s](https://github.com/neandertech/cue4s/)) so the user can select agent(s) and location before cloning/installing.
+
+|  Flags given               | Agent(s)           | Location           |
+|----------------------------|--------------------|--------------------|
+|  (none)                    | interactive prompt | interactive prompt |
+|  `--agent claude`          | claude             | project (default)  |
+|  `--global`                | interactive prompt | global             |
+|  `--agent claude --global` | claude             | global             |
+|  `--all-agents`            | all agents         | project (default)  |
+|  `--all-agents --global`   | all agents         | global             |
+
+It asks users to choose the agents and location before cloning/installing the skills repo.
+So they do not need to wait for the skills repository to be cloned.
+
+It can also warn users and ask if they want to overwrite existing skills with the same names.
+
+***
+### The `sync` command should let the user decide whether to overwrite the skill if it already exists in the target agent, instead of skipping it (#22)
+
+When `sync`ing the already existing skill, it should ask users if they want to overwrite (`Yes`) or skip (`No`) or overwrite it and all the subsequent ones (`Yes to all`) or skip it and the rest (`No to all`).
+
+  - `Yes` — overwrite this skill
+  - `No` — skip this skill
+  - `Yes to all` — overwrite this and all remaining conflicts
+  - `No to all` — skip this and all remaining conflicts
+
+***
+### `install` command should ask users if they want to overwrite, skip, overwrite all or skip all when the skills to be installed already exist (#27)
+
+In older versions, when the skills that are about to be installed by the `install` command already exist, it asks users whether they want to overwrite them one by one.
+
+If there are many skills, asking one by one and getting the answers one by one would not be ideal.
+
+So, just like (#22), this update introduces options to `overwrite all` and `skip all`.
+
+***
+### Use `just-spinner` in places where the task takes some time to process (#31)
+
+Finally, I've released the very [first version](https://github.com/kevin-lee/just-spinner/releases/tag/v0.1.0) of [just-spinner](https://github.com/kevin-lee/just-spinner), so `ai-skills` can now use it. 🎉🎂🍾
+
+You can see the spinner in the `install` command and the `update` command.
+
+***
+### Add path to agent location (#33)
+
+Add path to agent location
+
+#### Old
+For `install` interactive mode,
+```
+? Select target agent(s) ›
+Tab to toggle, Enter to submit.
+ ◯ Universal
+ ◯ Claude
+ ◯ Cursor
+ ◯ Codex
+ ◯ Gemini
+ ◯ Windsurf
+ ◯ Copilot
+```
+If `Universal` and `Claude` are selected, it shows
+```
+? Select install location ›
+Tab to toggle, Enter to submit.
+ ◯ project
+ ◯ global
+```
+
+#### New (This Release)
+```
+? Select install location ›
+Tab to toggle, Enter to submit.
+ ◯ project (.agents, .claude)
+ ◯ global  (~/.agents, ~/.claude)
+```
+
+#### For `list`,
+For `list`, it's like this
+Old:
+```
+  2020-hindsight-scala      (global, Claude)
+```
+
+New:
+```
+  2020-hindsight-scala      (global, Claude): ~/.claude/skills
+```
+***
+
+### Add `agent` and `scope` selection for the `list` command (#35)
+
+The old `list` command takes no parameters and displays all global and project skills.
+
+It could be too much if a user wants to see the skill list for the current project or the global skills of one agent.
+
+So this update introduces a way to specify the agents and the scope (`global`, `project` or both).
+
+e.g.)
+
+```bash
+aiskills list --agent claude --global      # skills from ~/.claude/skills
+aiskills list --agent universal --project  # skills from .agents/skills
+aiskills list --agent claude               # skills from both ~/.claude/skills and .claude/skills
+
+aiskills list --all-agents --global   # skills from all agents' global skills
+aiskills list --all-agents --project  # skills from all agents' project skills
+aiskills list --all-agents            # show everything for all agents in both project and global
+
+# skills from both (~/.claude/skills, ~/.codex/skills, ~/.gemini/skills) and (.claude/skills, .codex/skills, .gemini/skills)
+aiskills list --agent claude,codex,gemini
+```
+
+***
+### `--agent` param in the `install` command should support multiple agents (#37)
+
+Just like the `list` command, the `install` command now supports multiple agents via the `--agent` parameter like `--agent universal,claude,cursor`.
+
+e.g.)
+```bash
+# skills for ~/.claude/skills, ~/.cursor/skills, ~/.codeium/windsurf/skills
+aiskills install owner/repo --agent claude,cursor,windsurf --global
+
+# skills for .agents/skills, .claude/skills
+aiskills install owner/repo --agent universal,claude --project
+```
+
+***
+
+## Bug Fixed
+### The available skill list in `AGENTS.md` added during installation is not cleaned when the skills are removed by `remove` or `manage` (#29)
+
+There are AI agents (and the universal one, i.e. `.agents`) that require the available skill list in the `AGENTS.md` file. So `ai-skills` add it when the skill is installed with the `install` command.
+
+However, the added skills in the skill list in the `AGENTS.md` file are not cleaned up when the installed skills are removed by the `remove` command or the `manage` command.
+
+This bug has been fixed in this release.
+
+
+## Internal Housekeeping
+
+* There should be only one project version source (#16)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.2-SNAPSHOT"
+ThisBuild / version := "1.0.0"


### PR DESCRIPTION
# ai-skills v1.0.0
## [1.0.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am3) - 2026-03-29

## New Features

### Add Windsurf support (#17)
  
Now Windsurf supports [SKILLS](https://docs.windsurf.com/windsurf/cascade/skills) so `ai-skills` supports Windsurf.

#### Supported Agents

| Agent                | Project Dir             | Global Dir                        |
|----------------------|-------------------------|-----------------------------------|
| Universal  (default) | `.agents/skills/`       | `~/.agents/skills/`               |
| Claude               | `.claude/skills/`       | `~/.claude/skills/`               |
| Cursor               | `.cursor/skills/`       | `~/.cursor/skills/`               |
| Codex                | `.codex/skills/`        | `~/.codex/skills/`                |
| Gemini               | `.gemini/skills/`       | `~/.gemini/skills/`               |
| **Windsurf**  🎉🎂🍾 | **`.windsurf/skills/`** | **`~/.codeium/windsurf/skills/`** |
| Copilot              | `.github/skills/`       | `~/.copilot/skills/`              |

## Improvements

### Interactive Agent (`--agent`) & Location (`--global`) Selection for `install` Command (#21)

#### Old Behavioral Specification
The old behavior when `--agent` and `--global` are missing when running `install` like
```bash
aiskills install anthropics/skills
```
it uses the default agent and location, which are `universal` and `project` respectively. So it will be installed at the current project folder (i.e. `.agents/skills`).

#### New Behavioral Specification

Removed: the default `(universal, project)` for `aiskills install` when `--agent` and `--global` are not given. Instead, launch interactive prompts (using [cue4s](https://github.com/neandertech/cue4s/)) so the user can select agent(s) and location before cloning/installing.

|  Flags given               | Agent(s)           | Location           |
|----------------------------|--------------------|--------------------|
|  (none)                    | interactive prompt | interactive prompt |
|  `--agent claude`          | claude             | project (default)  |
|  `--global`                | interactive prompt | global             |
|  `--agent claude --global` | claude             | global             |
|  `--all-agents`            | all agents         | project (default)  |
|  `--all-agents --global`   | all agents         | global             |

It asks users to choose the agents and location before cloning/installing the skills repo.
So they do not need to wait for the skills repository to be cloned.

It can also warn users and ask if they want to overwrite existing skills with the same names.

***
### The `sync` command should let the user decide whether to overwrite the skill if it already exists in the target agent, instead of skipping it (#22)

When `sync`ing the already existing skill, it should ask users if they want to overwrite (`Yes`) or skip (`No`) or overwrite it and all the subsequent ones (`Yes to all`) or skip it and the rest (`No to all`).

  - `Yes` — overwrite this skill
  - `No` — skip this skill
  - `Yes to all` — overwrite this and all remaining conflicts
  - `No to all` — skip this and all remaining conflicts

***
### `install` command should ask users if they want to overwrite, skip, overwrite all or skip all when the skills to be installed already exist (#27)

In older versions, when the skills that are about to be installed by the `install` command already exist, it asks users whether they want to overwrite them one by one.

If there are many skills, asking one by one and getting the answers one by one would not be ideal.

So, just like (#22), this update introduces options to `overwrite all` and `skip all`.

***
### Use `just-spinner` in places where the task takes some time to process (#31)

Finally, I've released the very [first version](https://github.com/kevin-lee/just-spinner/releases/tag/v0.1.0) of [just-spinner](https://github.com/kevin-lee/just-spinner), so `ai-skills` can now use it. 🎉🎂🍾

You can see the spinner in the `install` command and the `update` command.

***
### Add path to agent location (#33)

Add path to agent location

#### Old
For `install` interactive mode,
```
? Select target agent(s) ›
Tab to toggle, Enter to submit.
 ◯ Universal
 ◯ Claude
 ◯ Cursor
 ◯ Codex
 ◯ Gemini
 ◯ Windsurf
 ◯ Copilot
```
If `Universal` and `Claude` are selected, it shows
```
? Select install location ›
Tab to toggle, Enter to submit.
 ◯ project
 ◯ global
```

#### New (This Release)
```
? Select install location ›
Tab to toggle, Enter to submit.
 ◯ project (.agents, .claude)
 ◯ global  (~/.agents, ~/.claude)
```

#### For `list`,
For `list`, it's like this
Old:
```
  2020-hindsight-scala      (global, Claude)
```

New:
```
  2020-hindsight-scala      (global, Claude): ~/.claude/skills
```
***

### Add `agent` and `scope` selection for the `list` command (#35)

The old `list` command takes no parameters and displays all global and project skills.

It could be too much if a user wants to see the skill list for the current project or the global skills of one agent.

So this update introduces a way to specify the agents and the scope (`global`, `project` or both).

e.g.)

```bash
aiskills list --agent claude --global      # skills from ~/.claude/skills
aiskills list --agent universal --project  # skills from .agents/skills
aiskills list --agent claude               # skills from both ~/.claude/skills and .claude/skills

aiskills list --all-agents --global   # skills from all agents' global skills
aiskills list --all-agents --project  # skills from all agents' project skills
aiskills list --all-agents            # show everything for all agents in both project and global

# skills from both (~/.claude/skills, ~/.codex/skills, ~/.gemini/skills) and (.claude/skills, .codex/skills, .gemini/skills)
aiskills list --agent claude,codex,gemini
```

***
### `--agent` param in the `install` command should support multiple agents (#37)

Just like the `list` command, the `install` command now supports multiple agents via the `--agent` parameter like `--agent universal,claude,cursor`.

e.g.)
```bash
# skills for ~/.claude/skills, ~/.cursor/skills, ~/.codeium/windsurf/skills
aiskills install owner/repo --agent claude,cursor,windsurf --global

# skills for .agents/skills, .claude/skills
aiskills install owner/repo --agent universal,claude --project
```

***

## Bug Fixed
### The available skill list in `AGENTS.md` added during installation is not cleaned when the skills are removed by `remove` or `manage` (#29)

There are AI agents (and the universal one, i.e. `.agents`) that require the available skill list in the `AGENTS.md` file. So `ai-skills` add it when the skill is installed with the `install` command.

However, the added skills in the skill list in the `AGENTS.md` file are not cleaned up when the installed skills are removed by the `remove` command or the `manage` command.

This bug has been fixed in this release.


## Internal Housekeeping

* There should be only one project version source (#16)
