### PR TITLE
Close #52: Add skill selection to `sync` interactive mode with terminal-width-aware label truncation

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -1,7 +1,7 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, SkillLocation, SyncOptions}
-import aiskills.core.utils.{AgentsMd, Dirs, Skills}
+import aiskills.core.{Agent, Skill, SkillLocation, SyncOptions}
+import aiskills.core.utils.{AgentsMd, Dirs, Skills, TerminalWidth}
 import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
@@ -233,6 +233,96 @@ object Sync {
     }
   }
 
+  private def syncSelectedSkillsWithLocations(
+    selectedSkills: List[Skill],
+    from: Agent,
+    to: Agent,
+    sourceLocation: SkillLocation,
+    targetLocations: List[SkillLocation],
+    yes: Boolean,
+  ): Unit = {
+    if from === to then println(s"Skipped: source and target are the same agent (${from.toString})".yellow)
+    else if selectedSkills.isEmpty then println("No skills selected.".yellow)
+    else {
+      val targetLabel = targetLocations.map(_.toString.toLowerCase).mkString(" and ")
+      println(
+        s"Syncing ${selectedSkills.length} skill(s) from ${from.toString} (${sourceLocation.toString.toLowerCase}) to ${to.toString} ($targetLabel)...".dim
+      )
+
+      val (synced, _) =
+        selectedSkills.foldLeft((0, BulkDecision.Undecided: BulkDecision)) {
+          case ((count, bulk), s) =>
+            targetLocations.foldLeft((count, bulk)) {
+              case ((count, bulk), targetLocation) =>
+                val targetDir  = Dirs.getSkillsDir(to, targetLocation)
+                val targetPath = targetDir / s.name
+
+                def doSync(): Int = {
+                  if os.exists(targetPath) then {
+                    println(s"Overwriting: ${s.name} (all existing files and folders will be removed)".dim)
+                    os.remove.all(targetPath)
+                  } else ()
+                  os.makeDir.all(targetDir)
+                  os.copy(s.path, targetPath, replaceExisting = true)
+                  println(
+                    s"\u2705 Synced: ${s.name} -> ${to.toString} (${targetLocation.toString.toLowerCase})".green
+                  )
+                  count + 1
+                }
+
+                if !os.exists(targetPath) then {
+                  os.makeDir.all(targetDir)
+                  os.copy(s.path, targetPath, replaceExisting = true)
+                  println(
+                    s"\u2705 Synced: ${s.name} -> ${to.toString} (${targetLocation.toString.toLowerCase})".green
+                  )
+                  (count + 1, bulk)
+                } else if yes then (doSync(), bulk)
+                else
+                  bulk match {
+                    case BulkDecision.OverwriteAll =>
+                      (doSync(), bulk)
+
+                    case BulkDecision.SkipAll =>
+                      println(s"Skipped: ${s.name}".yellow)
+                      (count, bulk)
+
+                    case BulkDecision.Undecided =>
+                      val pathLabel = Dirs.displaySkillsDir(to, targetLocation)
+                      OverwritePrompt.askOverwriteChoice(
+                        s.name,
+                        s"Skill '${s.name}' already exists in ${to.toString} (${targetLocation.toString.toLowerCase}): $pathLabel. What would you like to do?",
+                      ) match {
+                        case Left(code) => sys.exit(code)
+
+                        case Right(OverwriteChoice.Yes) =>
+                          (doSync(), BulkDecision.Undecided)
+
+                        case Right(OverwriteChoice.No) =>
+                          println(s"Skipped: ${s.name}".yellow)
+                          (count, BulkDecision.Undecided)
+
+                        case Right(OverwriteChoice.YesToAll) =>
+                          (doSync(), BulkDecision.OverwriteAll)
+
+                        case Right(OverwriteChoice.NoToAll) =>
+                          println(s"Skipped: ${s.name}".yellow)
+                          (count, BulkDecision.SkipAll)
+                      }
+                  }
+            }
+        }
+
+      println(
+        s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green
+      )
+
+      for targetLocation <- targetLocations do {
+        AgentsMd.updateAgentsMdForAgent(to, targetLocation)
+      }
+    }
+  }
+
   private def interactiveSync(yes: Boolean): Unit = {
     val allSkills = Skills.findAllSkills()
 
@@ -300,42 +390,27 @@ object Sync {
           case None =>
             println("No agent selected.".yellow)
           case Some(from) =>
-            // Step 3: Pick target location
-            val targetLocations = {
-              val options = List("project", "global", "both")
-              aiskills.cli.SigintHandler.install()
-              val result  = Prompts.sync.use { prompts =>
-                prompts.singleChoice("Select target location", options) match {
-                  case Completion.Finished(selected) =>
-                    selected match {
-                      case "project" => Right(List(SkillLocation.Project))
-                      case "global" => Right(List(SkillLocation.Global))
-                      case _ => Right(List(SkillLocation.Project, SkillLocation.Global))
-                    }
-                  case Completion.Fail(CompletionError.Interrupted) =>
-                    println("\n\nCancelled by user".yellow)
-                    Left(0)
-                  case Completion.Fail(CompletionError.Error(msg)) =>
-                    System.err.println(s"Error: $msg")
-                    Left(1)
-                }
-              }
-              result match {
-                case Left(code) => sys.exit(code)
-                case Right(v) => v
-              }
+            // Step 3: Pick skills to sync
+            val sourceSkills = Skills.findSkillsByAgent(from, sourceLocation).sortBy(_.name)
+
+            val terminalWidth  = TerminalWidth.getTerminalWidth()
+            val cue4sPrefixLen = 4 // " ◉ "
+            val namePadLen     = 25
+            val maxDescLen     =
+              (terminalWidth - cue4sPrefixLen - namePadLen - 1).max(10) // -1 for space between name and desc
+            val skillLabels    = sourceSkills.map { s =>
+              val desc =
+                if s.description.length > maxDescLen then s.description.take(maxDescLen - 3) + "..."
+                else s.description
+              s"${s.name.padTo(namePadLen, ' ')} $desc"
             }
 
-            // Step 4: Pick target agents
-            val targetAgents = Agent.all.filterNot(_ === from)
-            val targetLabels = targetAgents.map(_.toString)
-
-            val selectedTargets = {
+            val selectedSkills = {
               aiskills.cli.SigintHandler.install()
               val result = Prompts.sync.use { prompts =>
-                prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
+                prompts.multiChoiceAllSelected("Select skills to sync", skillLabels) match {
                   case Completion.Finished(selectedLabels) =>
-                    Right(targetAgents.filter(a => selectedLabels.contains(a.toString)))
+                    Right(sourceSkills.filter(s => selectedLabels.exists(_.startsWith(s.name))))
                   case Completion.Fail(CompletionError.Interrupted) =>
                     println("\n\nCancelled by user".yellow)
                     Left(0)
@@ -350,11 +425,64 @@ object Sync {
               }
             }
 
-            if selectedTargets.isEmpty then println("No target agents selected.".yellow)
-            else
-              for target <- selectedTargets do {
-                syncAllSkillsWithLocations(from, target, sourceLocation, targetLocations, yes)
+            if selectedSkills.isEmpty then println("No skills selected.".yellow)
+            else {
+              // Step 4: Pick target location
+              val targetLocations = {
+                val options = List("project", "global", "both")
+                aiskills.cli.SigintHandler.install()
+                val result  = Prompts.sync.use { prompts =>
+                  prompts.singleChoice("Select target location", options) match {
+                    case Completion.Finished(selected) =>
+                      selected match {
+                        case "project" => Right(List(SkillLocation.Project))
+                        case "global" => Right(List(SkillLocation.Global))
+                        case _ => Right(List(SkillLocation.Project, SkillLocation.Global))
+                      }
+                    case Completion.Fail(CompletionError.Interrupted) =>
+                      println("\n\nCancelled by user".yellow)
+                      Left(0)
+                    case Completion.Fail(CompletionError.Error(msg)) =>
+                      System.err.println(s"Error: $msg")
+                      Left(1)
+                  }
+                }
+                result match {
+                  case Left(code) => sys.exit(code)
+                  case Right(v) => v
+                }
               }
+
+              // Step 5: Pick target agents
+              val targetAgents = Agent.all.filterNot(_ === from)
+              val targetLabels = targetAgents.map(_.toString)
+
+              val selectedTargets = {
+                aiskills.cli.SigintHandler.install()
+                val result = Prompts.sync.use { prompts =>
+                  prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
+                    case Completion.Finished(selectedLabels) =>
+                      Right(targetAgents.filter(a => selectedLabels.contains(a.toString)))
+                    case Completion.Fail(CompletionError.Interrupted) =>
+                      println("\n\nCancelled by user".yellow)
+                      Left(0)
+                    case Completion.Fail(CompletionError.Error(msg)) =>
+                      System.err.println(s"Error: $msg")
+                      Left(1)
+                  }
+                }
+                result match {
+                  case Left(code) => sys.exit(code)
+                  case Right(v) => v
+                }
+              }
+
+              if selectedTargets.isEmpty then println("No target agents selected.".yellow)
+              else
+                for target <- selectedTargets do {
+                  syncSelectedSkillsWithLocations(selectedSkills, from, target, sourceLocation, targetLocations, yes)
+                }
+            }
         }
       }
     }

--- a/modules/ai-skills-core/src/main/resources/scala-native/terminal_width.c
+++ b/modules/ai-skills-core/src/main/resources/scala-native/terminal_width.c
@@ -1,0 +1,13 @@
+#if defined(__linux__) || defined(__APPLE__)
+
+#include <sys/ioctl.h>
+
+int aiskills_get_terminal_width() {
+    struct winsize ws;
+    if (ioctl(0, TIOCGWINSZ, &ws) == 0) {
+        return ws.ws_col;
+    }
+    return -1;
+}
+
+#endif

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TerminalWidth.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TerminalWidth.scala
@@ -1,0 +1,14 @@
+package aiskills.core.utils
+
+import scala.scalanative.unsafe.*
+
+object TerminalWidth {
+
+  @extern
+  private def aiskills_get_terminal_width(): Int = extern
+
+  def getTerminalWidth(): Int = {
+    val width = aiskills_get_terminal_width()
+    if width > 0 then width else 80
+  }
+}


### PR DESCRIPTION
# Close #52: Add skill selection to `sync` interactive mode with terminal-width-aware label truncation

Add a new Step 3 (skill selection) to the `sync` command's interactive wizard. Previously, after selecting the source location and agent, all skills were synced. Now users can choose which skills to sync via a multi-select prompt with all skills pre-selected by default.

The interactive flow is now:
  1. Select source location (`project`/`global`)
  2. Select source agent
  3. Select skills to sync (new - multi-select, all pre-selected)
  4. Select target location (`project`/`global`/both)
  5. Select target agent(s)

Add a new `syncSelectedSkillsWithLocations` method that accepts a `List[Skill]` parameter instead of fetching all skills internally, keeping existing `syncAllSkillsWithLocations` and `syncSingleSkillWithLocations` untouched so non-interactive mode is unaffected.

Skill descriptions in the selection prompt are truncated based on the actual terminal width to avoid a `cue4s` rendering bug where labels exceeding the terminal width cause duplicated/corrupted display. Terminal width is detected via `ioctl(TIOCGWINSZ)` through a Scala Native C glue function, falling back to 80 columns if detection fails.

New files:
- modules/ai-skills-core/src/main/resources/scala-native/terminal_width.c
- modules/ai-skills-core/src/main/scala/aiskills/core/utils/TerminalWidth.scala