### PR TITLE
Close #62: Increase `MultipleChoice` window size from `10` to `20`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/CliDefaults.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/CliDefaults.scala
@@ -1,0 +1,10 @@
+package aiskills.cli
+
+import cue4s.Prompt
+
+object CliDefaults {
+  val MultiChoiceWindowSize: Int = 20
+
+  val multiChoiceModify: Prompt.MultipleChoice => Prompt.MultipleChoice =
+    _.withWindowSize(MultiChoiceWindowSize)
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -1,13 +1,12 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, InstallOptions, InstallSourceInfo, SkillLocation, SkillSourceMetadata, SkillSourceType}
-import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMetadata, Yaml}
-import cats.syntax.all.*
-import extras.scala.io.syntax.color.*
-import cue4s.*
-
 import OverwritePrompt.{BulkDecision, OverwriteChoice}
-
+import aiskills.cli.CliDefaults
+import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMetadata, Yaml}
+import aiskills.core.*
+import cats.syntax.all.*
+import cue4s.*
+import extras.scala.io.syntax.color.*
 import just.spinner.*
 
 import scala.util.{Failure, Success, Try}
@@ -80,7 +79,7 @@ object Install {
 
     aiskills.cli.SigintHandler.install()
     val result = Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels) match {
+      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels, CliDefaults.multiChoiceModify) match {
         case Completion.Finished(selectedLabels) =>
           val selected = Agent.all.filter(a => selectedLabels.contains(a.toString))
           if selected.isEmpty then {
@@ -111,7 +110,7 @@ object Install {
 
     aiskills.cli.SigintHandler.install()
     val result = Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select install location", locationLabels) match {
+      prompts.multiChoiceNoneSelected("Select install location", locationLabels, CliDefaults.multiChoiceModify) match {
         case Completion.Finished(selectedLabels) =>
           if selectedLabels.isEmpty then {
             println("No location selected. Defaulting to project.".yellow)
@@ -488,7 +487,7 @@ object Install {
 
         aiskills.cli.SigintHandler.install()
         val result = Prompts.sync.use { prompts =>
-          prompts.multiChoiceAllSelected("Select skills to install", labels) match {
+          prompts.multiChoiceAllSelected("Select skills to install", labels, CliDefaults.multiChoiceModify) match {
             case Completion.Finished(selectedLabels) =>
               if selectedLabels.isEmpty then {
                 println("No skills selected. Installation cancelled.".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -1,10 +1,11 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, ListOptions, Skill, SkillLocation}
+import aiskills.cli.CliDefaults
 import aiskills.core.utils.{Dirs, Skills}
+import aiskills.core.{Agent, ListOptions, Skill, SkillLocation}
 import cats.syntax.all.*
-import extras.scala.io.syntax.color.*
 import cue4s.*
+import extras.scala.io.syntax.color.*
 
 object ListCmd {
 
@@ -102,7 +103,7 @@ object ListCmd {
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select agent(s)", labels) match {
+      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
         case Completion.Finished(selectedLabels) =>
           val selected = agentsWithCounts
             .filter { (agent, _) =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -1,10 +1,11 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, ReadOptions, Skill, SkillLocation, SkillLocationInfo}
+import aiskills.cli.CliDefaults
 import aiskills.core.utils.{Dirs, SkillNames, Skills}
+import aiskills.core.{Agent, ReadOptions, Skill, SkillLocation, SkillLocationInfo}
 import cats.syntax.all.*
-import extras.scala.io.syntax.color.*
 import cue4s.*
+import extras.scala.io.syntax.color.*
 
 object Read {
 
@@ -162,7 +163,7 @@ object Read {
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select agent(s)", labels) match {
+      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
         case Completion.Finished(selectedLabels) =>
           val selected = agentsWithCounts
             .filter { (agent, _) =>
@@ -193,7 +194,7 @@ object Read {
 
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skill(s) to read", labels) match {
+      prompts.multiChoiceNoneSelected("Select skill(s) to read", labels, CliDefaults.multiChoiceModify) match {
         case Completion.Finished(selectedLabels) =>
           val selectedIndices = selectedLabels.flatMap { label =>
             labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -1,10 +1,11 @@
 package aiskills.cli.commands
 
-import aiskills.core.{RemoveOptions, SkillLocation}
+import aiskills.cli.CliDefaults
 import aiskills.core.utils.{AgentsMd, Dirs, Skills}
+import aiskills.core.{RemoveOptions, SkillLocation}
 import cats.syntax.all.*
-import extras.scala.io.syntax.color.*
 import cue4s.*
+import extras.scala.io.syntax.color.*
 
 object Remove {
 
@@ -26,7 +27,7 @@ object Remove {
 
       aiskills.cli.SigintHandler.install()
       val result = Prompts.sync.use { prompts =>
-        prompts.multiChoiceNoneSelected("Select skills to remove", labels) match {
+        prompts.multiChoiceNoneSelected("Select skills to remove", labels, CliDefaults.multiChoiceModify) match {
           case Completion.Finished(selectedLabels) =>
             if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
             else {

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -1,12 +1,12 @@
 package aiskills.cli.commands
 
-import aiskills.core.{Agent, Skill, SkillLocation, SyncOptions}
+import OverwritePrompt.{BulkDecision, OverwriteChoice}
+import aiskills.cli.CliDefaults
 import aiskills.core.utils.{AgentsMd, Dirs, Skills, TerminalWidth}
+import aiskills.core.{Agent, Skill, SkillLocation, SyncOptions}
 import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
-
-import OverwritePrompt.{BulkDecision, OverwriteChoice}
 
 object Sync {
 
@@ -347,7 +347,11 @@ object Sync {
             val selectedSkills = {
               aiskills.cli.SigintHandler.install()
               val result = Prompts.sync.use { prompts =>
-                prompts.multiChoiceAllSelected("Select skills to sync", skillLabels) match {
+                prompts.multiChoiceAllSelected(
+                  "Select skills to sync",
+                  skillLabels,
+                  CliDefaults.multiChoiceModify
+                ) match {
                   case Completion.Finished(selectedLabels) =>
                     sourceSkills.filter(s => selectedLabels.exists(_.startsWith(s.name))).asRight
                   case Completion.Fail(CompletionError.Interrupted) =>
@@ -399,7 +403,11 @@ object Sync {
               val selectedTargets = {
                 aiskills.cli.SigintHandler.install()
                 val result = Prompts.sync.use { prompts =>
-                  prompts.multiChoiceNoneSelected("Select target agent(s)", targetLabels) match {
+                  prompts.multiChoiceNoneSelected(
+                    "Select target agent(s)",
+                    targetLabels,
+                    CliDefaults.multiChoiceModify
+                  ) match {
                     case Completion.Finished(selectedLabels) =>
                       targetAgents.filter(a => selectedLabels.contains(a.toString)).asRight
                     case Completion.Fail(CompletionError.Interrupted) =>


### PR DESCRIPTION
# Close #62: Increase `MultipleChoice` window size from `10` to `20`

- Standardize CLI multi-choice prompt window sizing
  - Extract `CliDefaults` to centralize the shared `cue4s` multi-choice configuration and set the window size to 20 in one place.
  - Update `Install`, `ListCmd`, `Read`, `Remove`, and `Sync` commands to apply `CliDefaults.multiChoiceModify` to their multiple choice prompts to increase the visible options.

Before:
<img width="776" height="629" alt="multiple-choice-10" src="https://github.com/user-attachments/assets/8dcf9a44-81a6-4a3c-baa9-527f8c02f7f0" />

After:
<img width="540" height="642" alt="multiple-choice-20" src="https://github.com/user-attachments/assets/5d175164-3aa1-4f51-bff8-e56d5dd95471" />
