### PR TITLE
Refactor tuple mapping in `Sync` command agent selection

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -323,7 +323,10 @@ object Sync {
               val result = Prompts.sync.use { prompts =>
                 prompts.singleChoice("Select source agent", agentLabels) match {
                   case Completion.Finished(selectedLabel) =>
-                    agentsWithCounts.map(_._1).find(a => selectedLabel.contains(a.toString)).asRight
+                    agentsWithCounts
+                      .map { case (agent, _) => agent }
+                      .find(a => selectedLabel.contains(a.toString))
+                      .asRight
                   case Completion.Fail(CompletionError.Interrupted) =>
                     println("\n\nCancelled by user".yellow)
                     0.asLeft


### PR DESCRIPTION
# Refactor tuple mapping in `Sync` command agent selection

Update `agentsWithCounts.map` to use pattern matching (`{ case (agent, _) => agent }`) instead of the `_._1` accessor. This improves code readability in the interactive source agent selection logic within `Sync`.