### PR TITLE
Refactor CLI command logic to replace `Left`/`Right` with `asLeft`/`asRight` and streamline map/filter usage for improved readability.

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -85,14 +85,14 @@ object Install {
           val selected = Agent.all.filter(a => selectedLabels.contains(a.toString))
           if selected.isEmpty then {
             println("No agents selected. Installation cancelled.".yellow)
-            Left(0)
-          } else Right(selected)
+            0.asLeft
+          } else selected.asRight
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
-          Left(0)
+          0.asLeft
         case Completion.Fail(CompletionError.Error(msg)) =>
           System.err.println(s"Error: $msg")
-          Left(1)
+          1.asLeft
       }
     }
     result match {
@@ -115,20 +115,20 @@ object Install {
         case Completion.Finished(selectedLabels) =>
           if selectedLabels.isEmpty then {
             println("No location selected. Defaulting to project.".yellow)
-            Right(Set(SkillLocation.Project))
+            Set(SkillLocation.Project).asRight
           } else {
             val locs = selectedLabels.foldLeft(Set.empty[SkillLocation]) { (acc, label) =>
               if label.startsWith("project") then acc + SkillLocation.Project
               else acc + SkillLocation.Global
             }
-            Right(locs)
+            locs.asRight
           }
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
-          Left(0)
+          0.asLeft
         case Completion.Fail(CompletionError.Error(msg)) =>
           System.err.println(s"Error: $msg")
-          Left(1)
+          1.asLeft
       }
     }
     result match {
@@ -492,19 +492,19 @@ object Install {
             case Completion.Finished(selectedLabels) =>
               if selectedLabels.isEmpty then {
                 println("No skills selected. Installation cancelled.".yellow)
-                Right(Nil)
+                List.empty[SkillInfo].asRight
               } else
-                Right(skillInfos.filter { info =>
+                skillInfos.filter { info =>
                   selectedLabels.exists(_.contains(info.skillName))
-                })
+                }.asRight
 
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
-              Left(0)
+              0.asLeft
 
             case Completion.Fail(CompletionError.Error(msg)) =>
               System.err.println(s"Error: $msg")
-              Left(1)
+              1.asLeft
           }
         }
         result match {
@@ -656,12 +656,12 @@ object Install {
           prompts.confirm(s"Skill '$skillName' already exists. Overwrite?".yellow, default = false) match {
             case Completion.Finished(shouldOverwrite) =>
               if shouldOverwrite then os.remove.all(targetPath) else ()
-              Right(shouldOverwrite)
+              shouldOverwrite.asRight
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
-              Left(0)
+              0.asLeft
             case Completion.Fail(CompletionError.Error(_)) =>
-              Right(false)
+              false.asRight
           }
         }
         result match {

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -108,7 +108,7 @@ object ListCmd {
             .filter { (agent, _) =>
               selectedLabels.exists(_.contains(agent.toString))
             }
-            .map(_._1)
+            .map { case (agent, _) => agent }
           selected.asRight
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -35,10 +35,10 @@ object Read {
           source = skillPath / os.up / os.up,
           agent = agent,
           location = location,
-        )).toList
+        ))
 
         if found.isEmpty then missing += name
-        else found.foreach(skill => resolved += ((name, skill)))
+        else found.foreach(skill => resolved += name -> skill)
       }
 
       val missingList = missing.result()
@@ -168,7 +168,7 @@ object Read {
             .filter { (agent, _) =>
               selectedLabels.exists(_.contains(agent.toString))
             }
-            .map(_._1)
+            .map { case (agent, _) => agent }
           selected.asRight
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -277,15 +277,15 @@ object Sync {
           prompts.singleChoice("Select source location", options) match {
             case Completion.Finished(selected) =>
               selected match {
-                case "project" => Right(SkillLocation.Project)
-                case _ => Right(SkillLocation.Global)
+                case "project" => SkillLocation.Project.asRight
+                case _ => SkillLocation.Global.asRight
               }
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)
-              Left(0)
+              0.asLeft
             case Completion.Fail(CompletionError.Error(msg)) =>
               System.err.println(s"Error: $msg")
-              Left(1)
+              1.asLeft
           }
         }
         result match {
@@ -310,13 +310,13 @@ object Sync {
           val result = Prompts.sync.use { prompts =>
             prompts.singleChoice("Select source agent", agentLabels) match {
               case Completion.Finished(selectedLabel) =>
-                Right(agents.find(a => selectedLabel.contains(a.toString)))
+                agents.find(a => selectedLabel.contains(a.toString)).asRight
               case Completion.Fail(CompletionError.Interrupted) =>
                 println("\n\nCancelled by user".yellow)
-                Left(0)
+                0.asLeft
               case Completion.Fail(CompletionError.Error(msg)) =>
                 System.err.println(s"Error: $msg")
-                Left(1)
+                1.asLeft
             }
           }
           result match {
@@ -349,13 +349,13 @@ object Sync {
               val result = Prompts.sync.use { prompts =>
                 prompts.multiChoiceAllSelected("Select skills to sync", skillLabels) match {
                   case Completion.Finished(selectedLabels) =>
-                    Right(sourceSkills.filter(s => selectedLabels.exists(_.startsWith(s.name))))
+                    sourceSkills.filter(s => selectedLabels.exists(_.startsWith(s.name))).asRight
                   case Completion.Fail(CompletionError.Interrupted) =>
                     println("\n\nCancelled by user".yellow)
-                    Left(0)
+                    0.asLeft
                   case Completion.Fail(CompletionError.Error(msg)) =>
                     System.err.println(s"Error: $msg")
-                    Left(1)
+                    1.asLeft
                 }
               }
               result match {
@@ -374,16 +374,16 @@ object Sync {
                   prompts.singleChoice("Select target location", options) match {
                     case Completion.Finished(selected) =>
                       selected match {
-                        case "project" => Right(List(SkillLocation.Project))
-                        case "global" => Right(List(SkillLocation.Global))
-                        case _ => Right(List(SkillLocation.Project, SkillLocation.Global))
+                        case "project" => List(SkillLocation.Project).asRight
+                        case "global" => List(SkillLocation.Global).asRight
+                        case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
                       }
                     case Completion.Fail(CompletionError.Interrupted) =>
                       println("\n\nCancelled by user".yellow)
-                      Left(0)
+                      0.asLeft
                     case Completion.Fail(CompletionError.Error(msg)) =>
                       System.err.println(s"Error: $msg")
-                      Left(1)
+                      1.asLeft
                   }
                 }
                 result match {
@@ -401,13 +401,13 @@ object Sync {
                 val result = Prompts.sync.use { prompts =>
                   prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
                     case Completion.Finished(selectedLabels) =>
-                      Right(targetAgents.filter(a => selectedLabels.contains(a.toString)))
+                      targetAgents.filter(a => selectedLabels.contains(a.toString)).asRight
                     case Completion.Fail(CompletionError.Interrupted) =>
                       println("\n\nCancelled by user".yellow)
-                      Left(0)
+                      0.asLeft
                     case Completion.Fail(CompletionError.Error(msg)) =>
                       System.err.println(s"Error: $msg")
-                      Left(1)
+                      1.asLeft
                   }
                 }
                 result match {

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -95,7 +95,8 @@ object DirsSpec extends Properties {
   }
 
   private def testSearchDirsOrder: Result = {
-    val dirs = Dirs.getSearchDirs()
+    val dirs   = Dirs.getSearchDirs()
+    val agents = dirs.map { case (_, agent, _) => agent }
     // 1. Project universal
     // 2-7. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini, Windsurf)
     // 8. Global universal
@@ -105,25 +106,25 @@ object DirsSpec extends Properties {
         // Project universal
         dirs(0) ==== (os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project),
         // Project agent-specific (alphabetical)
-        dirs(1)._2 ==== Agent.Claude,
-        dirs(2)._2 ==== Agent.Codex,
-        dirs(3)._2 ==== Agent.Copilot,
-        dirs(4)._2 ==== Agent.Cursor,
-        dirs(5)._2 ==== Agent.Gemini,
-        dirs(6)._2 ==== Agent.Windsurf,
+        agents(1) ==== Agent.Claude,
+        agents(2) ==== Agent.Codex,
+        agents(3) ==== Agent.Copilot,
+        agents(4) ==== Agent.Cursor,
+        agents(5) ==== Agent.Gemini,
+        agents(6) ==== Agent.Windsurf,
         // All project dirs are Project location
-        Result.assert(dirs.take(7).forall(_._3 === SkillLocation.Project)),
+        Result.assert(dirs.take(7).forall { case (_, _, location) => location === SkillLocation.Project }),
         // Global universal
         dirs(7) ==== (os.home / ".agents" / "skills", Agent.Universal, SkillLocation.Global),
         // Global agent-specific (alphabetical)
-        dirs(8)._2 ==== Agent.Claude,
-        dirs(9)._2 ==== Agent.Codex,
-        dirs(10)._2 ==== Agent.Copilot,
-        dirs(11)._2 ==== Agent.Cursor,
-        dirs(12)._2 ==== Agent.Gemini,
-        dirs(13)._2 ==== Agent.Windsurf,
+        agents(8) ==== Agent.Claude,
+        agents(9) ==== Agent.Codex,
+        agents(10) ==== Agent.Copilot,
+        agents(11) ==== Agent.Cursor,
+        agents(12) ==== Agent.Gemini,
+        agents(13) ==== Agent.Windsurf,
         // All global dirs are Global location
-        Result.assert(dirs.drop(7).forall(_._3 === SkillLocation.Global)),
+        Result.assert(dirs.drop(7).forall { case (_, _, location) => location === SkillLocation.Global }),
       )
     )
   }


### PR DESCRIPTION
Refactor CLI command logic to replace `Left`/`Right` with `asLeft`/`asRight` and streamline map/filter usage for improved readability.