### PR TITLE
Close #81: Improve `update` by updating all the skills from the same repo together

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -43,116 +43,157 @@ object Update {
 
         aiskills.cli.TempDirCleanup.ensureAtexitRegistered()
 
-        val (updated, skipped) = targets.foldLeft((0, 0)) {
-          case ((upd, skp), skill) =>
-            val metadata = SkillMetadata.readSkillMetadata(skill.path)
-            metadata match {
+        // Phase 1: Classify targets by source type
+        val classified = targets.map(skill => (skill, SkillMetadata.readSkillMetadata(skill.path)))
+
+        val (noMeta, withMeta)       = classified.partition { case (_, meta) => meta.isEmpty }
+        val withMetaFlat             = withMeta.collect { case (s, Some(m)) => (s, m) }
+        val (localSkills, gitSkills) =
+          withMetaFlat.partition { case (_, meta) => meta.sourceType === SkillSourceType.Local }
+        val (gitWithUrl, gitNoUrl)   =
+          gitSkills.partition { case (_, meta) => meta.repoUrl.isDefined }
+
+        // Phase 2: Skip skills with no metadata or missing repo URL
+        noMeta.foreach {
+          case (skill, _) =>
+            val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
+            println(
+              s"Skipped: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel (no source metadata; re-install once to enable updates)".yellow
+            )
+            missingMetadata += skill.name
+        }
+
+        gitNoUrl.foreach {
+          case (skill, _) =>
+            println(s"Skipped: ${skill.name} (missing repo URL metadata)".yellow)
+            missingRepoUrl += skill.name
+        }
+
+        // Phase 3: Process local skills individually
+        localSkills.foreach {
+          case (skill, meta) =>
+            val localPath = meta.localPath.map(os.Path(_))
+            localPath match {
               case None =>
+                println(s"Skipped: ${skill.name} (local source missing)".yellow)
+                missingLocalSource += skill.name
+              case Some(lp) if !os.exists(lp) =>
+                println(s"Skipped: ${skill.name} (local source missing)".yellow)
+                missingLocalSource += skill.name
+              case Some(lp) if !os.exists(lp / "SKILL.md") =>
+                println(s"Skipped: ${skill.name} (SKILL.md missing at local source)".yellow)
+                missingLocalSkillFile += skill.name
+              case Some(lp) =>
+                updateSkillFromDir(skill.path, lp)
+                SkillMetadata.writeSkillMetadata(
+                  skill.path,
+                  meta.copy(installedAt = aiskills.core.utils.isoNow()),
+                )
                 val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
                 println(
-                  s"Skipped: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel (no source metadata; re-install once to enable updates)".yellow
+                  s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
                 )
-                missingMetadata += skill.name
-                (upd, skp + 1)
-
-              case Some(meta) if meta.sourceType === SkillSourceType.Local =>
-                val localPath = meta.localPath.map(os.Path(_))
-                localPath match {
-                  case None =>
-                    println(s"Skipped: ${skill.name} (local source missing)".yellow)
-                    missingLocalSource += skill.name
-                    (upd, skp + 1)
-                  case Some(lp) if !os.exists(lp) =>
-                    println(s"Skipped: ${skill.name} (local source missing)".yellow)
-                    missingLocalSource += skill.name
-                    (upd, skp + 1)
-                  case Some(lp) if !os.exists(lp / "SKILL.md") =>
-                    println(s"Skipped: ${skill.name} (SKILL.md missing at local source)".yellow)
-                    missingLocalSkillFile += skill.name
-                    (upd, skp + 1)
-                  case Some(lp) =>
-                    updateSkillFromDir(skill.path, lp)
-                    SkillMetadata.writeSkillMetadata(
-                      skill.path,
-                      meta.copy(installedAt = aiskills.core.utils.isoNow()),
-                    )
-                    val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
-                    println(
-                      s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
-                    )
-                    (upd + 1, skp)
-                }
-
-              case Some(meta) =>
-                meta.repoUrl match {
-                  case None =>
-                    println(s"Skipped: ${skill.name} (missing repo URL metadata)".yellow)
-                    missingRepoUrl += skill.name
-                    (upd, skp + 1)
-
-                  case Some(repoUrl) =>
-                    val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
-                    os.makeDir.all(tempDir)
-                    aiskills.cli.TempDirCleanup.register(tempDir)
-                    try {
-                      val spinner = Spinner.createDefaultSideEffect(
-                        SpinnerConfig
-                          .default
-                          .withText(s"Updating ${skill.name}...")
-                          .withColor(Color.cyan)
-                          .withIndent(2),
-                      )
-                      val _       = spinner.start()
-                      Try {
-                        Install.cloneWithFallback(repoUrl, (tempDir / "repo").toString)
-                      } match {
-                        case Failure(ex) =>
-                          val _   = spinner.fail(Some(s"Clone failed: ${skill.name}"))
-                          val msg = ex.getMessage
-                          if msg.nonEmpty then println(msg.dim) else ()
-                          println(s"Skipped: ${skill.name} (git clone failed)".yellow)
-                          cloneFailures += skill.name
-                          (upd, skp + 1)
-
-                        case Success(actualUrl) =>
-                          val repoDir   = tempDir / "repo"
-                          val subpath   = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
-                          val sourceDir = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
-
-                          if !os.exists(sourceDir / "SKILL.md") then {
-                            val _ = spinner.fail(Some(s"Failed: ${skill.name}"))
-                            println(
-                              s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
-                            )
-                            missingRepoSkillFile += skill.name -> subpath.getOrElse(".")
-                            (upd, skp + 1)
-                          } else {
-                            updateSkillFromDir(skill.path, sourceDir)
-                            val updatedMeta =
-                              if actualUrl =!= repoUrl
-                              then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
-                              else meta.copy(installedAt = aiskills.core.utils.isoNow())
-                            SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
-                            val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
-                            val _           = spinner.succeed(
-                              Some(
-                                s"Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel"
-                              )
-                            )
-                            (upd + 1, skp)
-                          }
-                      }
-                    } finally {
-                      aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
-                      aiskills.cli.TempDirCleanup.unregister()
-                    }
-                }
             }
         }
 
+        // Phase 4: Group git skills by normalized repo URL and clone each repo once
+        if gitWithUrl.nonEmpty then {
+          val groupedByRepo = gitWithUrl.groupBy {
+            case (_, meta) =>
+              meta.repoUrl.fold("")(normalizeRepoUrl)
+          }
+
+          val parentTempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+          os.makeDir.all(parentTempDir)
+          aiskills.cli.TempDirCleanup.register(parentTempDir)
+
+          try {
+            groupedByRepo.iterator.zipWithIndex.foreach {
+              case ((_, groupSkills), idx) =>
+                val (firstSkill, firstMeta) = groupSkills.head
+                val cloneUrl                = firstMeta.repoUrl.getOrElse(firstSkill.name)
+                val repoSubDir              = parentTempDir / s"repo-$idx"
+                os.makeDir.all(repoSubDir)
+                val skillNames              = groupSkills.map { case (skill, _) => skill.name }
+                val skillsLabel             = if skillNames.length > 1 then s" (${skillNames.length} skills)" else ""
+
+                val spinner = Spinner.createDefaultSideEffect(
+                  SpinnerConfig
+                    .default
+                    .withText(s"Cloning ${cloneUrl}${skillsLabel}...")
+                    .withColor(Color.cyan)
+                    .withIndent(2),
+                )
+                val _       = spinner.start()
+
+                Try {
+                  Install.cloneWithFallback(cloneUrl, (repoSubDir / "repo").toString)
+                } match {
+                  case Failure(ex) =>
+                    val _   = spinner.fail(Some(s"Clone failed: $cloneUrl"))
+                    val msg = ex.getMessage
+                    if msg.nonEmpty then println(msg.dim) else ()
+                    groupSkills.foreach {
+                      case (skill, _) =>
+                        println(s"Skipped: ${skill.name} (git clone failed)".yellow)
+                        cloneFailures += skill.name
+                    }
+
+                  case Success(actualUrl) =>
+                    val _       = spinner.succeed(Some(s"Cloned: $cloneUrl$skillsLabel"))
+                    val repoDir = repoSubDir / "repo"
+
+                    groupSkills.foreach {
+                      case (skill, meta) =>
+                        val originalRepoUrl = meta.repoUrl.getOrElse("")
+                        val subpath         = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
+                        val sourceDir       = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
+
+                        if !os.exists(sourceDir / "SKILL.md") then {
+                          println(
+                            s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
+                          )
+                          missingRepoSkillFile += skill.name -> subpath.getOrElse(".")
+                        } else {
+                          updateSkillFromDir(skill.path, sourceDir)
+                          val updatedMeta =
+                            if actualUrl =!= originalRepoUrl
+                            then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
+                            else meta.copy(installedAt = aiskills.core.utils.isoNow())
+                          SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
+                          val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
+                          println(
+                            s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
+                          )
+                        }
+                    }
+                }
+            }
+          } finally {
+            aiskills.cli.TempDirCleanup.safeRemoveAll(parentTempDir)
+            aiskills.cli.TempDirCleanup.unregister()
+          }
+        } else ()
+
+        // Phase 5: Summary
+        val missingMetadataList       = missingMetadata.result()
+        val missingLocalSourceList    = missingLocalSource.result()
+        val missingLocalSkillFileList = missingLocalSkillFile.result()
+        val missingRepoUrlList        = missingRepoUrl.result()
+        val missingRepoSkillFileList  = missingRepoSkillFile.result()
+        val cloneFailuresList         = cloneFailures.result()
+
+        val skipped =
+          missingMetadataList.length +
+            missingLocalSourceList.length +
+            missingLocalSkillFileList.length +
+            missingRepoUrlList.length +
+            missingRepoSkillFileList.length +
+            cloneFailuresList.length
+        val updated = targets.length - skipped
+
         println(s"Summary: $updated updated, $skipped skipped (${targets.length} total)".dim)
 
-        val missingMetadataList = missingMetadata.result()
         if missingMetadataList.nonEmpty then {
           println(
             s"Missing source metadata (${missingMetadataList.length}): ${missingMetadataList.mkString(", ")}".yellow
@@ -160,31 +201,26 @@ object Update {
           println("Re-install these skills once to enable updates (e.g., `aiskills install <source>`).".dim)
         } else ()
 
-        val missingLocalSourceList = missingLocalSource.result()
         if missingLocalSourceList.nonEmpty then println(
           s"Local source missing (${missingLocalSourceList.length}): ${missingLocalSourceList.mkString(", ")}".yellow
         )
         else ()
 
-        val missingLocalSkillFileList = missingLocalSkillFile.result()
         if missingLocalSkillFileList.nonEmpty then println(
           s"Local SKILL.md missing (${missingLocalSkillFileList.length}): ${missingLocalSkillFileList.mkString(", ")}".yellow
         )
         else ()
 
-        val missingRepoUrlList = missingRepoUrl.result()
         if missingRepoUrlList.nonEmpty then println(
           s"Missing repo URL metadata (${missingRepoUrlList.length}): ${missingRepoUrlList.mkString(", ")}".yellow
         )
         else ()
 
-        val missingRepoSkillFileList = missingRepoSkillFile.result()
         if missingRepoSkillFileList.nonEmpty then {
-          val formatted = missingRepoSkillFileList.map((n, s) => s"$n ($s)").mkString(", ")
+          val formatted = missingRepoSkillFileList.map { case (name, sub) => s"$name ($sub)" }.mkString(", ")
           println(s"Repo SKILL.md missing (${missingRepoSkillFileList.length}): $formatted".yellow)
         } else ()
 
-        val cloneFailuresList = cloneFailures.result()
         if cloneFailuresList.nonEmpty then println(
           s"Clone failed (${cloneFailuresList.length}): ${cloneFailuresList.mkString(", ")}".yellow
         )
@@ -208,4 +244,27 @@ object Update {
 
   private def isPathInside(target: os.Path, parent: os.Path): Boolean =
     target.startsWith(parent)
+
+  /** Normalize a Git repository URL to a canonical form for grouping.
+    * Strips protocol, trailing slashes, and .git suffix. Lowercases.
+    * {{{
+    * "https://github.com/owner/repo.git" -> "github.com/owner/repo"
+    * "git@github.com:owner/repo.git"     -> "github.com/owner/repo"
+    * }}}
+    */
+  def normalizeRepoUrl(url: String): String = {
+    val cleaned = url.trim.stripSuffix("/").stripSuffix(".git").toLowerCase
+    if cleaned.startsWith("git@") then {
+      val afterAt  = cleaned.stripPrefix("git@")
+      val colonIdx = afterAt.indexOf(':')
+      if colonIdx > 0 then {
+        val host = afterAt.substring(0, colonIdx)
+        val path = afterAt.substring(colonIdx + 1)
+        s"$host/$path"
+      } else cleaned
+    } else if cleaned.startsWith("https://") then cleaned.stripPrefix("https://")
+    else if cleaned.startsWith("http://") then cleaned.stripPrefix("http://")
+    else if cleaned.startsWith("git://") then cleaned.stripPrefix("git://")
+    else cleaned
+  }
 }

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/UpdateSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/UpdateSpec.scala
@@ -1,0 +1,58 @@
+package aiskills.cli.commands
+
+import hedgehog.*
+import hedgehog.runner.*
+
+object UpdateSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    // normalizeRepoUrl
+    example("normalizeRepoUrl: normalizes HTTPS GitHub URL", testNormalizeHttps),
+    example("normalizeRepoUrl: normalizes HTTPS GitHub URL with .git", testNormalizeHttpsDotGit),
+    example("normalizeRepoUrl: normalizes SSH GitHub URL", testNormalizeSsh),
+    example("normalizeRepoUrl: normalizes SSH GitHub URL without .git", testNormalizeSshNoDotGit),
+    example("normalizeRepoUrl: HTTPS and SSH normalize to the same value", testHttpsSshSame),
+    example("normalizeRepoUrl: normalizes HTTP URL", testNormalizeHttp),
+    example("normalizeRepoUrl: normalizes git:// URL", testNormalizeGitProtocol),
+    example("normalizeRepoUrl: normalizes non-GitHub host", testNormalizeGitLab),
+    example("normalizeRepoUrl: strips trailing slash", testNormalizeTrailingSlash),
+    example("normalizeRepoUrl: lowercases", testNormalizeLowercase),
+    example("normalizeRepoUrl: handles unknown format", testNormalizeUnknown),
+  )
+
+  private def testNormalizeHttps: Result =
+    Update.normalizeRepoUrl("https://github.com/owner/repo") ==== "github.com/owner/repo"
+
+  private def testNormalizeHttpsDotGit: Result =
+    Update.normalizeRepoUrl("https://github.com/owner/repo.git") ==== "github.com/owner/repo"
+
+  private def testNormalizeSsh: Result =
+    Update.normalizeRepoUrl("git@github.com:owner/repo.git") ==== "github.com/owner/repo"
+
+  private def testNormalizeSshNoDotGit: Result =
+    Update.normalizeRepoUrl("git@github.com:owner/repo") ==== "github.com/owner/repo"
+
+  private def testHttpsSshSame: Result = {
+    val https = Update.normalizeRepoUrl("https://github.com/anthropics/skills")
+    val ssh   = Update.normalizeRepoUrl("git@github.com:anthropics/skills.git")
+    https ==== ssh
+  }
+
+  private def testNormalizeHttp: Result =
+    Update.normalizeRepoUrl("http://github.com/owner/repo") ==== "github.com/owner/repo"
+
+  private def testNormalizeGitProtocol: Result =
+    Update.normalizeRepoUrl("git://github.com/owner/repo.git") ==== "github.com/owner/repo"
+
+  private def testNormalizeGitLab: Result =
+    Update.normalizeRepoUrl("https://gitlab.com/group/project") ==== "gitlab.com/group/project"
+
+  private def testNormalizeTrailingSlash: Result =
+    Update.normalizeRepoUrl("https://github.com/owner/repo/") ==== "github.com/owner/repo"
+
+  private def testNormalizeLowercase: Result =
+    Update.normalizeRepoUrl("https://github.com/Owner/Repo") ==== "github.com/owner/repo"
+
+  private def testNormalizeUnknown: Result =
+    Update.normalizeRepoUrl("some-custom-url") ==== "some-custom-url"
+}


### PR DESCRIPTION
# Close #81: Improve `update` by updating all the skills from the same repo together

Group skills by repo URL in `update` to clone each repo once.

Previously, `update` cloned the repository separately for each skill, even when multiple skills came from the same repo. For example, 5 skills from `anthropics/skills` would trigger 5 clones.

Now, all target skills are classified upfront and Git-sourced skills are grouped by a normalized repo URL before cloning. Each unique repository is cloned once into a shared parent temp directory, and all skills from that repo are updated from the single clone.

- Add `normalizeRepoUrl` to canonicalize Git URLs (HTTPS, SSH, git://, HTTP) to a common `host/owner/repo` form, so skills installed via different URL formats (e.g. HTTPS vs SSH fallback) are grouped together
- Restructure `updateSkills` from a single `foldLeft` into a multi-phase approach: classify targets, skip invalid, process local skills, then group and batch-process Git skills
- Use a single parent temp dir (`~/.aiskills-temp-<ts>/`) with per-repo subdirs, compatible with the existing `TempDirCleanup` atexit hook
- When a clone fails, all skills in that repo group are skipped together
- When SSH fallback changes the URL, metadata is updated for each skill comparing against its own original `repoUrl`
- Add `UpdateSpec` with 11 hedgehog tests for `normalizeRepoUrl`