### PR TITLE
ai-skills v2.1.0

### DIFF
--- a/changelogs/2.1.0.md
+++ b/changelogs/2.1.0.md
@@ -1,0 +1,82 @@
+## [2.1.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am5) - 2026-04-04 🥚
+
+## Improvement
+
+### Increase `MultipleChoice` window size from 10 to 20 (#62)
+
+The current multiple-choice shows only up to 10 items.
+
+<img width="776" height="629" alt="Image" src="https://github.com/user-attachments/assets/73b6dda6-5e40-45d3-8556-d2c66246c275" />
+
+This release increases it to 20 items.
+
+<img width="540" height="642" alt="multiple-choice-20" src="https://github.com/user-attachments/assets/5d175164-3aa1-4f51-bff8-e56d5dd95471" />
+
+***
+
+### Command `read`: Make the separator of each skill more noticeable (#64)
+
+**The current one:**
+
+<img width="1052" height="657" alt="Screenshot 2026-04-03 at 3 15 09 pm" src="https://github.com/user-attachments/assets/bc687448-ba29-47ef-8c4a-7f10bf7efa38" />
+
+**This relase:**
+
+<img width="1051" height="699" alt="Screenshot 2026-04-03 at 3 15 26 pm" src="https://github.com/user-attachments/assets/15a03114-119e-419b-8237-b260ac1c5a34" />
+
+
+***
+
+### Add location and agent selections to the `remove` command's interactive mode (#66)
+
+The current `remove` shows all skills found, like below.
+
+<img width="874" height="360" alt="Image" src="https://github.com/user-attachments/assets/e318572b-aa2e-43de-a541-6016dfbb47c0" />
+
+It would be convenient to have location and agent selection options.
+
+After this release, it shows like below.
+
+<img width="325" height="172" alt="Screenshot 2026-04-04 at 2 39 24 pm" src="https://github.com/user-attachments/assets/1fcfe607-2def-4aae-969a-b12ae8bee33b" />
+
+<img width="1060" height="202" alt="Screenshot 2026-04-04 at 2 39 40 pm" src="https://github.com/user-attachments/assets/b32112ac-7146-467c-a7e7-e5a080ede5d2" />
+
+<img width="912" height="252" alt="Screenshot 2026-04-04 at 2 39 54 pm" src="https://github.com/user-attachments/assets/45b300b9-58c1-401e-b721-9f2ea868f96f" />
+
+
+***
+
+### Change the behavior of location and agent selection in the interactive modes of `list`, `read`, `sync` commands to match the `remove` command's behavior (#68)
+
+So, it should check the skill availability to decide what to ask.
+
+
+## Bug Fixed
+
+### Fixed: Multi-line skill description is not displayed properly (#70)
+
+When the `description` in `SKILL.md` has `>` or `|` with multple lines of the description content, it shouls `>` or `|`.
+
+> YAML Block Scalars: `>` (Folded) and `|` (Literal)
+
+e.g.) If `SKILL.md` has
+```markdown
+---
+name: 2020-hindsight-scala
+description: >
+  Refactor Scala code and apply good practices from 2020 Hindsight Scala (https://2020-hindsight-scala.kevinly.dev/docs/).
+  Use this skill whenever writing new Scala code, reviewing Scala code, or refactoring existing Scala code.
+  Also trigger when the user mentions Scala best practices, ADTs, type safety, Option/Either usage,
+  or asks to clean up / improve Scala code quality. This skill applies even if the user doesn't
+  explicitly mention "2020 hindsight" — any Scala code writing or refactoring should follow these practices.
+---
+```
+It shows like
+```
+ ◉ 2020-hindsight-scala      >
+```
+
+After this release, it shows like
+```
+ ◉ 2020-hindsight-scala      Refactor Scala code and apply good practices from 2020 Hindsight Scala (https://2020-hindsight-scala.kevinly.dev/docs/). Us...
+```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0"
+ThisBuild / version := "2.1.0"


### PR DESCRIPTION
# ai-skills v2.1.0
## [2.1.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am5) - 2026-04-04 🥚

## Improvement

### Increase `MultipleChoice` window size from 10 to 20 (#62)

The current multiple-choice shows only up to 10 items.

<img width="776" height="629" alt="Image" src="https://github.com/user-attachments/assets/73b6dda6-5e40-45d3-8556-d2c66246c275" />

This release increases it to 20 items.

<img width="540" height="642" alt="multiple-choice-20" src="https://github.com/user-attachments/assets/5d175164-3aa1-4f51-bff8-e56d5dd95471" />

***

### Command `read`: Make the separator of each skill more noticeable (#64)

**The current one:**

<img width="1052" height="657" alt="Screenshot 2026-04-03 at 3 15 09 pm" src="https://github.com/user-attachments/assets/bc687448-ba29-47ef-8c4a-7f10bf7efa38" />

**This relase:**

<img width="1051" height="699" alt="Screenshot 2026-04-03 at 3 15 26 pm" src="https://github.com/user-attachments/assets/15a03114-119e-419b-8237-b260ac1c5a34" />


***

### Add location and agent selections to the `remove` command's interactive mode (#66)

The current `remove` shows all skills found, like below.

<img width="874" height="360" alt="Image" src="https://github.com/user-attachments/assets/e318572b-aa2e-43de-a541-6016dfbb47c0" />

It would be convenient to have location and agent selection options.

After this release, it shows like below.

<img width="325" height="172" alt="Screenshot 2026-04-04 at 2 39 24 pm" src="https://github.com/user-attachments/assets/1fcfe607-2def-4aae-969a-b12ae8bee33b" />

<img width="1060" height="202" alt="Screenshot 2026-04-04 at 2 39 40 pm" src="https://github.com/user-attachments/assets/b32112ac-7146-467c-a7e7-e5a080ede5d2" />

<img width="912" height="252" alt="Screenshot 2026-04-04 at 2 39 54 pm" src="https://github.com/user-attachments/assets/45b300b9-58c1-401e-b721-9f2ea868f96f" />


***

### Change the behavior of location and agent selection in the interactive modes of `list`, `read`, `sync` commands to match the `remove` command's behavior (#68)

So, it should check the skill availability to decide what to ask.


## Bug Fixed

### Fixed: Multi-line skill description is not displayed properly (#70)

When the `description` in `SKILL.md` has `>` or `|` with multple lines of the description content, it shouls `>` or `|`.

> YAML Block Scalars: `>` (Folded) and `|` (Literal)

e.g.) If `SKILL.md` has
```markdown
---
name: 2020-hindsight-scala
description: >
  Refactor Scala code and apply good practices from 2020 Hindsight Scala (https://2020-hindsight-scala.kevinly.dev/docs/).
  Use this skill whenever writing new Scala code, reviewing Scala code, or refactoring existing Scala code.
  Also trigger when the user mentions Scala best practices, ADTs, type safety, Option/Either usage,
  or asks to clean up / improve Scala code quality. This skill applies even if the user doesn't
  explicitly mention "2020 hindsight" — any Scala code writing or refactoring should follow these practices.
---
```
It shows like
```
 ◉ 2020-hindsight-scala      >
```

After this release, it shows like
```
 ◉ 2020-hindsight-scala      Refactor Scala code and apply good practices from 2020 Hindsight Scala (https://2020-hindsight-scala.kevinly.dev/docs/). Us...
```
