### PR TITLE
Close #95: Support "toggle to `select`/`deselect` all" in multiple selections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val props = new {
 
   val DeclineVersion = "2.6.1"
 
-  val Cue4sVersion = "0.0.10"
+  val Cue4sVersion = "0.0.11"
 
   val ExtrasVersion = "0.51.0"
 


### PR DESCRIPTION
# Close #95: Support "toggle to `select`/`deselect` all" in multiple selections

Now, cue4s supports toggle to `select`/`deselect` all in `MultiChoice` (v0.0.11), so it's bumped to `0.0.11` to support it.

<img width="965" height="654" alt="Toggle to Select/Deselect All 1" src="https://github.com/user-attachments/assets/c27c5248-410a-4eea-9e4e-04ec797a567d" />

<img width="972" height="649" alt="Toggle to Select/Deselect All 2" src="https://github.com/user-attachments/assets/4216e391-382c-44ec-8d9f-0875d8592cb9" />

<img width="982" height="327" alt="Toggle to Select/Deselect All 3" src="https://github.com/user-attachments/assets/4f72f97d-4e74-401c-bc71-00bd2f70c2c2" />

<img width="973" height="331" alt="Toggle to Select/Deselect All 4" src="https://github.com/user-attachments/assets/c541f58a-6e8e-4e45-bf1e-5b39e8f5085c" />

<img width="973" height="648" alt="Toggle to Select/Deselect All 5" src="https://github.com/user-attachments/assets/f468143c-4126-488a-9e10-dbdbddfb3f5e" />
