### PR TITLE
Close #79: Change interactive location order from project-first to global-first

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -142,8 +142,8 @@ object Install {
     val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
     val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
     val locationLabels = List(
-      s"project ($projectPaths)",
       s"global  ($globalPaths)",
+      s"project ($projectPaths)",
     )
 
     aiskills.cli.SigintHandler.install()

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/InteractiveHelper.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/InteractiveHelper.scala
@@ -29,7 +29,7 @@ object InteractiveHelper {
     * e.g. List("(project, Claude): .claude/skills", "(global, Claude): ~/.claude/skills")
     */
   def agentLocationLabels(agent: Agent, locations: List[SkillLocation]): List[String] =
-    locations.sortBy(_.ordinal).map { loc =>
+    locations.sorted.map { loc =>
       s"(${loc.toString.toLowerCase}, ${agent.toString})".blue + s": ${Dirs.displaySkillsDir(agent, loc)}".dim
     }
 
@@ -37,7 +37,7 @@ object InteractiveHelper {
     * e.g. List("(project, Claude): .claude/skills", "(global, Claude): ~/.claude/skills")
     */
   def agentLocationLabelsPlain(agent: Agent, locations: List[SkillLocation]): List[String] =
-    locations.sortBy(_.ordinal).map { loc =>
+    locations.sorted.map { loc =>
       s"(${loc.toString.toLowerCase}, ${agent.toString}): ${Dirs.displaySkillsDir(agent, loc)}"
     }
 
@@ -45,7 +45,7 @@ object InteractiveHelper {
     * e.g. "Claude          (4 skill(s))  (project, Claude): .claude/skills, (global, Claude): ~/.claude/skills"
     */
   def buildAgentLabel(agent: Agent, count: Int, skillsInScope: List[Skill]): String = {
-    val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sortBy(_.ordinal)
+    val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sorted
     val pathParts      = agentLocationLabelsPlain(agent, agentLocations)
     s"${agent.toString.padTo(15, ' ')} ($count skill(s))  ${pathParts.mkString(", ")}"
   }
@@ -77,7 +77,7 @@ object InteractiveHelper {
   )(f: Option[Agent] => A): A = {
     resolved.foreach { agent =>
       println(s"Only ${agent.toString} has skills. Auto-selecting ${agent.toString}.".yellow)
-      val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sortBy(_.ordinal)
+      val agentLocations = skillsInScope.filter(_.agent === agent).map(_.location).distinct.sorted
       agentLocationLabels(agent, agentLocations).foreach(println)
     }
     f(resolved)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -90,7 +90,7 @@ object ListCmd {
   }
 
   private def promptForScope(): Either[Int, List[SkillLocation]] = {
-    val options = List("project", "global", "both")
+    val options = List("global", "project", "both")
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
       prompts.singleChoice("Select scope", options) match {
@@ -98,7 +98,7 @@ object ListCmd {
           selected match {
             case "project" => List(SkillLocation.Project).asRight
             case "global" => List(SkillLocation.Global).asRight
-            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Global, SkillLocation.Project).asRight
           }
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
@@ -150,9 +150,9 @@ object ListCmd {
   private def displaySkills(skills: List[Skill]): Unit = {
     println("Available Skills:\n".bold)
 
-    val sorted = skills.sortBy { s =>
-      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
-    }
+    given Ordering[SkillLocation] = SkillLocation.ordering.reverse
+
+    val sorted = skills.sortBy(s => (s.agent.ordinal, s.location, s.name))
 
     for skill <- sorted do {
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -154,7 +154,7 @@ object Read {
   }
 
   private def promptForScope(): Either[Int, List[SkillLocation]] = {
-    val options = List("project", "global", "both")
+    val options = List("global", "project", "both")
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
       prompts.singleChoice("Select scope", options) match {
@@ -162,7 +162,7 @@ object Read {
           selected match {
             case "project" => List(SkillLocation.Project).asRight
             case "global" => List(SkillLocation.Global).asRight
-            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Global, SkillLocation.Project).asRight
           }
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
@@ -202,9 +202,9 @@ object Read {
   }
 
   private def promptForSkills(skills: List[Skill]): Either[Int, List[Skill]] = {
-    val sorted = skills.sortBy { s =>
-      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
-    }
+    given Ordering[SkillLocation] = SkillLocation.ordering.reverse
+
+    val sorted = skills.sortBy(s => (s.agent.ordinal, s.location, s.name))
 
     val labels = sorted.map { skill =>
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -64,9 +64,9 @@ object Remove {
   }
 
   private def promptForSkillsAndRemove(skills: List[Skill]): Either[Int, Unit] = {
-    val sorted = skills.sortBy { s =>
-      (s.agent.ordinal, if s.location === SkillLocation.Project then 0 else 1, s.name)
-    }
+    given Ordering[SkillLocation] = SkillLocation.ordering.reverse
+
+    val sorted = skills.sortBy(s => (s.agent.ordinal, s.location, s.name))
 
     val labels = sorted.map { skill =>
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
@@ -111,7 +111,7 @@ object Remove {
   }
 
   private def promptForScope(): Either[Int, List[SkillLocation]] = {
-    val options = List("project", "global", "both")
+    val options = List("global", "project", "both")
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
       prompts.singleChoice("Select scope", options) match {
@@ -119,7 +119,7 @@ object Remove {
           selected match {
             case "project" => List(SkillLocation.Project).asRight
             case "global" => List(SkillLocation.Global).asRight
-            case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+            case _ => List(SkillLocation.Global, SkillLocation.Project).asRight
           }
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -274,7 +274,7 @@ object Sync {
         InteractiveHelper.reportLocationResolutionThen("Syncing", InteractiveHelper.resolveLocations(allSkills)) {
           case Some(location) => location
           case None =>
-            val options = List("project", "global")
+            val options = List("global", "project")
             aiskills.cli.SigintHandler.install()
             val result  = Prompts.sync.use { prompts =>
               prompts.singleChoice("Select source location", options) match {
@@ -388,7 +388,7 @@ object Sync {
             else {
               // Step 4: Pick target location
               val targetLocations = {
-                val options = List("project", "global", "both")
+                val options = List("global", "project", "both")
                 aiskills.cli.SigintHandler.install()
                 val result  = Prompts.sync.use { prompts =>
                   prompts.singleChoice("Select target location", options) match {
@@ -396,7 +396,7 @@ object Sync {
                       selected match {
                         case "project" => List(SkillLocation.Project).asRight
                         case "global" => List(SkillLocation.Global).asRight
-                        case _ => List(SkillLocation.Project, SkillLocation.Global).asRight
+                        case _ => List(SkillLocation.Global, SkillLocation.Project).asRight
                       }
                     case Completion.Fail(CompletionError.Interrupted) =>
                       println("\n\nCancelled by user".yellow)

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InteractiveHelperSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InteractiveHelperSpec.scala
@@ -31,8 +31,11 @@ object InteractiveHelperSpec extends Properties {
     // agentLocationLabelsPlain
     example("agentLocationLabelsPlain: single project location", testPlainLabelsSingleProject),
     example("agentLocationLabelsPlain: single global location", testPlainLabelsSingleGlobal),
-    example("agentLocationLabelsPlain: both locations sorted project-first", testPlainLabelsBothSorted),
-    example("agentLocationLabelsPlain: both locations sorted even if input is reversed", testPlainLabelsBothReversed),
+    example("agentLocationLabelsPlain: both locations sorted global-first", testPlainLabelsBothSorted),
+    example(
+      "agentLocationLabelsPlain: both locations sorted even if input is reversed (global-first)",
+      testPlainLabelsBothReversed
+    ),
     // buildAgentLabel
     example("buildAgentLabel: single location", testBuildAgentLabelSingleLocation),
     example("buildAgentLabel: multiple locations", testBuildAgentLabelMultipleLocations),
@@ -118,8 +121,8 @@ object InteractiveHelperSpec extends Properties {
     Result.all(
       List(
         labels.length ==== 2,
-        labels(0) ==== "(project, Claude): .claude/skills",
-        labels(1) ==== "(global, Claude): ~/.claude/skills",
+        labels(0) ==== "(global, Claude): ~/.claude/skills",
+        labels(1) ==== "(project, Claude): .claude/skills",
       )
     )
   }
@@ -132,8 +135,8 @@ object InteractiveHelperSpec extends Properties {
     Result.all(
       List(
         labels.length ==== 2,
-        labels(0) ==== "(project, Claude): .claude/skills",
-        labels(1) ==== "(global, Claude): ~/.claude/skills",
+        labels(0) ==== "(global, Claude): ~/.claude/skills",
+        labels(1) ==== "(project, Claude): .claude/skills",
       )
     )
   }
@@ -156,7 +159,7 @@ object InteractiveHelperSpec extends Properties {
       skill("s3", SkillLocation.Project, Agent.Claude),
     )
     val label  = InteractiveHelper.buildAgentLabel(Agent.Claude, 3, skills)
-    label ==== "Claude          (3 skill(s))  (project, Claude): .claude/skills, (global, Claude): ~/.claude/skills"
+    label ==== "Claude          (3 skill(s))  (global, Claude): ~/.claude/skills, (project, Claude): .claude/skills"
   }
 
   private def testBuildAgentLabelPartialLocations: Result = {

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -50,6 +50,11 @@ object SkillLocation {
     case other => s"Invalid SkillLocation: $other".asLeft
   }
 
+  given ordering: Ordering[SkillLocation] = Ordering.by {
+    case SkillLocation.Project => 1
+    case SkillLocation.Global => 0
+  }
+
   given Encoder[SkillLocation] = Encoder.encodeString.contramap {
     case SkillLocation.Project => "project"
     case SkillLocation.Global => "global"


### PR DESCRIPTION
# Close #79: Change interactive location order from project-first to global-first

Use the new `SkillLocation.ordering` (Global=0, Project=1) to control location order in interactive prompts across all commands. Location selection prompts (`list`, `read`, `remove`, `install`, `sync`) now show `global` before `project`. Location labels in `InteractiveHelper` use `.sorted` instead of `.sortBy(_.ordinal)` to pick up the given `Ordering`.

For skill list/selection sorting (where project-first is desired), use `SkillLocation.ordering.reverse` via a local `given` override, replacing the inline `if s.location === SkillLocation.Project then 0 else 1` pattern in `ListCmd`, `Remove`, and `Read`.

Update `InteractiveHelperSpec` test expectations to match the new global-first label order.