### PR TITLE
Close #51: Add `--project`/`--global` and `--from <location>:<agent>` to `sync` non-interactive mode

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -278,31 +278,70 @@ object Main {
             |
             |Copies skills from one agent's directory to another. Without
             |arguments, runs an interactive wizard to pick source/target agents.
-            |Use --from / --to for scripted usage, and --to all to broadcast
-            |to every other agent directory.
+            |Use --from / --to / --project / --global for scripted usage.
             |
             |Examples:
-            |  aiskills sync                                         # Interactive wizard
-            |  aiskills sync commit --from claude --to cursor        # Sync one skill
-            |  aiskills sync commit --from claude --to all           # Sync one skill to all agents
-            |  aiskills sync --from claude --to cursor               # Sync all skills between two agents
-            |  aiskills sync --from claude --to all                  # Sync all skills to all agents
-            |  aiskills sync commit --from universal --to copilot    # Sync from universal to Copilot
-            |  aiskills sync commit --from claude --to cursor -y     # Skip confirmation prompts
+            |  aiskills sync                                                              # Interactive wizard
+            |  aiskills sync --from project:claude --to cursor --project                  # All skills, project -> project
+            |  aiskills sync --from global:claude --to cursor,windsurf --global           # All skills, global -> global
+            |  aiskills sync --from project:claude --to all --project --global            # All skills, project -> both
+            |  aiskills sync commit --from global:claude --to cursor --project --global   # One skill, global -> both
+            |  aiskills sync --from project:universal --to copilot --global -y            # Skip confirmation prompts
             |""".stripMargin,
         ) {
           val skillName = Opts.argument[String](metavar = "skill-name").orNone
-          val from      = Opts.option[String]("from", "Source agent").orNone
+          val from      = Opts
+            .option[String]("from", "Source location and agent (format: <project|global>:<agent>)")
+            .orNone
           val to        = Opts
             .option[String](
               "to",
               s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             )
             .orNone
+          val project   = Opts.flag("project", "Sync to project scope (current directory)", short = "p").orFalse
+          val global    = Opts.flag("global", "Sync to global scope (home directory)", short = "g").orFalse
           val yes       = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
-          (skillName, from, to, yes).mapN { (sn, f, t, y) =>
-            val fromAgent                     = f.flatMap(Agent.fromString)
-            val parsedTo: Option[List[Agent]] = t.map { toStr =>
+          (skillName, from, to, project, global, yes).mapN { (sn, f, t, p, g, y) =>
+            val parsedFrom: Option[(SkillLocation, Agent)] = f.map { fromStr =>
+              fromStr.split(":", 2) match {
+                case Array(locStr, agentStr) =>
+                  val location = locStr.toLowerCase match {
+                    case "project" => SkillLocation.Project
+                    case "global" => SkillLocation.Global
+                    case other =>
+                      System.err.println(s"Error: Invalid source location '$other' in --from value.")
+                      System.err.println()
+                      System.err.println("  --from must be in the format <location>:<agent>")
+                      System.err.println("  where <location> is 'project' or 'global'.")
+                      System.err.println()
+                      System.err.println("  Examples:")
+                      System.err.println("    --from project:claude")
+                      System.err.println("    --from global:universal")
+                      sys.exit(1)
+                  }
+                  val agent    = Agent.fromString(agentStr).getOrElse {
+                    System
+                      .err
+                      .println(
+                        s"Error: Invalid agent '$agentStr' in --from value. Valid agents: ${Agent.all.map(_.toString.toLowerCase).mkString(", ")}"
+                      )
+                    sys.exit(1)
+                  }
+                  (location, agent)
+                case _ =>
+                  System.err.println(s"Error: Invalid --from format '$fromStr'.")
+                  System.err.println()
+                  System.err.println("  --from must be in the format <location>:<agent>")
+                  System.err.println("  where <location> is 'project' or 'global'.")
+                  System.err.println()
+                  System.err.println("  Examples:")
+                  System.err.println("    --from project:claude")
+                  System.err.println("    --from global:universal")
+                  sys.exit(1)
+              }
+            }
+            val parsedTo: Option[List[Agent]]              = t.map { toStr =>
               aiskills.core.utils.AgentNames.parseAgentNames(toStr) match {
                 case Right(agents) => agents
                 case Left(invalid) =>
@@ -314,11 +353,27 @@ object Main {
                   sys.exit(1)
               }
             }
+
+            val locations: Set[SkillLocation] = Set.concat(
+              if p then Set(SkillLocation.Project) else Set.empty,
+              if g then Set(SkillLocation.Global) else Set.empty,
+            )
+            if parsedFrom.isDefined && parsedTo.isDefined && locations.isEmpty then {
+              System.err.println("Error: Must specify --project and/or --global when using --from/--to.")
+              System.err.println()
+              System.err.println("  --project (-p)  Sync to project scope (current directory)")
+              System.err.println("  --global  (-g)  Sync to global scope (home directory)")
+              System.err.println()
+              System.err.println("  Example: aiskills sync --from project:claude --to cursor --project")
+              sys.exit(1)
+            } else ()
+
             Sync.syncSkills(
               SyncOptions(
                 skillName = sn,
-                from = fromAgent,
+                from = parsedFrom,
                 to = parsedTo,
+                targetLocations = locations,
                 yes = y,
               )
             )

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -18,161 +18,122 @@ object Sync {
         interactiveSync(options.yes)
 
       // Specific skill, from/to specified
-      case (Some(from), Some(targets), Some(name)) =>
+      case (Some((sourceLocation, from)), Some(targets), Some(name)) =>
+        val targetLocations = options.targetLocations.toList
         for target <- targets.filterNot(_ === from) do {
-          syncSingleSkill(name, from, target, options.yes)
+          syncSingleSkillWithLocations(name, from, target, sourceLocation, targetLocations, options.yes)
         }
 
       // All skills from one agent to target(s)
-      case (Some(from), Some(targets), None) =>
+      case (Some((sourceLocation, from)), Some(targets), None) =>
+        val targetLocations = options.targetLocations.toList
         for target <- targets.filterNot(_ === from) do {
-          syncAllSkills(from, target, options.yes)
+          syncAllSkillsWithLocations(from, target, sourceLocation, targetLocations, options.yes)
         }
 
       case _ =>
         System.err.println("Error: Invalid flag combination.".red)
         System.err.println("Usage:")
-        System.err.println("  aiskills sync                                            # Interactive")
-        System.err.println("  aiskills sync <skill> --from <agent> --to <agent>        # One skill")
-        System.err.println("  aiskills sync <skill> --from <agent> --to all            # One skill to all")
-        System.err.println("  aiskills sync --from <agent> --to <agent>                # All skills")
-        System.err.println("  aiskills sync --from <agent> --to all                    # All skills to all")
+        System.err.println("")
+        System.err.println("  <location> should be either 'project' or 'global'")
+        System.err.println("")
+        System
+          .err
+          .println(
+            "  aiskills sync                                                             # Interactive"
+          )
+        System
+          .err
+          .println(
+            "  aiskills sync <skill> --from <location>:<agent> --to <agent> --project    # One skill"
+          )
+        System
+          .err
+          .println(
+            "  aiskills sync <skill> --from <location>:<agent> --to all --global         # One skill to all"
+          )
+        System
+          .err
+          .println(
+            "  aiskills sync --from <location>:<agent> --to <agent> --project            # All skills"
+          )
+        System
+          .err
+          .println(
+            "  aiskills sync --from <location>:<agent> --to all --project --global       # All skills to all"
+          )
         sys.exit(1)
     }
 
-  private def syncSingleSkill(name: String, from: Agent, to: Agent, yes: Boolean): Unit = {
+  private def syncSingleSkillWithLocations(
+    name: String,
+    from: Agent,
+    to: Agent,
+    sourceLocation: SkillLocation,
+    targetLocations: List[SkillLocation],
+    yes: Boolean,
+  ): Unit = {
     if from === to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
     else {
-      // Try project first, then global
-      val sourceSkills =
-        Skills.findSkillsByAgent(from, SkillLocation.Project) ++ Skills.findSkillsByAgent(from, SkillLocation.Global)
+      val sourceSkills = Skills.findSkillsByAgent(from, sourceLocation)
       val skill        = sourceSkills.find(_.name === name)
 
       skill match {
         case None =>
-          System.err.println(s"Error: Skill '$name' not found in ${from.toString} directories".red)
+          System
+            .err
+            .println(
+              s"Error: Skill '$name' not found in ${from.toString} (${sourceLocation.toString.toLowerCase})".red
+            )
           sys.exit(1)
 
         case Some(s) =>
-          val targetDir  = Dirs.getSkillsDir(to, s.location)
-          val targetPath = targetDir / name
+          for targetLocation <- targetLocations do {
+            val targetDir  = Dirs.getSkillsDir(to, targetLocation)
+            val targetPath = targetDir / name
 
-          val proceed =
-            if os.exists(targetPath) && !yes then {
-              aiskills.cli.SigintHandler.install()
-              val result = Prompts.sync.use { prompts =>
-                println(
-                  s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
-                )
-                val pathLabel = Dirs.displaySkillsDir(to, s.location)
-                prompts.confirm(
-                  s"Skill '$name' already exists in ${to.toString} (${s.location.toString.toLowerCase}): $pathLabel. Overwrite?".yellow,
-                  default = false,
-                ) match {
-                  case Completion.Finished(v) =>
-                    if v then os.remove.all(targetPath) else ()
-                    Right(v)
-                  case Completion.Fail(CompletionError.Interrupted) =>
-                    println("\n\nCancelled by user".yellow)
-                    Left(0)
-                  case Completion.Fail(CompletionError.Error(_)) => Right(false)
+            val proceed =
+              if os.exists(targetPath) && !yes then {
+                aiskills.cli.SigintHandler.install()
+                val result = Prompts.sync.use { prompts =>
+                  println(
+                    s"\u26a0 All existing files and folders in '$name' will be removed if you choose to overwrite.".yellow
+                  )
+                  val pathLabel = Dirs.displaySkillsDir(to, targetLocation)
+                  prompts.confirm(
+                    s"Skill '$name' already exists in ${to.toString} (${targetLocation.toString.toLowerCase}): $pathLabel. Overwrite?".yellow,
+                    default = false,
+                  ) match {
+                    case Completion.Finished(v) =>
+                      if v then os.remove.all(targetPath) else ()
+                      Right(v)
+                    case Completion.Fail(CompletionError.Interrupted) =>
+                      println("\n\nCancelled by user".yellow)
+                      Left(0)
+                    case Completion.Fail(CompletionError.Error(_)) => Right(false)
+                  }
                 }
-              }
-              result match {
-                case Left(code) => sys.exit(code)
-                case Right(v) => v
-              }
-            } else if os.exists(targetPath) then {
-              println(s"Overwriting: $name (all existing files and folders will be removed)".dim)
-              os.remove.all(targetPath)
-              true
+                result match {
+                  case Left(code) => sys.exit(code)
+                  case Right(v) => v
+                }
+              } else if os.exists(targetPath) then {
+                println(s"Overwriting: $name (all existing files and folders will be removed)".dim)
+                os.remove.all(targetPath)
+                true
+              } else
+                true
+
+            if proceed then {
+              os.makeDir.all(targetDir)
+              os.copy(s.path, targetPath, replaceExisting = true)
+              println(
+                s"\u2705 Synced: $name -> ${to.toString} (${targetLocation.toString.toLowerCase})".green
+              )
+              AgentsMd.updateAgentsMdForAgent(to, targetLocation)
             } else
-              true
-
-          if proceed then {
-            os.makeDir.all(targetDir)
-            os.copy(s.path, targetPath, replaceExisting = true)
-            println(s"\u2705 Synced: $name (${from.toString} -> ${to.toString})".green)
-
-            AgentsMd.updateAgentsMdForAgent(to, s.location)
-          } else
-            println(s"Skipped: $name".yellow)
-      }
-    }
-  }
-
-  private def syncAllSkills(from: Agent, to: Agent, yes: Boolean): Unit = {
-    if from === to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
-    else {
-      val sourceSkills =
-        Skills.findSkillsByAgent(from, SkillLocation.Project) ++ Skills.findSkillsByAgent(from, SkillLocation.Global)
-
-      if sourceSkills.isEmpty then println(s"No skills found in ${from.toString} directories.".yellow)
-      else {
-        println(s"Syncing ${sourceSkills.length} skill(s) from ${from.toString} to ${to.toString}...".dim)
-
-        val (synced, _) =
-          sourceSkills.foldLeft((0, BulkDecision.Undecided: BulkDecision)) {
-            case ((count, bulk), s) =>
-              val targetDir  = Dirs.getSkillsDir(to, s.location)
-              val targetPath = targetDir / s.name
-
-              def doSync(): Int = {
-                if os.exists(targetPath) then {
-                  println(s"Overwriting: ${s.name} (all existing files and folders will be removed)".dim)
-                  os.remove.all(targetPath)
-                } else ()
-                os.makeDir.all(targetDir)
-                os.copy(s.path, targetPath, replaceExisting = true)
-                println(s"\u2705 Synced: ${s.name}".green)
-                count + 1
-              }
-
-              if !os.exists(targetPath) then {
-                os.makeDir.all(targetDir)
-                os.copy(s.path, targetPath, replaceExisting = true)
-                println(s"\u2705 Synced: ${s.name}".green)
-                (count + 1, bulk)
-              } else if yes then (doSync(), bulk)
-              else
-                bulk match {
-                  case BulkDecision.OverwriteAll =>
-                    (doSync(), bulk)
-
-                  case BulkDecision.SkipAll =>
-                    println(s"Skipped: ${s.name}".yellow)
-                    (count, bulk)
-
-                  case BulkDecision.Undecided =>
-                    val pathLabel = Dirs.displaySkillsDir(to, s.location)
-                    OverwritePrompt.askOverwriteChoice(
-                      s.name,
-                      s"Skill '${s.name}' already exists in ${to.toString} (${s.location.toString.toLowerCase}): $pathLabel. What would you like to do?",
-                    ) match {
-                      case Left(code) => sys.exit(code)
-
-                      case Right(OverwriteChoice.Yes) =>
-                        (doSync(), BulkDecision.Undecided)
-
-                      case Right(OverwriteChoice.No) =>
-                        println(s"Skipped: ${s.name}".yellow)
-                        (count, BulkDecision.Undecided)
-
-                      case Right(OverwriteChoice.YesToAll) =>
-                        (doSync(), BulkDecision.OverwriteAll)
-
-                      case Right(OverwriteChoice.NoToAll) =>
-                        println(s"Skipped: ${s.name}".yellow)
-                        (count, BulkDecision.SkipAll)
-                    }
-                }
+              println(s"Skipped: $name".yellow)
           }
-
-        println(s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green)
-
-        // Update AGENTS.md for target if needed
-        AgentsMd.updateAgentsMdForAgent(to, SkillLocation.Project)
-        AgentsMd.updateAgentsMdForAgent(to, SkillLocation.Global)
       }
     }
   }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -179,8 +179,9 @@ final case class RemoveOptions(
 
 final case class SyncOptions(
   skillName: Option[String],
-  from: Option[Agent],
+  from: Option[(SkillLocation, Agent)],
   to: Option[List[Agent]],
+  targetLocations: Set[SkillLocation],
   yes: Boolean,
 )
 


### PR DESCRIPTION
# Close #51: Add `--project`/`--global` and `--from <location>:<agent>` to `sync` non-interactive mode

Change `--from` value format from `<agent>` to `<location>:<agent>` (e.g., `--from project:claude`, `--from global:universal`) so the source location is explicit. Add `--project`/`-p` and `--global`/`-g` flags to specify target location(s), consistent with other commands.

- `SyncOptions.from` is now `Option[(SkillLocation, Agent)]` instead of `Option[Agent]`, and a new `targetLocations: Set[SkillLocation]` field is added
- `--from` value is parsed by splitting on `":"` — the left side must be `project` or `global`, the right side a valid agent name, with clear error messages for invalid formats
- `--project` and/or `--global` are required when `--from`/`--to` are provided; missing both is an error
- Replace `syncSingleSkill` with `syncSingleSkillWithLocations` that takes explicit source and target locations, supporting cross-location sync (e.g., source from `global`, target to `project`)
- Remove old `syncSingleSkill` and `syncAllSkills` methods — the existing `syncAllSkillsWithLocations` already handles the all-skills case
- Update help text examples