### PR TITLE
Close #47: All commands for both `project` and `global` should require both `--global` and `--project` instead of both being missing in non-interactive mode

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -2,7 +2,7 @@ package aiskills.cli
 
 import cats.syntax.all.*
 import com.monovore.decline.*
-import aiskills.core.{Agent, InstallOptions, ListOptions, ReadOptions, RemoveOptions, SyncOptions}
+import aiskills.core.{Agent, InstallOptions, ListOptions, ReadOptions, RemoveOptions, SkillLocation, SyncOptions}
 import aiskills.cli.commands.*
 import aiskills.info.AiSkillsInfo
 
@@ -40,11 +40,11 @@ object Main {
           |  aiskills list                              # Interactive scope & agent selection
           |  aiskills list --project                    # Project skills, all agents
           |  aiskills list --global                     # Global skills, all agents
-          |  aiskills list --agent claude               # Both scopes, Claude only
-          |  aiskills list --agent claude,cursor        # Both scopes, Claude + Cursor
+          |  aiskills list --project --global           # Both scopes, all agents
           |  aiskills list --agent claude --project     # Project skills, Claude only
-          |  aiskills list --agent all                  # Both scopes, all agents (no prompt)
+          |  aiskills list --agent all --project        # Project skills, all agents (no prompt)
           |  aiskills list --agent all --global         # Global skills, all agents
+          |  aiskills list --agent all --project --global  # Both scopes, all agents
           |""".stripMargin,
       ) {
         val project = Opts.flag("project", "Show project skills only", short = "p").orFalse
@@ -57,10 +57,6 @@ object Main {
           )
           .orNone
         (project, global, agent).mapN { (p, g, a) =>
-          if p && g then {
-            System.err.println("Error: Cannot use both --project and --global. Omit both to show all.")
-            sys.exit(1)
-          } else ()
           val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
             aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
               case Right(agents) => agents
@@ -73,7 +69,19 @@ object Main {
                 sys.exit(1)
             }
           }
-          ListCmd.listSkills(ListOptions(project = p, global = g, agent = parsedAgents))
+
+          val locations: Set[SkillLocation] = Set.concat(
+            if p then Set(SkillLocation.Project) else Set.empty,
+            if g then Set(SkillLocation.Global) else Set.empty,
+          )
+          if parsedAgents.isDefined && locations.isEmpty then {
+            System.err.println("Error: Must specify --project and/or --global when using --agent.")
+            System.err.println()
+            System.err.println("  Example: aiskills list --agent claude --project")
+            sys.exit(1)
+          } else ()
+
+          ListCmd.listSkills(ListOptions(locations = locations, agent = parsedAgents))
         }
       }
 
@@ -87,35 +95,35 @@ object Main {
           |you choose the target agent(s) and location.
           |
           |Examples:
-          |  aiskills install anthropics/skills                     # Interactive agent & location selection
-          |  aiskills install anthropics/skills/skills/pdf          # Single skill by path (interactive)
-          |  aiskills install owner/repo/skills/skill-name          # Single skill by path (interactive)
-          |  aiskills install owner/repo --global                   # Install globally (interactive agent selection)
-          |  aiskills install owner/repo --agent universal          # Install into .agents/skills (project)
-          |  aiskills install owner/repo --agent claude             # Install into .claude/skills (project)
-          |  aiskills install owner/repo --agent claude,cursor      # Install into Claude + Cursor (project)
-          |  aiskills install owner/repo --agent cursor             # Install into .cursor/skills (project)
-          |  aiskills install owner/repo --agent claude --global    # Install globally (~/.claude/skills)
-          |  aiskills install owner/repo --agent all                # Install into all agent directories
-          |  aiskills install owner/repo --agent all --global       # Install globally for all agents
-          |  aiskills install owner/repo -y                         # Skip interactive selection, install all
-          |  aiskills install https://github.com/owner/repo.git     # Full HTTPS Git URL
-          |  aiskills install git@github.com:owner/repo.git         # SSH Git URL (Useful for private repos)
-          |  aiskills install ./local/skill-directory               # Install from a local directory
-          |  aiskills install ~/my-skills/my-skill                  # Install from home-relative path
+          |  aiskills install anthropics/skills                          # Interactive agent & location selection
+          |  aiskills install anthropics/skills/skills/pdf               # Single skill by path (interactive)
+          |  aiskills install owner/repo/skills/skill-name               # Single skill by path (interactive)
+          |  aiskills install owner/repo --agent claude --project        # Project, Claude
+          |  aiskills install owner/repo --agent claude --global         # Global, Claude (~/.claude/skills)
+          |  aiskills install owner/repo --agent claude --project --global  # Both scopes, Claude
+          |  aiskills install owner/repo --agent claude,cursor --project # Project, Claude + Cursor
+          |  aiskills install owner/repo --agent all --project           # Project, all agents
+          |  aiskills install owner/repo --agent all --global            # Global, all agents
+          |  aiskills install owner/repo --agent all --project --global  # Both scopes, all agents
+          |  aiskills install owner/repo -y                              # Skip interactive selection, install all
+          |  aiskills install https://github.com/owner/repo.git          # Full HTTPS Git URL
+          |  aiskills install git@github.com:owner/repo.git              # SSH Git URL (Useful for private repos)
+          |  aiskills install ./local/skill-directory                    # Install from a local directory
+          |  aiskills install ~/my-skills/my-skill                       # Install from home-relative path
           |""".stripMargin,
       ) {
-        val source = Opts.argument[String](metavar = "source")
-        val global = Opts.flag("global", "Install globally (default: project install)", short = "g").orFalse
-        val agent  = Opts
+        val source  = Opts.argument[String](metavar = "source")
+        val project = Opts.flag("project", "Install to project scope (current directory)", short = "p").orFalse
+        val global  = Opts.flag("global", "Install to global scope (home directory)", short = "g").orFalse
+        val agent   = Opts
           .option[String](
             "agent",
             s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             short = "a",
           )
           .orNone
-        val yes    = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
-        (source, global, agent, yes).mapN { (src, g, a, y) =>
+        val yes     = Opts.flag("yes", "Skip interactive selection, install all skills found", short = "y").orFalse
+        (source, project, global, agent, yes).mapN { (src, p, g, a, y) =>
           val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
             aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
               case Right(agents) => agents
@@ -128,7 +136,19 @@ object Main {
                 sys.exit(1)
             }
           }
-          Install.installSkill(src, InstallOptions(global = g, agent = parsedAgents, yes = y))
+
+          val locations: Set[SkillLocation] = Set.concat(
+            if p then Set(SkillLocation.Project) else Set.empty,
+            if g then Set(SkillLocation.Global) else Set.empty,
+          )
+          if parsedAgents.isDefined && locations.isEmpty then {
+            System.err.println("Error: Must specify --project and/or --global when using --agent.")
+            System.err.println()
+            System.err.println("  Example: aiskills install owner/repo --agent claude --project")
+            sys.exit(1)
+          } else ()
+
+          Install.installSkill(src, InstallOptions(locations = locations, agent = parsedAgents, yes = y))
         }
       }
 
@@ -274,7 +294,11 @@ object Main {
               } else ()
               Remove.removeInteractive()
             case Some(name) =>
-              if !p && !g then {
+              val locations: Set[SkillLocation] = Set.concat(
+                if p then Set(SkillLocation.Project) else Set.empty,
+                if g then Set(SkillLocation.Global) else Set.empty,
+              )
+              if locations.isEmpty then {
                 System.err.println("Error: Must specify --project and/or --global when removing by name.")
                 System.err.println()
                 System.err.println("  --project (-p)  Remove from project scope (current directory)")
@@ -295,6 +319,7 @@ object Main {
                 System.err.println("  Example: aiskills remove commit --project --agent claude")
                 sys.exit(1)
               } else ()
+
               val parsedAgents: List[Agent] = a
                 .map { agentStr =>
                   aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
@@ -309,7 +334,8 @@ object Main {
                   }
                 }
                 .getOrElse(Nil)
-              Remove.removeSkill(name, RemoveOptions(project = p, global = g, agent = parsedAgents.some))
+
+              Remove.removeSkill(name, RemoveOptions(locations = locations, agent = parsedAgents.some))
           }
         }
       }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -65,13 +65,13 @@ object Install {
     else f"${bytes / (1024.0 * 1024.0)}%.1fMB"
 
   /** Resolve agents and location from options, prompting interactively when not specified. */
-  private def resolveAgentsAndLocation(options: InstallOptions): (List[Agent], Boolean) = {
+  private def resolveAgentsAndLocation(options: InstallOptions): (List[Agent], Set[SkillLocation]) = {
     options.agent match {
-      case Some(agents) => (agents, !options.global)
+      case Some(agents) => (agents, options.locations)
       case None =>
         val agents    = promptForAgents()
-        val isProject = if options.global then false else promptForLocation(agents)
-        (agents, isProject)
+        val locations = if options.locations.nonEmpty then options.locations else promptForLocation(agents)
+        (agents, locations)
     }
   }
 
@@ -101,7 +101,7 @@ object Install {
     }
   }
 
-  private def promptForLocation(agents: List[Agent]): Boolean = {
+  private def promptForLocation(agents: List[Agent]): Set[SkillLocation] = {
     val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
     val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
     val locationLabels = List(
@@ -113,11 +113,15 @@ object Install {
     val result = Prompts.sync.use { prompts =>
       prompts.multiChoiceNoneSelected("Select install location", locationLabels) match {
         case Completion.Finished(selectedLabels) =>
-          selectedLabels.headOption match {
-            case Some(label) => Right(label.startsWith("project"))
-            case None =>
-              println("No location selected. Defaulting to project.".yellow)
-              Right(true)
+          if selectedLabels.isEmpty then {
+            println("No location selected. Defaulting to project.".yellow)
+            Right(Set(SkillLocation.Project))
+          } else {
+            val locs = selectedLabels.foldLeft(Set.empty[SkillLocation]) { (acc, label) =>
+              if label.startsWith("project") then acc + SkillLocation.Project
+              else acc + SkillLocation.Global
+            }
+            Right(locs)
           }
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
@@ -129,7 +133,7 @@ object Install {
     }
     result match {
       case Left(code) => throw SkillInstallException(code) // scalafix:ok DisableSyntax.throw
-      case Right(isProject) => isProject
+      case Right(locations) => locations
     }
   }
 
@@ -138,29 +142,34 @@ object Install {
     aiskills.cli.TempDirCleanup.ensureAtexitRegistered()
 
     // Resolve agents and location (interactive if not specified) before cloning
-    val (agents, isProject) = resolveAgentsAndLocation(options)
+    val (agents, locations) = resolveAgentsAndLocation(options)
 
     // Resolve source once
     val resolvedSource = resolveSource(source)
 
     try {
-      for agent <- agents do {
+      for {
+        agent    <- agents
+        location <- locations
+      } do {
+        val isProject    = location === SkillLocation.Project
         val folder       = s"${agent.projectDirName}/skills"
         val globalFolder = s"${agent.globalDirName}/skills"
         val targetDir    =
           if isProject then os.pwd / os.RelPath(folder)
           else os.home / os.RelPath(globalFolder)
 
-        val location =
+        val locationDisplay =
           if isProject then s"project ($folder)".blue
           else s"global (~/$globalFolder)".dim
 
-        if agents.length > 1 then println(s"\n--- ${agent.toString} ---".bold)
+        if agents.length > 1 || locations.size > 1
+        then println(s"\n--- ${agent.toString} (${location.toString.toLowerCase}) ---".bold)
         else ()
 
         println(s"Installing from: ${source.cyan}")
-        println(s"Location: $location")
-        if agents.length <= 1 then {
+        println(s"Location: $locationDisplay")
+        if agents.length <= 1 && locations.size <= 1 then {
           if !isProject then println(s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim)
           else ()
         } else ()
@@ -185,13 +194,10 @@ object Install {
             }
         }
 
-        AgentsMd.updateAgentsMdForAgent(
-          agent,
-          if options.global then SkillLocation.Global else SkillLocation.Project,
-        )
+        AgentsMd.updateAgentsMdForAgent(agent, location)
       }
 
-      printPostInstallHints(isProject)
+      printPostInstallHints(locations)
     } finally {
       resolvedSource.cleanup()
     }
@@ -287,9 +293,9 @@ object Install {
     }
   }
 
-  private def printPostInstallHints(isProject: Boolean): Unit = {
+  private def printPostInstallHints(locations: Set[SkillLocation]): Unit = {
     println(s"\n${"Read skill:".dim} ${"aiskills read <skill-name>".cyan}")
-    if isProject then println(
+    if locations.contains(SkillLocation.Project) then println(
       s"${"Sync to other agents:".dim} ${"aiskills sync <skill-name> --from <agent> --to <agent>".cyan}"
     )
     else ()

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -10,16 +10,13 @@ object ListCmd {
 
   /** List installed skills, optionally filtered by scope and agent. */
   def listSkills(options: ListOptions): Unit = {
-    val hasAnyFlag = options.project || options.global || options.agent.isDefined
+    val hasAnyFlag = options.locations.nonEmpty || options.agent.isDefined
     if hasAnyFlag then listWithFlags(options)
     else listInteractive()
   }
 
   private def listWithFlags(options: ListOptions): Unit = {
-    val locations: List[SkillLocation] =
-      if options.project then List(SkillLocation.Project)
-      else if options.global then List(SkillLocation.Global)
-      else List(SkillLocation.Project, SkillLocation.Global)
+    val locations: List[SkillLocation] = options.locations.toList
 
     val agents: List[Agent] =
       options.agent.getOrElse(Agent.all)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -67,11 +67,7 @@ object Remove {
 
   /** Remove a specific skill by name from the specified agent(s) and location(s). */
   def removeSkill(skillName: String, options: RemoveOptions): Unit = {
-    val locations: List[SkillLocation] =
-      List.concat(
-        if options.project then List(SkillLocation.Project) else Nil,
-        if options.global then List(SkillLocation.Global) else Nil,
-      )
+    val locations: List[SkillLocation] = options.locations.toList
 
     val agents = options.agent.getOrElse(Nil)
 

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -76,7 +76,7 @@ final case class SkillLocationInfo(
 )
 
 final case class InstallOptions(
-  global: Boolean,
+  locations: Set[SkillLocation],
   agent: Option[List[Agent]],
   yes: Boolean,
 )
@@ -86,8 +86,7 @@ final case class ReadOptions(
 )
 
 final case class ListOptions(
-  project: Boolean,
-  global: Boolean,
+  locations: Set[SkillLocation],
   agent: Option[List[Agent]],
 )
 
@@ -173,8 +172,7 @@ object AiSkillsError {
 }
 
 final case class RemoveOptions(
-  project: Boolean,
-  global: Boolean,
+  locations: Set[SkillLocation],
   agent: Option[List[Agent]],
 )
 


### PR DESCRIPTION
# Close #47: All commands for both `project` and `global` should require both `--global` and `--project` instead of both being missing in non-interactive mode

Replace Boolean `project`/`global` flags with `Set[SkillLocation]` and add `--project` to `install` command

- Replace `project: Boolean` / `global: Boolean` fields in `InstallOptions`, `ListOptions`, and `RemoveOptions` with a single `locations: Set[SkillLocation]` field, eliminating impossible states and redundant boolean logic.
- Add `--project` (`-p`) flag to the `install` command, which previously only had `--global`. All three commands (`list`, `install`, `remove`) now require explicit `--project` and/or `--global` when `--agent` is used in non-interactive mode, showing an error if neither scope flag is provided.
- Remove the mutual exclusion error from `list` that previously rejected `--project --global` together. Both flags can now be used simultaneously (consistent with `remove`).
- Update `Install.scala` to loop over `agents × locations` instead of using a single `isProject` boolean, enabling installation to both project and global scopes in one invocation.
- Fix `promptForLocation` in `Install.scala` to properly handle multi-selection (previously only read `headOption`, ignoring additional selections).
- Update help text examples for `list` and `install` to reflect the new flag requirements and combinations.