### PR TITLE
Close #75: Auto-fallback to SSH when HTTPS clone fails for GitHub shorthand

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -29,6 +29,44 @@ object Install {
       source.startsWith("https://") ||
       source.endsWith(".git")
 
+  /** Check if the URL is a GitHub HTTPS URL. */
+  def isGitHubHttpsUrl(url: String): Boolean =
+    url.startsWith("https://github.com/")
+
+  /** Convert a GitHub HTTPS URL to the equivalent SSH URL. */
+  def gitHubHttpsToSsh(url: String): String = {
+    val path = url.stripPrefix("https://github.com/").stripSuffix("/").stripSuffix(".git")
+    s"git@github.com:$path.git"
+  }
+
+  /** Clone a repo, falling back to SSH if the HTTPS GitHub URL fails.
+    *
+    * The HTTPS attempt uses `-c credential.helper=` to disable credential
+    * helpers and `GIT_TERMINAL_PROMPT=0` so the clone fails fast instead
+    * of prompting for a password.
+    *
+    * @return the URL that actually succeeded (may differ from `repoUrl` when fallback was used)
+    */
+  def cloneWithFallback(repoUrl: String, targetPath: String): String = {
+    val noPromptEnv = Map("GIT_TERMINAL_PROMPT" -> "0")
+    Try {
+      os.proc("git", "-c", "credential.helper=", "clone", "--depth", "1", "--quiet", repoUrl, targetPath)
+        .call(stderr = os.Pipe, env = noPromptEnv)
+    } match {
+      case Success(_) => repoUrl
+      case Failure(_) if isGitHubHttpsUrl(repoUrl) =>
+        val sshUrl = gitHubHttpsToSsh(repoUrl)
+        Try {
+          os.proc("git", "clone", "--depth", "1", "--quiet", sshUrl, targetPath)
+            .call(stderr = os.Pipe)
+        } match {
+          case Success(_) => sshUrl
+          case Failure(sshEx) => throw sshEx // scalafix:ok DisableSyntax.throw
+        }
+      case Failure(ex) => throw ex // scalafix:ok DisableSyntax.throw
+    }
+  }
+
   /** Extract the repo name from the git URL. */
   def getRepoName(repoUrl: String): Option[String] = {
     val cleaned = repoUrl.stripSuffix(".git")
@@ -254,15 +292,9 @@ object Install {
     } else {
       val (repoUrl, skillSubpath) = parseGitSource(source)
 
-      val tempDir    = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+      val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
       os.makeDir.all(tempDir)
       aiskills.cli.TempDirCleanup.register(tempDir)
-      val sourceInfo = InstallSourceInfo(
-        source = source,
-        sourceType = SkillSourceType.Git,
-        repoUrl = repoUrl.some,
-        localRoot = none[os.Path],
-      )
 
       val spinner = Spinner.createDefaultSideEffect(
         SpinnerConfig
@@ -272,23 +304,32 @@ object Install {
           .withIndent(2),
       )
       val _       = spinner.start()
-      Try {
-        os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
-          .call(stderr = os.Pipe)
-      } match {
-        case Failure(ex) =>
-          val _   = spinner.fail(Some("Clone failed"))
-          val msg = ex.getMessage
-          if msg.nonEmpty then println(msg.dim) else ()
-          println("\nTip: For private repos, ensure git SSH keys or credentials are configured".yellow)
-          aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
-          aiskills.cli.TempDirCleanup.unregister()
-          throw SkillInstallException(1) // scalafix:ok DisableSyntax.throw
-        case Success(_) =>
-          val _ = spinner.succeed(Some("Repository cloned"))
-      }
 
-      ResolvedSource.Git(tempDir / "repo", repoUrl, skillSubpath, sourceInfo)
+      val actualUrl =
+        Try {
+          cloneWithFallback(repoUrl, (tempDir / "repo").toString)
+        } match {
+          case Failure(ex) =>
+            val _   = spinner.fail(Some("Clone failed"))
+            val msg = ex.getMessage
+            if msg.nonEmpty then println(msg.dim) else ()
+            println("\nTip: For private repos, ensure git SSH keys or credentials are configured".yellow)
+            aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
+            aiskills.cli.TempDirCleanup.unregister()
+            throw SkillInstallException(1) // scalafix:ok DisableSyntax.throw
+          case Success(url) =>
+            val _ = spinner.succeed(Some("Repository cloned"))
+            url
+        }
+
+      val sourceInfo = InstallSourceInfo(
+        source = source,
+        sourceType = SkillSourceType.Git,
+        repoUrl = actualUrl.some,
+        localRoot = none[os.Path],
+      )
+
+      ResolvedSource.Git(tempDir / "repo", actualUrl, skillSubpath, sourceInfo)
     }
   }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -104,8 +104,7 @@ object Update {
                       )
                       val _       = spinner.start()
                       Try {
-                        os.proc("git", "clone", "--depth", "1", "--quiet", repoUrl, (tempDir / "repo").toString)
-                          .call(stderr = os.Pipe)
+                        Install.cloneWithFallback(repoUrl, (tempDir / "repo").toString)
                       } match {
                         case Failure(ex) =>
                           val _   = spinner.fail(Some(s"Clone failed: ${skill.name}"))
@@ -115,7 +114,7 @@ object Update {
                           cloneFailures += skill.name
                           (upd, skp + 1)
 
-                        case Success(_) =>
+                        case Success(actualUrl) =>
                           val repoDir   = tempDir / "repo"
                           val subpath   = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
                           val sourceDir = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
@@ -129,12 +128,13 @@ object Update {
                             (upd, skp + 1)
                           } else {
                             updateSkillFromDir(skill.path, sourceDir)
-                            SkillMetadata.writeSkillMetadata(
-                              skill.path,
-                              meta.copy(installedAt = aiskills.core.utils.isoNow()),
-                            )
-                            val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
-                            val _         = spinner.succeed(
+                            val updatedMeta =
+                              if actualUrl =!= repoUrl
+                              then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
+                              else meta.copy(installedAt = aiskills.core.utils.isoNow())
+                            SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
+                            val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
+                            val _           = spinner.succeed(
                               Some(
                                 s"Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
                               )

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
@@ -44,6 +44,16 @@ object InstallSpec extends Properties {
     // GitHub shorthand parsing
     example("GitHub shorthand: owner/repo", testGithubOwnerRepo),
     example("GitHub shorthand: owner/repo/path", testGithubOwnerRepoPath),
+    // isGitHubHttpsUrl
+    example("isGitHubHttpsUrl: detects GitHub HTTPS URL", testIsGitHubHttpsUrl),
+    example("isGitHubHttpsUrl: detects GitHub HTTPS URL with .git", testIsGitHubHttpsUrlDotGit),
+    example("isGitHubHttpsUrl: rejects non-GitHub HTTPS", testIsGitHubHttpsUrlNotGitLab),
+    example("isGitHubHttpsUrl: rejects SSH URL", testIsGitHubHttpsUrlNotSsh),
+    example("isGitHubHttpsUrl: rejects HTTP URL", testIsGitHubHttpsUrlNotHttp),
+    // gitHubHttpsToSsh
+    example("gitHubHttpsToSsh: converts plain URL", testGitHubHttpsToSshPlain),
+    example("gitHubHttpsToSsh: converts URL with .git", testGitHubHttpsToSshDotGit),
+    example("gitHubHttpsToSsh: converts URL with trailing slash", testGitHubHttpsToSshTrailingSlash),
   )
 
   // isLocalPath tests
@@ -247,4 +257,30 @@ object InstallSpec extends Properties {
       )
     )
   }
+
+  // isGitHubHttpsUrl tests
+  private def testIsGitHubHttpsUrl: Result =
+    Result.assert(Install.isGitHubHttpsUrl("https://github.com/owner/repo"))
+
+  private def testIsGitHubHttpsUrlDotGit: Result =
+    Result.assert(Install.isGitHubHttpsUrl("https://github.com/owner/repo.git"))
+
+  private def testIsGitHubHttpsUrlNotGitLab: Result =
+    Result.assert(!Install.isGitHubHttpsUrl("https://gitlab.com/owner/repo"))
+
+  private def testIsGitHubHttpsUrlNotSsh: Result =
+    Result.assert(!Install.isGitHubHttpsUrl("git@github.com:owner/repo.git"))
+
+  private def testIsGitHubHttpsUrlNotHttp: Result =
+    Result.assert(!Install.isGitHubHttpsUrl("http://github.com/owner/repo"))
+
+  // gitHubHttpsToSsh tests
+  private def testGitHubHttpsToSshPlain: Result =
+    Install.gitHubHttpsToSsh("https://github.com/owner/repo") ==== "git@github.com:owner/repo.git"
+
+  private def testGitHubHttpsToSshDotGit: Result =
+    Install.gitHubHttpsToSsh("https://github.com/owner/repo.git") ==== "git@github.com:owner/repo.git"
+
+  private def testGitHubHttpsToSshTrailingSlash: Result =
+    Install.gitHubHttpsToSsh("https://github.com/owner/repo/") ==== "git@github.com:owner/repo.git"
 }


### PR DESCRIPTION
# Close #75: Auto-fallback to SSH when HTTPS clone fails for GitHub shorthand

When `aiskills install org/repo` is used with a private repo, the HTTPS
clone hangs waiting for a password prompt. This change adds automatic
SSH fallback so `org/repo` just works for private repos without
requiring the user to type the full SSH URL.

The new `cloneWithFallback` method disables credential helpers via
`git -c credential.helper=` and sets `GIT_TERMINAL_PROMPT=0` on the
HTTPS attempt so it fails fast regardless of the user's git credential
configuration, then retries with the equivalent SSH URL
(`git@github.com:org/repo.git`) for GitHub HTTPS URLs. The URL that
actually succeeded is stored in `.aiskills.json` metadata, so future
`aiskills update` operations use the working URL directly.

The fallback is also applied in the `update` command. If the stored
HTTPS URL fails during update, it falls back to SSH and updates the
stored URL in metadata.