### PR TITLE
Close #43: Replace `--all-agents` with `--agent all` and `--to all`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -43,27 +43,22 @@ object Main {
           |  aiskills list --agent claude               # Both scopes, Claude only
           |  aiskills list --agent claude,cursor        # Both scopes, Claude + Cursor
           |  aiskills list --agent claude --project     # Project skills, Claude only
-          |  aiskills list --all-agents                 # Both scopes, all agents (no prompt)
-          |  aiskills list --all-agents --global        # Global skills, all agents
+          |  aiskills list --agent all                  # Both scopes, all agents (no prompt)
+          |  aiskills list --agent all --global         # Global skills, all agents
           |""".stripMargin,
       ) {
-        val project   = Opts.flag("project", "Show project skills only", short = "p").orFalse
-        val global    = Opts.flag("global", "Show global skills only", short = "g").orFalse
-        val agent     = Opts
+        val project = Opts.flag("project", "Show project skills only", short = "p").orFalse
+        val global  = Opts.flag("global", "Show global skills only", short = "g").orFalse
+        val agent   = Opts
           .option[String](
             "agent",
-            s"Filter by agent (comma-separated: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            s"Filter by agent (comma-separated or 'all': ${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             short = "a",
           )
           .orNone
-        val allAgents = Opts.flag("all-agents", "Show skills for all agents (skip agent prompt)").orFalse
-        (project, global, agent, allAgents).mapN { (p, g, a, all) =>
+        (project, global, agent).mapN { (p, g, a) =>
           if p && g then {
             System.err.println("Error: Cannot use both --project and --global. Omit both to show all.")
-            sys.exit(1)
-          } else ()
-          if a.isDefined && all then {
-            System.err.println("Error: Cannot use both --agent and --all-agents. Use one or the other.")
             sys.exit(1)
           } else ()
           val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
@@ -73,12 +68,12 @@ object Main {
                 System
                   .err
                   .println(
-                    s"Error: Invalid agent '$invalid'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                    s"Error: Invalid agent '$invalid'. Valid agents: all, ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
                   )
                 sys.exit(1)
             }
           }
-          ListCmd.listSkills(ListOptions(project = p, global = g, agent = parsedAgents, allAgents = all))
+          ListCmd.listSkills(ListOptions(project = p, global = g, agent = parsedAgents))
         }
       }
 
@@ -101,8 +96,8 @@ object Main {
           |  aiskills install owner/repo --agent claude,cursor      # Install into Claude + Cursor (project)
           |  aiskills install owner/repo --agent cursor             # Install into .cursor/skills (project)
           |  aiskills install owner/repo --agent claude --global    # Install globally (~/.claude/skills)
-          |  aiskills install owner/repo --all-agents               # Install into all agent directories
-          |  aiskills install owner/repo --all-agents --global      # Install globally for all agents
+          |  aiskills install owner/repo --agent all                # Install into all agent directories
+          |  aiskills install owner/repo --agent all --global       # Install globally for all agents
           |  aiskills install owner/repo -y                         # Skip interactive selection, install all
           |  aiskills install https://github.com/owner/repo.git     # Full HTTPS Git URL
           |  aiskills install git@github.com:owner/repo.git         # SSH Git URL (Useful for private repos)
@@ -110,22 +105,17 @@ object Main {
           |  aiskills install ~/my-skills/my-skill                  # Install from home-relative path
           |""".stripMargin,
       ) {
-        val source    = Opts.argument[String](metavar = "source")
-        val global    = Opts.flag("global", "Install globally (default: project install)", short = "g").orFalse
-        val agent     = Opts
+        val source = Opts.argument[String](metavar = "source")
+        val global = Opts.flag("global", "Install globally (default: project install)", short = "g").orFalse
+        val agent  = Opts
           .option[String](
             "agent",
-            s"Target agent (comma-separated: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             short = "a",
           )
           .orNone
-        val allAgents = Opts.flag("all-agents", "Install to all agent directories").orFalse
-        val yes       = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
-        (source, global, agent, allAgents, yes).mapN { (src, g, a, all, y) =>
-          if a.isDefined && all then {
-            System.err.println("Error: Cannot use both --agent and --all-agents. Use one or the other.")
-            sys.exit(1)
-          } else ()
+        val yes    = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
+        (source, global, agent, yes).mapN { (src, g, a, y) =>
           val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
             aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
               case Right(agents) => agents
@@ -133,12 +123,12 @@ object Main {
                 System
                   .err
                   .println(
-                    s"Error: Invalid agent '$invalid'. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                    s"Error: Invalid agent '$invalid'. Valid agents: all, ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
                   )
                 sys.exit(1)
             }
           }
-          Install.installSkill(src, InstallOptions(global = g, agent = parsedAgents, allAgents = all, yes = y))
+          Install.installSkill(src, InstallOptions(global = g, agent = parsedAgents, yes = y))
         }
       }
 
@@ -192,33 +182,47 @@ object Main {
             |
             |Copies skills from one agent's directory to another. Without
             |arguments, runs an interactive wizard to pick source/target agents.
-            |Use --from / --to for scripted usage, and --all-agents to broadcast
+            |Use --from / --to for scripted usage, and --to all to broadcast
             |to every other agent directory.
             |
             |Examples:
             |  aiskills sync                                         # Interactive wizard
             |  aiskills sync commit --from claude --to cursor        # Sync one skill
-            |  aiskills sync commit --from claude --all-agents       # Sync one skill to all agents
+            |  aiskills sync commit --from claude --to all           # Sync one skill to all agents
             |  aiskills sync --from claude --to cursor               # Sync all skills between two agents
-            |  aiskills sync --from claude --all-agents              # Sync all skills to all agents
+            |  aiskills sync --from claude --to all                  # Sync all skills to all agents
             |  aiskills sync commit --from universal --to copilot    # Sync from universal to Copilot
             |  aiskills sync commit --from claude --to cursor -y     # Skip confirmation prompts
             |""".stripMargin,
         ) {
           val skillName = Opts.argument[String](metavar = "skill-name").orNone
           val from      = Opts.option[String]("from", "Source agent").orNone
-          val to        = Opts.option[String]("to", "Target agent").orNone
-          val allAgents = Opts.flag("all-agents", "Sync to all other agent directories").orFalse
+          val to        = Opts
+            .option[String](
+              "to",
+              s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            )
+            .orNone
           val yes       = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
-          (skillName, from, to, allAgents, yes).mapN { (sn, f, t, all, y) =>
-            val fromAgent = f.flatMap(Agent.fromString)
-            val toAgent   = t.flatMap(Agent.fromString)
+          (skillName, from, to, yes).mapN { (sn, f, t, y) =>
+            val fromAgent                     = f.flatMap(Agent.fromString)
+            val parsedTo: Option[List[Agent]] = t.map { toStr =>
+              aiskills.core.utils.AgentNames.parseAgentNames(toStr) match {
+                case Right(agents) => agents
+                case Left(invalid) =>
+                  System
+                    .err
+                    .println(
+                      s"Error: Invalid agent '$invalid'. Valid agents: all, ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                    )
+                  sys.exit(1)
+              }
+            }
             Sync.syncSkills(
               SyncOptions(
                 skillName = sn,
                 from = fromAgent,
-                to = toAgent,
-                allAgents = all,
+                to = parsedTo,
                 yes = y,
               )
             )

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -66,15 +66,13 @@ object Install {
 
   /** Resolve agents and location from options, prompting interactively when not specified. */
   private def resolveAgentsAndLocation(options: InstallOptions): (List[Agent], Boolean) = {
-    if options.allAgents then (Agent.all, !options.global)
-    else
-      options.agent match {
-        case Some(agents) => (agents, !options.global)
-        case None =>
-          val agents    = promptForAgents()
-          val isProject = if options.global then false else promptForLocation(agents)
-          (agents, isProject)
-      }
+    options.agent match {
+      case Some(agents) => (agents, !options.global)
+      case None =>
+        val agents    = promptForAgents()
+        val isProject = if options.global then false else promptForLocation(agents)
+        (agents, isProject)
+    }
   }
 
   private def promptForAgents(): List[Agent] = {

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -10,7 +10,7 @@ object ListCmd {
 
   /** List installed skills, optionally filtered by scope and agent. */
   def listSkills(options: ListOptions): Unit = {
-    val hasAnyFlag = options.project || options.global || options.agent.isDefined || options.allAgents
+    val hasAnyFlag = options.project || options.global || options.agent.isDefined
     if hasAnyFlag then listWithFlags(options)
     else listInteractive()
   }
@@ -22,8 +22,7 @@ object ListCmd {
       else List(SkillLocation.Project, SkillLocation.Global)
 
     val agents: List[Agent] =
-      if options.allAgents then Agent.all
-      else options.agent.getOrElse(Agent.all)
+      options.agent.getOrElse(Agent.all)
 
     val skills = for {
       agent    <- agents
@@ -45,7 +44,7 @@ object ListCmd {
         s"  ${"aiskills install anthropics/skills".cyan}                   ${"# Project, universal (default)".dim}"
       )
       println(s"  ${"aiskills install owner/skill --agent claude".cyan}          ${"# Project, Claude".dim}")
-      println(s"  ${"aiskills install owner/skill --all-agents".cyan}            ${"# Project, all agents".dim}")
+      println(s"  ${"aiskills install owner/skill --agent all".cyan}              ${"# Project, all agents".dim}")
       println(s"  ${"aiskills install owner/skill --global".cyan}                ${"# Global".dim}")
     } else {
       promptForScope() match {

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -12,30 +12,20 @@ object Sync {
 
   /** Sync skills between agent directories. */
   def syncSkills(options: SyncOptions): Unit =
-    (options.from, options.to, options.skillName, options.allAgents) match {
+    (options.from, options.to, options.skillName) match {
       // Interactive mode: no flags provided
-      case (None, None, None, false) =>
+      case (None, None, None) =>
         interactiveSync(options.yes)
 
       // Specific skill, from/to specified
-      case (Some(from), Some(to), Some(name), false) =>
-        syncSingleSkill(name, from, to, options.yes)
-
-      // Specific skill, from specified, all agents
-      case (Some(from), None, Some(name), true) =>
-        val targets = Agent.all.filterNot(_ === from)
-        for target <- targets do {
+      case (Some(from), Some(targets), Some(name)) =>
+        for target <- targets.filterNot(_ === from) do {
           syncSingleSkill(name, from, target, options.yes)
         }
 
-      // All skills from one agent to another
-      case (Some(from), Some(to), None, false) =>
-        syncAllSkills(from, to, options.yes)
-
-      // All skills from one agent to all others
-      case (Some(from), None, None, true) =>
-        val targets = Agent.all.filterNot(_ === from)
-        for target <- targets do {
+      // All skills from one agent to target(s)
+      case (Some(from), Some(targets), None) =>
+        for target <- targets.filterNot(_ === from) do {
           syncAllSkills(from, target, options.yes)
         }
 
@@ -44,9 +34,9 @@ object Sync {
         System.err.println("Usage:")
         System.err.println("  aiskills sync                                            # Interactive")
         System.err.println("  aiskills sync <skill> --from <agent> --to <agent>        # One skill")
-        System.err.println("  aiskills sync <skill> --from <agent> --all-agents        # One skill to all")
+        System.err.println("  aiskills sync <skill> --from <agent> --to all            # One skill to all")
         System.err.println("  aiskills sync --from <agent> --to <agent>                # All skills")
-        System.err.println("  aiskills sync --from <agent> --all-agents                # All skills to all")
+        System.err.println("  aiskills sync --from <agent> --to all                    # All skills to all")
         sys.exit(1)
     }
 

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -78,7 +78,6 @@ final case class SkillLocationInfo(
 final case class InstallOptions(
   global: Boolean,
   agent: Option[List[Agent]],
-  allAgents: Boolean,
   yes: Boolean,
 )
 
@@ -90,7 +89,6 @@ final case class ListOptions(
   project: Boolean,
   global: Boolean,
   agent: Option[List[Agent]],
-  allAgents: Boolean,
 )
 
 final case class SkillMetadata(
@@ -183,8 +181,7 @@ final case class RemoveOptions(
 final case class SyncOptions(
   skillName: Option[String],
   from: Option[Agent],
-  to: Option[Agent],
-  allAgents: Boolean,
+  to: Option[List[Agent]],
   yes: Boolean,
 )
 


### PR DESCRIPTION
# Close #43: Replace `--all-agents` with `--agent all` and `--to all`

Consolidate the `--all-agents` boolean flag into the existing `--agent` option (or `--to` for the `sync` command) by treating `"all"` as a special value, matching the pattern already used by the `remove` command.

- Remove `--all-agents` flag from `list`, `install`, and `sync` commands
- `list` and `install`: use `--agent all` instead of `--all-agents`
- `sync`: use `--to all` instead of `--all-agents` (consistent with `--from`/`--to` vocabulary)
- Remove `allAgents: Boolean` field from `InstallOptions`, `ListOptions`, and `SyncOptions`
- Change `SyncOptions.to` from `Option[Agent]` to `Option[List[Agent]]` to support both single agent and "all agents" via `AgentNames.parseAgentNames`
- Remove mutual exclusivity checks (`Cannot use both --agent and --all-agents`) since `--agent all` handles both cases through a single option
- Update help text, examples, and error messages across all affected commands