### PR TITLE
Close #49: Improve read command with interactive mode and more non-interactive mode parameters

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -156,22 +156,98 @@ object Main {
         "read",
         """Read skill(s) to stdout (for AI agents)
           |
-          |Outputs the SKILL.md content for one or more skills. Searches
-          |project-local directories first, then global. When a skill exists
-          |in multiple agent directories, use --prefer to select a specific one.
+          |Without arguments, opens an interactive prompt to select scope,
+          |agents, and skills. With skill names, reads from the specified
+          |agent(s) and location(s).
           |
-          |Examples:
-          |  aiskills read commit                         # Read one skill
-          |  aiskills read commit review-pr               # Read multiple skills
-          |  aiskills read commit --prefer claude         # Prefer Claude's version
-          |  aiskills read commit --prefer cursor         # Prefer Cursor's version
+          |Interactive mode:
+          |  aiskills read                                              # Interactive scope, agent & skill selection
+          |
+          |Non-interactive mode (--project/--global and --agent are required):
+          |  aiskills read commit --agent claude --project              # Project, Claude
+          |  aiskills read commit --agent claude --global               # Global, Claude
+          |  aiskills read commit --agent claude --project --global     # Both scopes, Claude
+          |  aiskills read commit --agent claude,cursor --project       # Project, Claude + Cursor
+          |  aiskills read commit --agent all --project                 # Project, all agents
+          |  aiskills read commit --agent all --project --global        # Both scopes, all agents
           |""".stripMargin,
       ) {
-        val names  = Opts.arguments[String](metavar = "skill-names")
-        val prefer = Opts.option[String]("prefer", "Prefer skills from this agent's directory").orNone
-        (names, prefer).mapN { (ns, p) =>
-          val preferAgent = p.flatMap(Agent.fromString)
-          Read.readSkill(ns.toList, ReadOptions(prefer = preferAgent))
+        val names   = Opts.arguments[String](metavar = "skill-names").orEmpty
+        val project = Opts.flag("project", "Read from project scope", short = "p").orFalse
+        val global  = Opts.flag("global", "Read from global scope", short = "g").orFalse
+        val agent   = Opts
+          .option[String](
+            "agent",
+            s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
+            short = "a",
+          )
+          .orNone
+        (names, project, global, agent).mapN { (ns, p, g, a) =>
+          val parsedAgents: Option[List[Agent]] = a.map { agentStr =>
+            aiskills.core.utils.AgentNames.parseAgentNames(agentStr) match {
+              case Right(agents) => agents
+              case Left(invalid) =>
+                System
+                  .err
+                  .println(
+                    s"Error: Invalid agent '$invalid'. Valid agents: all, ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                  )
+                sys.exit(1)
+            }
+          }
+
+          val locations: Set[SkillLocation] = Set.concat(
+            if p then Set(SkillLocation.Project) else Set.empty,
+            if g then Set(SkillLocation.Global) else Set.empty,
+          )
+
+          val hasAnyFlag = locations.nonEmpty || parsedAgents.isDefined
+
+          if ns.isEmpty then {
+            if hasAnyFlag then {
+              System.err.println("Error: Must specify skill name(s) when using --project, --global, or --agent.")
+              System.err.println()
+              System.err.println("  Example: aiskills read commit --agent claude --project")
+              System.err.println()
+              System.err.println("For interactive reading, run without any flags:")
+              System.err.println("  aiskills read")
+              sys.exit(1)
+            } else ()
+            Read.readInteractive()
+          } else {
+            if !hasAnyFlag then {
+              System.err.println("Error: Must specify --project/--global and --agent when reading by name.")
+              System.err.println()
+              System.err.println("  --project (-p)  Read from project scope (current directory)")
+              System.err.println("  --global  (-g)  Read from global scope (home directory)")
+              System
+                .err
+                .println(
+                  s"  --agent (-a)    Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})"
+                )
+              System.err.println()
+              System.err.println("  Example: aiskills read commit --agent claude --project")
+              sys.exit(1)
+            } else if parsedAgents.isDefined && locations.isEmpty then {
+              System.err.println("Error: Must specify --project and/or --global when using --agent.")
+              System.err.println()
+              System.err.println("  Example: aiskills read commit --agent claude --project")
+              sys.exit(1)
+            } else if parsedAgents.isEmpty && locations.nonEmpty then {
+              System.err.println("Error: Must specify --agent when using --project/--global.")
+              System.err.println()
+              System
+                .err
+                .println(
+                  s"  --agent (-a)  Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})"
+                )
+              System.err.println()
+              System.err.println("  Example: aiskills read commit --agent claude --project")
+              sys.exit(1)
+            } else ()
+
+            Read.readSkill(ns, ReadOptions(locations = locations, agent = parsedAgents))
+          }
         }
       }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -1,27 +1,44 @@
 package aiskills.cli.commands
 
-import aiskills.core.ReadOptions
-import aiskills.core.given
+import aiskills.core.{Agent, ReadOptions, Skill, SkillLocation, SkillLocationInfo}
 import aiskills.core.utils.{Dirs, SkillNames, Skills}
 import cats.syntax.all.*
+import extras.scala.io.syntax.color.*
+import cue4s.*
 
 object Read {
 
-  /** Read skill(s) to stdout (for AI agents). */
+  private val separator = ">" * 80
+
+  /** Read skill(s) to stdout — non-interactive mode (with flags). */
   def readSkill(skillNames: List[String], options: ReadOptions): Unit = {
     val names = SkillNames.normalizeSkillNames(skillNames)
     if names.isEmpty then {
       System.err.println("Error: No skill names provided")
       sys.exit(1)
     } else {
-      val resolved = List.newBuilder[(String, aiskills.core.SkillLocationInfo)]
+      val locations = options.locations.toList
+      val agents    = options.agent.getOrElse(Nil)
+
+      val resolved = List.newBuilder[(String, SkillLocationInfo)]
       val missing  = List.newBuilder[String]
 
       for name <- names do {
-        Skills.findSkill(name, options.prefer) match {
-          case Some(skill) => resolved += ((name, skill))
-          case None => missing += name
-        }
+        val found = (for {
+          agent    <- agents
+          location <- locations
+          skillPath = Dirs.getSkillsDir(agent, location) / name / "SKILL.md"
+          if os.exists(skillPath)
+        } yield SkillLocationInfo(
+          path = skillPath,
+          baseDir = skillPath / os.up,
+          source = skillPath / os.up / os.up,
+          agent = agent,
+          location = location,
+        )).toList
+
+        if found.isEmpty then missing += name
+        else found.foreach(skill => resolved += ((name, skill)))
       }
 
       val missingList = missing.result()
@@ -29,7 +46,11 @@ object Read {
         System.err.println(s"Error: Skill(s) not found: ${missingList.mkString(", ")}")
         System.err.println()
         System.err.println("Searched:")
-        for (dir, agent, location) <- Dirs.getSearchDirs() do {
+        for {
+          agent    <- agents
+          location <- locations
+        } do {
+          val dir   = Dirs.getSkillsDir(agent, location)
           val scope = location.toString.toLowerCase
           val label =
             if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
@@ -41,7 +62,9 @@ object Read {
         sys.exit(1)
       } else ()
 
-      for (name, skill) <- resolved.result() do {
+      val resolvedList = resolved.result()
+      for ((name, skill), idx) <- resolvedList.zipWithIndex do {
+        if idx > 0 then println(separator)
         val content = os.read(skill.path)
         println(s"Reading: $name")
         println(s"Base directory: ${skill.baseDir}")
@@ -49,24 +72,139 @@ object Read {
         println(content)
         println()
         println(s"Skill read: $name")
+      }
+    }
+  }
 
-        // Note alternatives on stderr
-        val allLocations = Skills.findAllSkillLocations(name)
-        if allLocations.length > 1 then {
-          val otherDirs = allLocations
-            .filterNot(_._1 === skill.source)
-            .map {
-              case (dir, agent, _) =>
-                val label =
-                  if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
-                  else dir.relativeTo(os.pwd).toString
-                s"$label/ (${agent.toString.toLowerCase})"
+  /** Interactive mode: prompt for location -> agents -> skills -> read selected. */
+  def readInteractive(): Unit = {
+    val allSkills = Skills.findAllSkills()
+
+    if allSkills.isEmpty then {
+      println("No skills installed.\n")
+      println("Install skills:")
+      println(s"  ${"aiskills install anthropics/skills".cyan}   ${"# Install from GitHub".dim}")
+    } else {
+      promptForScope() match {
+        case Left(code) => sys.exit(code)
+        case Right(locations) =>
+          val skillsInScope = allSkills.filter(s => locations.contains(s.location))
+
+          if skillsInScope.isEmpty then {
+            val scopeLabel = locations.map(_.toString.toLowerCase).mkString(" and ")
+            println(s"No skills found in $scopeLabel scope.".yellow)
+          } else {
+            val agentsWithCounts = Agent
+              .all
+              .flatMap { agent =>
+                val count = skillsInScope.count(_.agent === agent)
+                if count > 0 then (agent, count).some else none
+              }
+
+            promptForAgents(agentsWithCounts) match {
+              case Left(code) => sys.exit(code)
+              case Right(selectedAgents) =>
+                if selectedAgents.isEmpty then println("No agents selected.".yellow)
+                else {
+                  val filtered = skillsInScope.filter(s => selectedAgents.contains(s.agent))
+                  if filtered.isEmpty then println("No skills found for the selected agents.".yellow)
+                  else {
+                    promptForSkills(filtered) match {
+                      case Left(code) => sys.exit(code)
+                      case Right(selectedSkills) =>
+                        if selectedSkills.isEmpty then println("No skills selected.".yellow)
+                        else {
+                          for (skill, idx) <- selectedSkills.zipWithIndex do {
+                            if idx > 0 then println(separator)
+                            val skillPath = skill.path / "SKILL.md"
+                            val content   = os.read(skillPath)
+                            println(s"Reading: ${skill.name}")
+                            println(s"Base directory: ${skill.path}")
+                            println()
+                            println(content)
+                            println()
+                            println(s"Skill read: ${skill.name}")
+                          }
+                        }
+                    }
+                  }
+                }
             }
-          if otherDirs.nonEmpty then System
-            .err
-            .println(s"Note: '$name' also found in: ${otherDirs.mkString(", ")} (use --prefer <agent>)")
-          else ()
-        } else ()
+          }
+      }
+    }
+  }
+
+  private def promptForScope(): Either[Int, List[SkillLocation]] = {
+    val options = List("project", "global", "both")
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("Select scope", options) match {
+        case Completion.Finished(selected) =>
+          selected match {
+            case "project" => List(SkillLocation.Project).asRight
+            case "global" => List(SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+          }
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+    val labels = agentsWithCounts.map { (agent, count) =>
+      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+    }
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select agent(s)", labels) match {
+        case Completion.Finished(selectedLabels) =>
+          val selected = agentsWithCounts
+            .filter { (agent, _) =>
+              selectedLabels.exists(_.contains(agent.toString))
+            }
+            .map(_._1)
+          selected.asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForSkills(skills: List[Skill]): Either[Int, List[Skill]] = {
+    val sorted = skills.sortBy { s =>
+      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
+    }
+
+    val labels = sorted.map { skill =>
+      val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+      val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
+      s"${skill.name.padTo(25, ' ')} $locationLabel"
+    }
+
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select skill(s) to read", labels) match {
+        case Completion.Finished(selectedLabels) =>
+          val selectedIndices = selectedLabels.flatMap { label =>
+            labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
+          }
+          selectedIndices.map(sorted(_)).asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
       }
     }
   }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -82,7 +82,8 @@ final case class InstallOptions(
 )
 
 final case class ReadOptions(
-  prefer: Option[Agent],
+  locations: Set[SkillLocation],
+  agent: Option[List[Agent]],
 )
 
 final case class ListOptions(

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -1,7 +1,6 @@
 package aiskills.core.utils
 
 import aiskills.core.{Agent, SkillLocation}
-import cats.syntax.all.*
 
 object Dirs {
 
@@ -46,13 +45,4 @@ object Dirs {
     projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific
   }
 
-  /** Get search dirs with a preferred agent's directories bumped to the front. */
-  def getSearchDirs(prefer: Option[Agent]): List[(os.Path, Agent, SkillLocation)] =
-    prefer match {
-      case None => getSearchDirs()
-      case Some(preferred) =>
-        val all                   = getSearchDirs()
-        val (preferredDirs, rest) = all.partition(_._2 === preferred)
-        preferredDirs ++ rest
-    }
 }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
@@ -39,12 +39,8 @@ object Skills {
   }
 
   /** Find a specific skill by name. Returns the first match in priority order. */
-  def findSkill(skillName: String): Option[SkillLocationInfo] =
-    findSkill(skillName, prefer = none[Agent])
-
-  /** Find a specific skill by name with optional agent preference. */
-  def findSkill(skillName: String, prefer: Option[Agent]): Option[SkillLocationInfo] = {
-    val dirs = Dirs.getSearchDirs(prefer)
+  def findSkill(skillName: String): Option[SkillLocationInfo] = {
+    val dirs = Dirs.getSearchDirs()
     dirs
       .iterator
       .map { case (dir, agent, location) => (dir / skillName / "SKILL.md", agent, location) }
@@ -60,13 +56,6 @@ object Skills {
           )
       }
   }
-
-  /** Find all locations where a skill with the given name exists. */
-  def findAllSkillLocations(skillName: String): List[(os.Path, Agent, SkillLocation)] =
-    Dirs.getSearchDirs().filter {
-      case (dir, _, _) =>
-        os.exists(dir / skillName / "SKILL.md")
-    }
 
   /** Find all skills installed for a specific agent. */
   def findSkillsByAgent(agent: Agent, location: SkillLocation): List[Skill] = {

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -30,8 +30,6 @@ object DirsSpec extends Properties {
     example("getSearchDirs: returns 14 dirs", testSearchDirsCount),
     example("getSearchDirs: correct priority order", testSearchDirsOrder),
     example("getSearchDirs: first is project universal", testSearchDirsFirst),
-    example("getSearchDirs: prefer reorders correctly", testSearchDirsPrefer),
-    example("getSearchDirs: prefer None returns default", testSearchDirsPreferNone),
   )
 
   private def testProjectUniversal: Result =
@@ -142,22 +140,4 @@ object DirsSpec extends Properties {
     )
   }
 
-  private def testSearchDirsPrefer: Result = {
-    val dirs                       = Dirs.getSearchDirs(Agent.Cursor.some)
-    // Cursor dirs should be first
-    val (firstPath, firstAgent, _) = dirs.head
-    Result.all(
-      List(
-        firstAgent ==== Agent.Cursor,
-        // Should still have 14 dirs
-        dirs.length ==== 14,
-      )
-    )
-  }
-
-  private def testSearchDirsPreferNone: Result = {
-    val defaultDirs    = Dirs.getSearchDirs()
-    val preferNoneDirs = Dirs.getSearchDirs(none[Agent])
-    defaultDirs ==== preferNoneDirs
-  }
 }


### PR DESCRIPTION
# Close #49: Improve read command with interactive mode and more non-interactive mode parameters

Replace `--prefer` with `--agent`/`--project`/`--global` in read command and add interactive mode

- Replace `ReadOptions.prefer: Option[Agent]` with locations: `Set[SkillLocation]` and agent: `Option[List[Agent]]` to match the pattern used by other commands
- Non-interactive mode now requires `--agent` with `--project`/`--global` (and vice versa) to explicitly target specific agent×location directories, instead of the old `--prefer` which only reordered the search but still searched everywhere
- Skill names without any flags now produce an error with usage help
- When a skill exists in multiple specified directories (e.g. both `--project` and `--global`), all matches are returned instead of just the first
- Add interactive mode (`aiskills read` with no arguments): 3-step prompt flow selecting scope (`project`/`global`/both), agents, then skills
- Add ">>" separator line between multiple skill outputs in both modes
- Remove `Dirs.getSearchDirs(prefer)`, `Skills.findSkill(name, prefer)`, and `Skills.findAllSkillLocations` which were only used by the old read command
- Remove prefer-related tests from `DirsSpec`