### PR TITLE
Close #54: Support syncing multiple skills in `sync` non-interactive mode

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -286,24 +286,24 @@ object Main {
             |  aiskills sync --from global:claude --to cursor,windsurf --global           # All skills, global -> global
             |  aiskills sync --from project:claude --to all --project --global            # All skills, project -> both
             |  aiskills sync commit --from global:claude --to cursor --project --global   # One skill, global -> both
-            |  aiskills sync a,b,c --from project:claude --to codex,gemini --project      # Multiple skills
+            |  aiskills sync a b c --from project:claude --to codex,gemini --project      # Multiple skills
             |  aiskills sync --from project:universal --to copilot --global -y            # Skip confirmation prompts
             |""".stripMargin,
         ) {
-          val skillName = Opts.argument[String](metavar = "skill-name").orNone
-          val from      = Opts
+          val skillNames = Opts.arguments[String](metavar = "skill-names").orEmpty
+          val from       = Opts
             .option[String]("from", "Source location and agent (format: <project|global>:<agent>)")
             .orNone
-          val to        = Opts
+          val to         = Opts
             .option[String](
               "to",
               s"Target agent(s), comma-separated or 'all' (${Agent.all.map(_.toString.toLowerCase).mkString(", ")})",
             )
             .orNone
-          val project   = Opts.flag("project", "Sync to project scope (current directory)", short = "p").orFalse
-          val global    = Opts.flag("global", "Sync to global scope (home directory)", short = "g").orFalse
-          val yes       = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
-          (skillName, from, to, project, global, yes).mapN { (sn, f, t, p, g, y) =>
+          val project    = Opts.flag("project", "Sync to project scope (current directory)", short = "p").orFalse
+          val global     = Opts.flag("global", "Sync to global scope (home directory)", short = "g").orFalse
+          val yes        = Opts.flag("yes", "Skip confirmation", short = "y").orFalse
+          (skillNames, from, to, project, global, yes).mapN { (sn, f, t, p, g, y) =>
             val parsedFrom: Option[(SkillLocation, Agent)] = f.map { fromStr =>
               fromStr.split(":", 2) match {
                 case Array(locStr, agentStr) =>
@@ -371,7 +371,7 @@ object Main {
 
             Sync.syncSkills(
               SyncOptions(
-                skillNames = sn.map(_.split(",").toList.map(_.trim).filter(_.nonEmpty)),
+                skillNames = sn,
                 from = parsedFrom,
                 to = parsedTo,
                 targetLocations = locations,

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -12,38 +12,40 @@ object Sync {
 
   /** Sync skills between agent directories. */
   def syncSkills(options: SyncOptions): Unit =
-    (options.from, options.to, options.skillNames) match {
+    (options.from, options.to) match {
       // Interactive mode: no flags provided
-      case (None, None, None) =>
+      case (None, None) =>
         interactiveSync(options.yes)
 
-      // Specific skill(s), from/to specified
-      case (Some((sourceLocation, from)), Some(targets), Some(names)) =>
+      // Non-interactive: from/to specified
+      case (Some((sourceLocation, from)), Some(targets)) =>
         val targetLocations = options.targetLocations.toList
-        val sourceSkills    = Skills.findSkillsByAgent(from, sourceLocation)
 
-        val (notFound, found) = names.partitionMap { name =>
-          sourceSkills.find(_.name === name).toRight(name)
-        }
+        if options.skillNames.nonEmpty then {
+          // Specific skill(s)
+          val sourceSkills = Skills.findSkillsByAgent(from, sourceLocation)
 
-        if notFound.nonEmpty then {
-          System
-            .err
-            .println(
-              s"Error: Skill(s) not found in ${from.toString} (${sourceLocation.toString.toLowerCase}): ${notFound.mkString(", ")}".red
-            )
-          sys.exit(1)
-        }
+          val (notFound, found) = options.skillNames.partitionMap { name =>
+            sourceSkills.find(_.name === name).toRight(name)
+          }
 
-        for target <- targets.filterNot(_ === from) do {
-          syncSelectedSkillsWithLocations(found, from, target, sourceLocation, targetLocations, options.yes)
-        }
+          if notFound.nonEmpty then {
+            System
+              .err
+              .println(
+                s"Error: Skill(s) not found in ${from.toString} (${sourceLocation.toString.toLowerCase}): ${notFound.mkString(", ")}".red
+              )
+            sys.exit(1)
+          }
 
-      // All skills from one agent to target(s)
-      case (Some((sourceLocation, from)), Some(targets), None) =>
-        val targetLocations = options.targetLocations.toList
-        for target <- targets.filterNot(_ === from) do {
-          syncAllSkillsWithLocations(from, target, sourceLocation, targetLocations, options.yes)
+          for target <- targets.filterNot(_ === from) do {
+            syncSelectedSkillsWithLocations(found, from, target, sourceLocation, targetLocations, options.yes)
+          }
+        } else {
+          // All skills
+          for target <- targets.filterNot(_ === from) do {
+            syncAllSkillsWithLocations(from, target, sourceLocation, targetLocations, options.yes)
+          }
         }
 
       case _ =>
@@ -60,7 +62,7 @@ object Sync {
         System
           .err
           .println(
-            "  aiskills sync <skill>[,<skill>...] --from <location>:<agent> --to <agent> --project    # Specific skill(s)"
+            "  aiskills sync <skill> [<skill>...] --from <location>:<agent> --to <agent> --project    # Specific skill(s)"
           )
         System
           .err

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -178,7 +178,7 @@ final case class RemoveOptions(
 )
 
 final case class SyncOptions(
-  skillNames: Option[List[String]],
+  skillNames: List[String],
   from: Option[(SkillLocation, Agent)],
   to: Option[List[Agent]],
   targetLocations: Set[SkillLocation],


### PR DESCRIPTION
# Close #54: Support syncing multiple skills in `sync` non-interactive mode

Add space-separated multi-skill support to the `sync` command's non-interactive mode, consistent with the `read` and `update` commands which use `Opts.arguments[String].orEmpty` for positional arguments.

e.g.)
```
aiskills sync skill-1 skill-2 skill-3 --from global:claude --to codex,gemini --project
```

- Change `SyncOptions.skillNames` from `Option[List[String]]` to `List[String]` where empty list means sync all skills (when `--from`/`--to` present) or interactive mode (when no flags)
- Switch CLI parser from `Opts.argument[String].orNone` (single) to `Opts.arguments[String].orEmpty` (multiple, space-separated)
- Unify single-skill and multi-skill non-interactive paths into one branch that validates all names up front, reports any not-found skills, and delegates to `syncSelectedSkillsWithLocations`
- Remove the now-unused `syncSingleSkillWithLocations` method
- Update help text and error messages with space-separated examples