### PR TITLE
Close #66: Add location and agent selections to the `remove` command's interactive mode

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -2,7 +2,7 @@ package aiskills.cli.commands
 
 import aiskills.cli.CliDefaults
 import aiskills.core.utils.{AgentsMd, Dirs, Skills}
-import aiskills.core.{RemoveOptions, SkillLocation}
+import aiskills.core.{Agent, RemoveOptions, Skill, SkillLocation}
 import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
@@ -11,57 +11,141 @@ object Remove {
 
   /** Interactively manage (remove) installed skills via multi-select prompt. */
   def removeInteractive(): Unit = {
-    val skills = Skills.findAllSkills()
+    val allSkills = Skills.findAllSkills()
 
-    if skills.isEmpty then println("No skills installed.")
+    if allSkills.isEmpty then println("No skills installed.")
     else {
-      val sorted = skills.sortBy { s =>
-        (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
-      }
+      val hasProjectSkills = allSkills.exists(_.location === SkillLocation.Project)
 
-      val labels = sorted.map { skill =>
-        val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
-        val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
-        s"${skill.name.padTo(25, ' ')} $locationLabel"
-      }
-
-      aiskills.cli.SigintHandler.install()
-      val result = Prompts.sync.use { prompts =>
-        prompts.multiChoiceNoneSelected("Select skills to remove", labels, CliDefaults.multiChoiceModify) match {
-          case Completion.Finished(selectedLabels) =>
-            if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
-            else {
-              val selectedIndices = selectedLabels.flatMap { label =>
-                labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
-              }
-              val removedSkills   = selectedIndices.map(sorted(_))
-              for skill <- removedSkills do {
-                os.remove.all(skill.path)
-                val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
-                println(
-                  s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
-                )
-              }
-
-              val agentLocationPairs = removedSkills.map(s => (s.agent, s.location)).distinct
-              for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
-
-              println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
-            }
-            ().asRight
-
-          case Completion.Fail(CompletionError.Interrupted) =>
-            println("\n\nCancelled by user".yellow)
-            0.asLeft
-
-          case Completion.Fail(CompletionError.Error(msg)) =>
-            System.err.println(s"Error: $msg")
-            1.asLeft
+      val locationsResult: Either[Int, List[SkillLocation]] =
+        if hasProjectSkills then promptForScope()
+        else {
+          println("No project skills found. Removing from global scope.".yellow)
+          List(SkillLocation.Global).asRight
         }
-      }
-      result match {
+
+      locationsResult match {
         case Left(code) => sys.exit(code)
-        case Right(()) => ()
+        case Right(locations) =>
+          val skillsInScope = allSkills.filter(s => locations.contains(s.location))
+
+          if skillsInScope.isEmpty then {
+            val scopeLabel = locations.map(_.toString.toLowerCase).mkString(" and ")
+            println(s"No skills found in $scopeLabel scope.".yellow)
+          } else {
+            val agentsWithCounts = Agent.all.flatMap { agent =>
+              val count = skillsInScope.count(_.agent === agent)
+              if count > 0 then (agent, count).some else none
+            }
+
+            promptForAgents(agentsWithCounts) match {
+              case Left(code) => sys.exit(code)
+              case Right(selectedAgents) =>
+                if selectedAgents.isEmpty then println("No agents selected.".yellow)
+                else {
+                  val filtered = skillsInScope.filter(s => selectedAgents.contains(s.agent))
+                  if filtered.isEmpty then println("No skills found for the selected agents.".yellow)
+                  else {
+                    promptForSkillsAndRemove(filtered) match {
+                      case Left(code) => sys.exit(code)
+                      case Right(()) => ()
+                    }
+                  }
+                }
+            }
+          }
+      }
+    }
+  }
+
+  private def promptForSkillsAndRemove(skills: List[Skill]): Either[Int, Unit] = {
+    val sorted = skills.sortBy { s =>
+      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
+    }
+
+    val labels = sorted.map { skill =>
+      val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+      val locationLabel = s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
+      s"${skill.name.padTo(25, ' ')} $locationLabel"
+    }
+
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select skills to remove", labels, CliDefaults.multiChoiceModify) match {
+        case Completion.Finished(selectedLabels) =>
+          if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
+          else {
+            val selectedIndices = selectedLabels.flatMap { label =>
+              labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
+            }
+            val removedSkills   = selectedIndices.map(sorted(_))
+            for skill <- removedSkills do {
+              os.remove.all(skill.path)
+              val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
+              println(
+                s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
+              )
+            }
+
+            val agentLocationPairs = removedSkills.map(s => (s.agent, s.location)).distinct
+            for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+
+            println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
+          }
+          ().asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForScope(): Either[Int, List[SkillLocation]] = {
+    val options = List("project", "global", "both")
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("Select scope", options) match {
+        case Completion.Finished(selected) =>
+          selected match {
+            case "project" => List(SkillLocation.Project).asRight
+            case "global" => List(SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+          }
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+    val labels = agentsWithCounts.map { (agent, count) =>
+      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+    }
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
+        case Completion.Finished(selectedLabels) =>
+          val selected = agentsWithCounts
+            .filter { (agent, _) =>
+              selectedLabels.exists(_.contains(agent.toString))
+            }
+            .map { case (agent, _) => agent }
+          selected.asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
       }
     }
   }
@@ -88,9 +172,9 @@ object Remove {
         println(
           s"\u2705 Removed: $skillName (${location.toString.toLowerCase}, ${agent.toString}): $pathLabel".green
         )
-        removed += ((agent, location))
+        removed += agent -> location
       } else {
-        notFound += ((agent, location))
+        notFound += agent -> location
       }
     }
 


### PR DESCRIPTION
# Close #66: Add location and agent selections to the `remove` command's interactive mode

Refactor `removeInteractive()` in the `remove` command to use a 3-step wizard (`scope` -> `agents` -> `skills`) consistent with the `read` and `list` interactive modes.

* Step 1. prompts for scope (`project`/`global`/`both`) via single-choice. If no project skills exist, the scope step is skipped and the user is informed that removal will be from global scope only.
* Step 2. prompts for agent(s) via multi-choice, showing only agents that have skills in the selected scope along with skill counts.
* Step 3. prompts for skill(s) to remove via multi-choice, filtered by the selected scope and agents.

The existing skill selection and removal logic is extracted into a `promptForSkillsAndRemove` helper. Two new private methods `promptForScope` and `promptForAgents` are added following the same patterns used in `Read` and `ListCmd`.

The non-interactive mode (`aiskills remove <name> --agent --project`) remains unchanged.

**After this PR:**

<img width="325" height="172" alt="Screenshot 2026-04-04 at 2 39 24 pm" src="https://github.com/user-attachments/assets/1fcfe607-2def-4aae-969a-b12ae8bee33b" />

<img width="1060" height="202" alt="Screenshot 2026-04-04 at 2 39 40 pm" src="https://github.com/user-attachments/assets/b32112ac-7146-467c-a7e7-e5a080ede5d2" />

<img width="912" height="252" alt="Screenshot 2026-04-04 at 2 39 54 pm" src="https://github.com/user-attachments/assets/45b300b9-58c1-401e-b721-9f2ea868f96f" />
