### PR TITLE
Close #68: Add skill availability checks and path labels to interactive mode

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/InteractiveHelper.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/InteractiveHelper.scala
@@ -1,0 +1,85 @@
+package aiskills.cli.commands
+
+import aiskills.core.{Agent, Skill, SkillLocation}
+import aiskills.core.utils.Dirs
+import cats.syntax.all.*
+import extras.scala.io.syntax.color.*
+
+object InteractiveHelper {
+
+  /** Pure decision: returns Some(location) if only one location has skills, None if both do. */
+  def resolveLocations(allSkills: List[Skill]): Option[SkillLocation] = {
+    val hasProject = allSkills.exists(_.location === SkillLocation.Project)
+    val hasGlobal  = allSkills.exists(_.location === SkillLocation.Global)
+    (hasProject, hasGlobal) match {
+      case (true, false) => SkillLocation.Project.some
+      case (false, true) => SkillLocation.Global.some
+      case _ => none
+    }
+  }
+
+  /** Pure decision: returns Some(agent) if only one agent has skills, None if multiple do. */
+  def resolveAgents(agentsWithCounts: List[(Agent, Int)]): Option[Agent] =
+    agentsWithCounts match {
+      case (agent, _) :: Nil => agent.some
+      case _ => none
+    }
+
+  /** Build colored location path labels for an agent (for println output).
+    * e.g. List("(project, Claude): .claude/skills", "(global, Claude): ~/.claude/skills")
+    */
+  def agentLocationLabels(agent: Agent, locations: List[SkillLocation]): List[String] =
+    locations.sortBy(_.ordinal).map { loc =>
+      s"(${loc.toString.toLowerCase}, ${agent.toString})".blue + s": ${Dirs.displaySkillsDir(agent, loc)}".dim
+    }
+
+  /** Build plain-text location path labels for an agent (for prompt labels).
+    * e.g. List("(project, Claude): .claude/skills", "(global, Claude): ~/.claude/skills")
+    */
+  def agentLocationLabelsPlain(agent: Agent, locations: List[SkillLocation]): List[String] =
+    locations.sortBy(_.ordinal).map { loc =>
+      s"(${loc.toString.toLowerCase}, ${agent.toString}): ${Dirs.displaySkillsDir(agent, loc)}"
+    }
+
+  /** Build an agent label for interactive prompts (plain text, no ANSI colors).
+    * e.g. "Claude          (4 skill(s))  (project, Claude): .claude/skills, (global, Claude): ~/.claude/skills"
+    */
+  def buildAgentLabel(agent: Agent, count: Int, skillsInScope: List[Skill]): String = {
+    val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sortBy(_.ordinal)
+    val pathParts      = agentLocationLabelsPlain(agent, agentLocations)
+    s"${agent.toString.padTo(15, ' ')} ($count skill(s))  ${pathParts.mkString(", ")}"
+  }
+
+  /** Report location resolution result, then delegate to continuation.
+    * If resolved (Some), prints an auto-select message before calling f.
+    * If not resolved (None), calls f directly (caller handles prompting).
+    */
+  def reportLocationResolutionThen[A](verb: String, resolved: Option[SkillLocation])(
+    f: Option[SkillLocation] => A
+  ): A = {
+    resolved match {
+      case Some(SkillLocation.Project) =>
+        println(s"No global skills found. $verb from project scope.".yellow)
+      case Some(SkillLocation.Global) =>
+        println(s"No project skills found. $verb from global scope.".yellow)
+      case None => ()
+    }
+    f(resolved)
+  }
+
+  /** Report agent resolution result, then delegate to continuation.
+    * If resolved (Some), prints an auto-select message and path labels before calling f.
+    * If not resolved (None), calls f directly (caller handles prompting).
+    */
+  def reportAgentResolutionThen[A](
+    resolved: Option[Agent],
+    skillsInScope: List[Skill],
+  )(f: Option[Agent] => A): A = {
+    resolved.foreach { agent =>
+      println(s"Only ${agent.toString} has skills. Auto-selecting ${agent.toString}.".yellow)
+      val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sortBy(_.ordinal)
+      agentLocationLabels(agent, agentLocations).foreach(println)
+    }
+    f(resolved)
+  }
+}

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -45,7 +45,12 @@ object ListCmd {
       println(s"  ${"aiskills install owner/skill --agent all".cyan}              ${"# Project, all agents".dim}")
       println(s"  ${"aiskills install owner/skill --global".cyan}                ${"# Global".dim}")
     } else {
-      promptForScope() match {
+      val locationsResult: Either[Int, List[SkillLocation]] =
+        InteractiveHelper.reportLocationResolutionThen("Listing", InteractiveHelper.resolveLocations(allSkills)) {
+          case Some(location) => List(location).asRight
+          case None => promptForScope()
+        }
+      locationsResult match {
         case Left(code) => sys.exit(code)
         case Right(locations) =>
           val skillsInScope = allSkills.filter(s => locations.contains(s.location))
@@ -61,7 +66,15 @@ object ListCmd {
                 if count > 0 then (agent, count).some else none
               }
 
-            promptForAgents(agentsWithCounts) match {
+            val agentsResult: Either[Int, List[Agent]] =
+              InteractiveHelper.reportAgentResolutionThen(
+                InteractiveHelper.resolveAgents(agentsWithCounts),
+                skillsInScope
+              ) {
+                case Some(agent) => List(agent).asRight
+                case None => promptForAgents(agentsWithCounts, skillsInScope)
+              }
+            agentsResult match {
               case Left(code) => sys.exit(code)
               case Right(selectedAgents) =>
                 if selectedAgents.isEmpty then println("No agents selected.".yellow)
@@ -97,9 +110,12 @@ object ListCmd {
     }
   }
 
-  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+  private def promptForAgents(
+    agentsWithCounts: List[(Agent, Int)],
+    skillsInScope: List[Skill]
+  ): Either[Int, List[Agent]] = {
     val labels = agentsWithCounts.map { (agent, count) =>
-      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+      InteractiveHelper.buildAgentLabel(agent, count, skillsInScope)
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -28,7 +28,7 @@ object Read {
       val missing  = List.newBuilder[String]
 
       for name <- names do {
-        val found = (for {
+        val found = for {
           agent    <- agents
           location <- locations
           skillPath = Dirs.getSkillsDir(agent, location) / name / "SKILL.md"
@@ -39,7 +39,7 @@ object Read {
           source = skillPath / os.up / os.up,
           agent = agent,
           location = location,
-        ))
+        )
 
         if found.isEmpty then missing += name
         else found.foreach(skill => resolved += name -> skill)
@@ -90,7 +90,12 @@ object Read {
       println("Install skills:")
       println(s"  ${"aiskills install anthropics/skills".cyan}   ${"# Install from GitHub".dim}")
     } else {
-      promptForScope() match {
+      val locationsResult: Either[Int, List[SkillLocation]] =
+        InteractiveHelper.reportLocationResolutionThen("Reading", InteractiveHelper.resolveLocations(allSkills)) {
+          case Some(location) => List(location).asRight
+          case None => promptForScope()
+        }
+      locationsResult match {
         case Left(code) => sys.exit(code)
         case Right(locations) =>
           val skillsInScope = allSkills.filter(s => locations.contains(s.location))
@@ -106,7 +111,15 @@ object Read {
                 if count > 0 then (agent, count).some else none
               }
 
-            promptForAgents(agentsWithCounts) match {
+            val agentsResult: Either[Int, List[Agent]] =
+              InteractiveHelper.reportAgentResolutionThen(
+                InteractiveHelper.resolveAgents(agentsWithCounts),
+                skillsInScope
+              ) {
+                case Some(agent) => List(agent).asRight
+                case None => promptForAgents(agentsWithCounts, skillsInScope)
+              }
+            agentsResult match {
               case Left(code) => sys.exit(code)
               case Right(selectedAgents) =>
                 if selectedAgents.isEmpty then println("No agents selected.".yellow)
@@ -161,9 +174,12 @@ object Read {
     }
   }
 
-  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+  private def promptForAgents(
+    agentsWithCounts: List[(Agent, Int)],
+    skillsInScope: List[Skill]
+  ): Either[Int, List[Agent]] = {
     val labels = agentsWithCounts.map { (agent, count) =>
-      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+      InteractiveHelper.buildAgentLabel(agent, count, skillsInScope)
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -15,13 +15,10 @@ object Remove {
 
     if allSkills.isEmpty then println("No skills installed.")
     else {
-      val hasProjectSkills = allSkills.exists(_.location === SkillLocation.Project)
-
       val locationsResult: Either[Int, List[SkillLocation]] =
-        if hasProjectSkills then promptForScope()
-        else {
-          println("No project skills found. Removing from global scope.".yellow)
-          List(SkillLocation.Global).asRight
+        InteractiveHelper.reportLocationResolutionThen("Removing", InteractiveHelper.resolveLocations(allSkills)) {
+          case Some(location) => List(location).asRight
+          case None => promptForScope()
         }
 
       locationsResult match {
@@ -38,7 +35,15 @@ object Remove {
               if count > 0 then (agent, count).some else none
             }
 
-            promptForAgents(agentsWithCounts) match {
+            val agentsResult: Either[Int, List[Agent]] =
+              InteractiveHelper.reportAgentResolutionThen(
+                InteractiveHelper.resolveAgents(agentsWithCounts),
+                skillsInScope
+              ) {
+                case Some(agent) => List(agent).asRight
+                case None => promptForAgents(agentsWithCounts, skillsInScope)
+              }
+            agentsResult match {
               case Left(code) => sys.exit(code)
               case Right(selectedAgents) =>
                 if selectedAgents.isEmpty then println("No agents selected.".yellow)
@@ -126,9 +131,12 @@ object Remove {
     }
   }
 
-  private def promptForAgents(agentsWithCounts: List[(Agent, Int)]): Either[Int, List[Agent]] = {
+  private def promptForAgents(
+    agentsWithCounts: List[(Agent, Int)],
+    skillsInScope: List[Skill]
+  ): Either[Int, List[Agent]] = {
     val labels = agentsWithCounts.map { (agent, count) =>
-      s"${agent.toString.padTo(15, ' ')} ($count skill(s))"
+      InteractiveHelper.buildAgentLabel(agent, count, skillsInScope)
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -270,60 +270,73 @@ object Sync {
       println(s"  ${"aiskills install anthropics/skills".cyan}")
     } else {
       // Step 1: Pick source location
-      val sourceLocation = {
-        val options = List("project", "global")
-        aiskills.cli.SigintHandler.install()
-        val result  = Prompts.sync.use { prompts =>
-          prompts.singleChoice("Select source location", options) match {
-            case Completion.Finished(selected) =>
-              selected match {
-                case "project" => SkillLocation.Project.asRight
-                case _ => SkillLocation.Global.asRight
+      val sourceLocation: SkillLocation =
+        InteractiveHelper.reportLocationResolutionThen("Syncing", InteractiveHelper.resolveLocations(allSkills)) {
+          case Some(location) => location
+          case None =>
+            val options = List("project", "global")
+            aiskills.cli.SigintHandler.install()
+            val result  = Prompts.sync.use { prompts =>
+              prompts.singleChoice("Select source location", options) match {
+                case Completion.Finished(selected) =>
+                  selected match {
+                    case "project" => SkillLocation.Project.asRight
+                    case _ => SkillLocation.Global.asRight
+                  }
+                case Completion.Fail(CompletionError.Interrupted) =>
+                  println("\n\nCancelled by user".yellow)
+                  0.asLeft
+                case Completion.Fail(CompletionError.Error(msg)) =>
+                  System.err.println(s"Error: $msg")
+                  1.asLeft
               }
-            case Completion.Fail(CompletionError.Interrupted) =>
-              println("\n\nCancelled by user".yellow)
-              0.asLeft
-            case Completion.Fail(CompletionError.Error(msg)) =>
-              System.err.println(s"Error: $msg")
-              1.asLeft
-          }
+            }
+            result match {
+              case Left(code) => sys.exit(code)
+              case Right(v) => v
+            }
         }
-        result match {
-          case Left(code) => sys.exit(code)
-          case Right(v) => v
-        }
-      }
 
       // Step 2: Pick source agent (filtered by source location)
-      val skillsByAgent = allSkills.filter(_.location === sourceLocation).groupBy(_.agent)
-      val agents        = Agent.all.filter(skillsByAgent.contains)
+      val skillsForSource  = allSkills.filter(_.location === sourceLocation)
+      val skillsByAgent    = skillsForSource.groupBy(_.agent)
+      val agentsWithCounts = Agent.all.flatMap { agent =>
+        skillsByAgent.get(agent).map(skills => (agent, skills.length))
+      }
 
-      if agents.isEmpty then println(s"No skills found in ${sourceLocation.toString.toLowerCase} scope.".yellow)
+      if agentsWithCounts.isEmpty then println(
+        s"No skills found in ${sourceLocation.toString.toLowerCase} scope.".yellow
+      )
       else {
-        val agentLabels = agents.map { a =>
-          val count = skillsByAgent(a).length
-          s"${a.toString.padTo(15, ' ')} ($count skill(s))"
-        }
+        val sourceAgent: Option[Agent] =
+          InteractiveHelper.reportAgentResolutionThen(
+            InteractiveHelper.resolveAgents(agentsWithCounts),
+            skillsForSource
+          ) {
+            case Some(agent) => agent.some
+            case None =>
+              val agentLabels = agentsWithCounts.map { (a, count) =>
+                InteractiveHelper.buildAgentLabel(a, count, skillsForSource)
+              }
+              aiskills.cli.SigintHandler.install()
 
-        val sourceAgent = {
-          aiskills.cli.SigintHandler.install()
-          val result = Prompts.sync.use { prompts =>
-            prompts.singleChoice("Select source agent", agentLabels) match {
-              case Completion.Finished(selectedLabel) =>
-                agents.find(a => selectedLabel.contains(a.toString)).asRight
-              case Completion.Fail(CompletionError.Interrupted) =>
-                println("\n\nCancelled by user".yellow)
-                0.asLeft
-              case Completion.Fail(CompletionError.Error(msg)) =>
-                System.err.println(s"Error: $msg")
-                1.asLeft
-            }
+              val result = Prompts.sync.use { prompts =>
+                prompts.singleChoice("Select source agent", agentLabels) match {
+                  case Completion.Finished(selectedLabel) =>
+                    agentsWithCounts.map(_._1).find(a => selectedLabel.contains(a.toString)).asRight
+                  case Completion.Fail(CompletionError.Interrupted) =>
+                    println("\n\nCancelled by user".yellow)
+                    0.asLeft
+                  case Completion.Fail(CompletionError.Error(msg)) =>
+                    System.err.println(s"Error: $msg")
+                    1.asLeft
+                }
+              }
+              result match {
+                case Left(code) => sys.exit(code)
+                case Right(v) => v
+              }
           }
-          result match {
-            case Left(code) => sys.exit(code)
-            case Right(v) => v
-          }
-        }
 
         sourceAgent match {
           case None =>

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InteractiveHelperSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InteractiveHelperSpec.scala
@@ -1,0 +1,209 @@
+package aiskills.cli.commands
+
+import aiskills.core.{Agent, Skill, SkillLocation}
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+
+object InteractiveHelperSpec extends Properties {
+
+  private val dummyPath = os.pwd / "test"
+
+  private def skill(name: String, location: SkillLocation, agent: Agent): Skill =
+    Skill(
+      name = name,
+      description = s"$name description",
+      location = location,
+      agent = agent,
+      path = dummyPath / name,
+    )
+
+  override def tests: List[Test] = List(
+    // resolveLocations
+    example("resolveLocations: only project skills returns Some(Project)", testResolveLocationsOnlyProject),
+    example("resolveLocations: only global skills returns Some(Global)", testResolveLocationsOnlyGlobal),
+    example("resolveLocations: both project and global returns None", testResolveLocationsBoth),
+    example("resolveLocations: empty list returns None", testResolveLocationsEmpty),
+    // resolveAgents
+    example("resolveAgents: single agent returns Some(agent)", testResolveAgentsSingle),
+    example("resolveAgents: multiple agents returns None", testResolveAgentsMultiple),
+    example("resolveAgents: empty list returns None", testResolveAgentsEmpty),
+    // agentLocationLabelsPlain
+    example("agentLocationLabelsPlain: single project location", testPlainLabelsSingleProject),
+    example("agentLocationLabelsPlain: single global location", testPlainLabelsSingleGlobal),
+    example("agentLocationLabelsPlain: both locations sorted project-first", testPlainLabelsBothSorted),
+    example("agentLocationLabelsPlain: both locations sorted even if input is reversed", testPlainLabelsBothReversed),
+    // buildAgentLabel
+    example("buildAgentLabel: single location", testBuildAgentLabelSingleLocation),
+    example("buildAgentLabel: multiple locations", testBuildAgentLabelMultipleLocations),
+    example("buildAgentLabel: agent with skills in one of two locations", testBuildAgentLabelPartialLocations),
+    // reportLocationResolutionThen
+    example("reportLocationResolutionThen: Some passes resolved to continuation", testReportLocationSome),
+    example("reportLocationResolutionThen: None passes None to continuation", testReportLocationNone),
+    // reportAgentResolutionThen
+    example("reportAgentResolutionThen: Some passes resolved to continuation", testReportAgentSome),
+    example("reportAgentResolutionThen: None passes None to continuation", testReportAgentNone),
+  )
+
+  // resolveLocations tests
+
+  private def testResolveLocationsOnlyProject: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Project, Agent.Claude),
+      skill("s2", SkillLocation.Project, Agent.Cursor),
+    )
+    InteractiveHelper.resolveLocations(skills) ==== Some(SkillLocation.Project)
+  }
+
+  private def testResolveLocationsOnlyGlobal: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Global, Agent.Claude),
+    )
+    InteractiveHelper.resolveLocations(skills) ==== Some(SkillLocation.Global)
+  }
+
+  private def testResolveLocationsBoth: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Project, Agent.Claude),
+      skill("s2", SkillLocation.Global, Agent.Claude),
+    )
+    InteractiveHelper.resolveLocations(skills) ==== None
+  }
+
+  private def testResolveLocationsEmpty: Result =
+    InteractiveHelper.resolveLocations(Nil) ==== None
+
+  // resolveAgents tests
+
+  private def testResolveAgentsSingle: Result = {
+    val agentsWithCounts = List((Agent.Claude, 3))
+    InteractiveHelper.resolveAgents(agentsWithCounts) ==== Some(Agent.Claude)
+  }
+
+  private def testResolveAgentsMultiple: Result = {
+    val agentsWithCounts = List((Agent.Claude, 3), (Agent.Cursor, 2))
+    InteractiveHelper.resolveAgents(agentsWithCounts) ==== None
+  }
+
+  private def testResolveAgentsEmpty: Result =
+    InteractiveHelper.resolveAgents(Nil) ==== None
+
+  // agentLocationLabelsPlain tests
+
+  private def testPlainLabelsSingleProject: Result = {
+    val labels = InteractiveHelper.agentLocationLabelsPlain(Agent.Claude, List(SkillLocation.Project))
+    Result.all(
+      List(
+        labels.length ==== 1,
+        labels.head ==== "(project, Claude): .claude/skills",
+      )
+    )
+  }
+
+  private def testPlainLabelsSingleGlobal: Result = {
+    val labels = InteractiveHelper.agentLocationLabelsPlain(Agent.Claude, List(SkillLocation.Global))
+    Result.all(
+      List(
+        labels.length ==== 1,
+        labels.head ==== "(global, Claude): ~/.claude/skills",
+      )
+    )
+  }
+
+  private def testPlainLabelsBothSorted: Result = {
+    val labels = InteractiveHelper.agentLocationLabelsPlain(
+      Agent.Claude,
+      List(SkillLocation.Project, SkillLocation.Global),
+    )
+    Result.all(
+      List(
+        labels.length ==== 2,
+        labels(0) ==== "(project, Claude): .claude/skills",
+        labels(1) ==== "(global, Claude): ~/.claude/skills",
+      )
+    )
+  }
+
+  private def testPlainLabelsBothReversed: Result = {
+    val labels = InteractiveHelper.agentLocationLabelsPlain(
+      Agent.Claude,
+      List(SkillLocation.Global, SkillLocation.Project),
+    )
+    Result.all(
+      List(
+        labels.length ==== 2,
+        labels(0) ==== "(project, Claude): .claude/skills",
+        labels(1) ==== "(global, Claude): ~/.claude/skills",
+      )
+    )
+  }
+
+  // buildAgentLabel tests
+
+  private def testBuildAgentLabelSingleLocation: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Project, Agent.Claude),
+      skill("s2", SkillLocation.Project, Agent.Claude),
+    )
+    val label  = InteractiveHelper.buildAgentLabel(Agent.Claude, 2, skills)
+    label ==== "Claude          (2 skill(s))  (project, Claude): .claude/skills"
+  }
+
+  private def testBuildAgentLabelMultipleLocations: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Project, Agent.Claude),
+      skill("s2", SkillLocation.Global, Agent.Claude),
+      skill("s3", SkillLocation.Project, Agent.Claude),
+    )
+    val label  = InteractiveHelper.buildAgentLabel(Agent.Claude, 3, skills)
+    label ==== "Claude          (3 skill(s))  (project, Claude): .claude/skills, (global, Claude): ~/.claude/skills"
+  }
+
+  private def testBuildAgentLabelPartialLocations: Result = {
+    val skills = List(
+      skill("s1", SkillLocation.Global, Agent.Cursor),
+      skill("s2", SkillLocation.Project, Agent.Claude),
+    )
+    val label  = InteractiveHelper.buildAgentLabel(Agent.Cursor, 1, skills)
+    label ==== "Cursor          (1 skill(s))  (global, Cursor): ~/.cursor/skills"
+  }
+
+  // reportLocationResolutionThen tests
+
+  private def testReportLocationSome: Result = {
+    val resolved = SkillLocation.Project.some
+    val result   = InteractiveHelper.reportLocationResolutionThen("Testing", resolved) {
+      case Some(loc) => loc.toString
+      case None => "none"
+    }
+    result ==== "Project"
+  }
+
+  private def testReportLocationNone: Result = {
+    val result = InteractiveHelper.reportLocationResolutionThen("Testing", none[SkillLocation]) {
+      case Some(loc) => loc.toString
+      case None => "none"
+    }
+    result ==== "none"
+  }
+
+  // reportAgentResolutionThen tests
+
+  private def testReportAgentSome: Result = {
+    val skills   = List(skill("s1", SkillLocation.Project, Agent.Claude))
+    val resolved = Agent.Claude.some
+    val result   = InteractiveHelper.reportAgentResolutionThen(resolved, skills) {
+      case Some(agent) => agent.toString
+      case None => "none"
+    }
+    result ==== "Claude"
+  }
+
+  private def testReportAgentNone: Result = {
+    val result = InteractiveHelper.reportAgentResolutionThen(none[Agent], Nil) {
+      case Some(agent) => agent.toString
+      case None => "none"
+    }
+    result ==== "none"
+  }
+}


### PR DESCRIPTION
# Close #68: Add skill availability checks and path labels to interactive mode

Extract shared `InteractiveHelper` with pure decision logic (`resolveLocations`, `resolveAgents`) and reporting helpers (`reportLocationResolutionThen`, `reportAgentResolutionThen`) to reduce duplicated prompting across commands.

- Auto-select location when skills exist in only one scope (`project` or `global`), skipping the location prompt and informing the user
- Auto-select agent when only one agent has skills, skipping the agent prompt and showing `(location, agent): path` labels
- Add `(location, agent): path` labels to agent selection prompts in all interactive commands (`list`, `read`, `remove`, `sync`) so users can see where each agent's skills are located
- Separate colored labels (for println) from plain-text labels (for cue4s prompts) to avoid fansi ANSI parsing errors
- Apply symmetric location checks to `remove` (previously only checked for missing project skills, not missing global skills)