### PR TITLE
ai-skills v2.2.0

### DIFF
--- a/changelogs/2.2.0.md
+++ b/changelogs/2.2.0.md
@@ -1,0 +1,54 @@
+## [2.2.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am6) - 2026-04-05 🥚
+
+## Improvement
+
+### Handle a private repo better in installation (#75)
+
+Skill installation like
+```
+aiskills install org/repo
+```
+fails if `org/repo` is a private repo.
+
+It may ask a user for the password to access the repo, or it may just hang.
+
+After this release, the private repository can be handled better, 
+and `ai-skills` can internally do ssh clone with scp-like syntax (e.g. `git@github.com:org/repo.git`)
+instead of a URL like `https://github.com/org/repo.git`.
+***
+
+### Change the location list order from project-first to global-first (#79)
+
+Current:
+```
+? Select scope ›
+  ‣ project
+    global
+    both
+```
+
+After this release,
+```
+? Select scope ›
+  ‣ global
+    project
+    both
+```
+***
+
+### Improve `update` by updating all the skills from the same repo together (#81)
+
+The current `update` command updates each skill one by one, even when multiple skills are from the same repository. This can be improved by grouping skills from the same repository, cloning the repository once, and then updating the skills together.
+
+After this release, `update` will update all the skills from the same repository together.
+***
+
+
+## Internal Housekeeping
+
+### Update Scala to `3.8.3` (#73)
+
+* Release Note: https://github.com/scala/scala3/releases/tag/3.8.3
+* News: https://www.scala-lang.org/news/3.8.3/
+* Download: https://www.scala-lang.org/download/3.8.3.html
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.1-SNAPSHOT"
+ThisBuild / version := "2.2.0"


### PR DESCRIPTION
# ai-skills v2.2.0
## [2.2.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am6) - 2026-04-05 🥚

## Improvement

### Handle a private repo better in installation (#75)

Skill installation like
```
aiskills install org/repo
```
fails if `org/repo` is a private repo.

It may ask a user for the password to access the repo, or it may just hang.

After this release, the private repository can be handled better, 
and `ai-skills` can internally do ssh clone with scp-like syntax (e.g. `git@github.com:org/repo.git`)
instead of a URL like `https://github.com/org/repo.git`.
***

### Change the location list order from project-first to global-first (#79)

Current:
```
? Select scope ›
  ‣ project
    global
    both
```

After this release,
```
? Select scope ›
  ‣ global
    project
    both
```
***

### Improve `update` by updating all the skills from the same repo together (#81)

The current `update` command updates each skill one by one, even when multiple skills are from the same repository. This can be improved by grouping skills from the same repository, cloning the repository once, and then updating the skills together.

After this release, `update` will update all the skills from the same repository together.
***


## Internal Housekeeping

### Update Scala to `3.8.3` (#73)

* Release Note: https://github.com/scala/scala3/releases/tag/3.8.3
* News: https://www.scala-lang.org/news/3.8.3/
* Download: https://www.scala-lang.org/download/3.8.3.html

