### PR TITLE
Fix #70: Multi-line skill description is not displayed properly

### DIFF
--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
@@ -7,12 +7,41 @@ object Yaml {
   private val fieldPattern: String => Regex =
     field => s"""(?m)^${Regex.quote(field)}:\\s*(.+?)$$""".r
 
+  private val blockScalarIndicator: Regex = """^([>|])[-+]?$""".r
+
   /** Extract a single field value from YAML frontmatter. */
   def extractYamlField(content: String, field: String): String =
     fieldPattern(field).findFirstMatchIn(content) match {
-      case Some(m) => m.group(1).trim
+      case Some(m) =>
+        val value = m.group(1).trim
+        value match {
+          case blockScalarIndicator(indicator) =>
+            extractBlockScalarValue(content, m.end, isFolded = indicator == ">")
+          case _ => value
+        }
       case None => ""
     }
+
+  /** Collect indented continuation lines after a block scalar indicator and join them. */
+  private def extractBlockScalarValue(content: String, matchEnd: Int, isFolded: Boolean): String = {
+    val remaining = content.substring(matchEnd)
+    val lines     = remaining.linesIterator.toList
+
+    val indentedLines = lines
+      .dropWhile(_.trim.isEmpty)
+      .takeWhile(line => line.headOption.exists(_.isWhitespace))
+
+    if indentedLines.isEmpty then ""
+    else {
+      val indent    = indentedLines.head.indexWhere(!_.isWhitespace)
+      val stripped  = indentedLines.map { line =>
+        if line.length >= indent then line.substring(indent)
+        else line.trim
+      }
+      val separator = if isFolded then " " else "\n"
+      stripped.mkString(separator).trim
+    }
+  }
 
   /** Check if content starts with YAML frontmatter delimiter. */
   def hasValidFrontmatter(content: String): Boolean =

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/YamlSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/YamlSpec.scala
@@ -13,6 +13,14 @@ object YamlSpec extends Properties {
     example("extractYamlField: should not be vulnerable to ReDoS patterns", testReDoS),
     example("extractYamlField: should handle special characters in values", testSpecialChars),
     example("extractYamlField: should handle colons in values", testColonsInValues),
+    example("extractYamlField: should handle folded scalar (>)", testFoldedScalar),
+    example("extractYamlField: should handle literal scalar (|)", testLiteralScalar),
+    example("extractYamlField: should handle folded scalar with strip (>-)", testFoldedScalarWithStrip),
+    example("extractYamlField: should stop block scalar at next field", testBlockScalarStopsAtNextField),
+    example(
+      "extractYamlField: should stop block scalar at frontmatter end (---)",
+      testBlockScalarStopsAtFrontmatterEnd
+    ),
     example("hasValidFrontmatter: should return true for valid frontmatter", testValidFrontmatter),
     example("hasValidFrontmatter: should return false for missing frontmatter", testMissingFrontmatter),
     example("hasValidFrontmatter: should return false for empty content", testEmptyContent),
@@ -98,6 +106,78 @@ object YamlSpec extends Properties {
 
     val desc = Yaml.extractYamlField(content, "description")
     Result.assert(desc.contains("URL:"))
+  }
+
+  private def testFoldedScalar: Result = {
+    val content =
+      """---
+        |name: 2020-hindsight-scala
+        |description: >
+        |  Refactor Scala code and apply good practices from 2020 Hindsight Scala.
+        |  Use this skill whenever writing new Scala code, reviewing Scala code,
+        |  or refactoring existing Scala code.
+        |---
+        |
+        |Content""".stripMargin
+
+    Yaml.extractYamlField(content, "description") ====
+      "Refactor Scala code and apply good practices from 2020 Hindsight Scala. Use this skill whenever writing new Scala code, reviewing Scala code, or refactoring existing Scala code."
+  }
+
+  private def testLiteralScalar: Result = {
+    val content =
+      """---
+        |name: my-skill
+        |description: |
+        |  Line one.
+        |  Line two.
+        |  Line three.
+        |---""".stripMargin
+
+    Yaml.extractYamlField(content, "description") ==== "Line one.\nLine two.\nLine three."
+  }
+
+  private def testFoldedScalarWithStrip: Result = {
+    val content =
+      """---
+        |name: my-skill
+        |description: >-
+        |  Folded with strip indicator.
+        |  Second line here.
+        |---""".stripMargin
+
+    Yaml.extractYamlField(content, "description") ==== "Folded with strip indicator. Second line here."
+  }
+
+  private def testBlockScalarStopsAtNextField: Result = {
+    val content =
+      """---
+        |name: my-skill
+        |description: >
+        |  First line of description.
+        |  Second line of description.
+        |context: some-context
+        |---""".stripMargin
+
+    Result.all(
+      List(
+        Yaml.extractYamlField(content, "description") ==== "First line of description. Second line of description.",
+        Yaml.extractYamlField(content, "context") ==== "some-context",
+      )
+    )
+  }
+
+  private def testBlockScalarStopsAtFrontmatterEnd: Result = {
+    val content =
+      """---
+        |name: my-skill
+        |description: >
+        |  Description before frontmatter end.
+        |---
+        |
+        |Body content here.""".stripMargin
+
+    Yaml.extractYamlField(content, "description") ==== "Description before frontmatter end."
   }
 
   private def testValidFrontmatter: Result = {


### PR DESCRIPTION
# Fix #70: Multi-line skill description is not displayed properly

Fix YAML multi-line scalar parsing for `>` and `|` block indicators

`extractYamlField` used a single-line regex that only captured the value on the same line as the field name. When SKILL.md used YAML folded scalar (`>`) or literal scalar (`|`) syntax for `description`, the method returned just the indicator character instead of the actual multi-line content. This caused skill listings to display truncated descriptions like
`2020-hindsight-scala      >`.

Add `blockScalarIndicator` regex to detect `>`, `|`, `>-`, `|-`, `>+`, and `|+` indicators. When detected, the new `extractBlockScalarValue` method collects subsequent indented continuation lines, strips common leading indentation, and joins them with spaces (folded `>`) or newlines (literal `|`).

Add 5 new test cases covering folded scalar, literal scalar, folded with strip indicator, block scalar stopping at the next YAML field, and block scalar stopping at the frontmatter end delimiter (`---`).