### PR TITLE
Close #101: Simplify `home` directory in `Base directory` display for `read` command

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -56,9 +56,7 @@ object Read {
         } do {
           val dir   = Dirs.getSkillsDir(agent, location)
           val scope = location.toString.toLowerCase
-          val label =
-            if dir.startsWith(os.home) then dir.toString.replace(os.home.toString, "~")
-            else dir.relativeTo(os.pwd).toString
+          val label = Dirs.displayPath(dir)
           System.err.println(s"  $label ($scope, ${agent.toString})")
         }
         System.err.println()
@@ -71,7 +69,7 @@ object Read {
         if idx > 0 then println(separator)
         val content = os.read(skill.path)
         println("       Reading:".bold + s" ${name.blue.bold}")
-        println("Base directory:".bold + s" ${skill.baseDir.toString.yellow.bold}")
+        println("Base directory:".bold + s" ${Dirs.displayPath(skill.baseDir).yellow.bold}")
 
         println()
         println(content)
@@ -137,7 +135,7 @@ object Read {
                             val skillPath = skill.path / "SKILL.md"
                             val content   = os.read(skillPath)
                             println("       Reading:".bold + s" ${skill.name.blue.bold}")
-                            println("Base directory:".bold + s" ${skill.path.toString.yellow.bold}")
+                            println("Base directory:".bold + s" ${Dirs.displayPath(skill.path).yellow.bold}")
                             println()
                             println(content)
                             println()

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -21,6 +21,12 @@ object Dirs {
       case SkillLocation.Global => s"~/${agent.globalDirName}/skills"
     }
 
+  /** Display-friendly path: replaces home prefix with ~, or shows relative to pwd if possible. */
+  def displayPath(path: os.Path): String =
+    if path.startsWith(os.home) then "~" + path.toString.stripPrefix(os.home.toString)
+    else if path.startsWith(os.pwd) then path.relativeTo(os.pwd).toString
+    else path.toString
+
   /** Get all searchable skill directories in priority order.
     * Priority:
     *   1. Project universal (.agents)

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -27,6 +27,9 @@ object DirsSpec extends Properties {
     example("displaySkillsDir: global Windsurf (asymmetric)", testDisplayGlobalWindsurf),
     example("displaySkillsDir: project Copilot", testDisplayProjectCopilot),
     example("displaySkillsDir: global Copilot (asymmetric)", testDisplayGlobalCopilot),
+    example("displayPath: global path replaces home with ~", testDisplayPathGlobal),
+    example("displayPath: project path shows relative to pwd", testDisplayPathProject),
+    example("displayPath: only replaces home prefix, not duplicates in path", testDisplayPathHomeDuplicate),
     example("getSearchDirs: returns 14 dirs", testSearchDirsCount),
     example("getSearchDirs: correct priority order", testSearchDirsOrder),
     example("getSearchDirs: first is project universal", testSearchDirsFirst),
@@ -88,6 +91,20 @@ object DirsSpec extends Properties {
 
   private def testDisplayGlobalCopilot: Result =
     Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Global) ==== "~/.copilot/skills"
+
+  private def testDisplayPathGlobal: Result =
+    Dirs.displayPath(os.home / ".claude" / "skills" / "foo") ==== "~/.claude/skills/foo"
+
+  private def testDisplayPathProject: Result =
+    Dirs.displayPath(os.root / "tmp" / ".claude" / "skills" / "foo") ==== "/tmp/.claude/skills/foo"
+
+  private def testDisplayPathHomeDuplicate: Result = {
+    val homeStr  = os.home.toString
+    // e.g. /Users/username/blah/Users/username/something/.claude/skills/foo
+    val path     = os.Path(s"$homeStr/blah$homeStr/something/.claude/skills/foo")
+    val expected = s"~/blah$homeStr/something/.claude/skills/foo"
+    Dirs.displayPath(path) ==== expected
+  }
 
   private def testSearchDirsCount: Result = {
     val dirs = Dirs.getSearchDirs()


### PR DESCRIPTION
# Close #101: Simplify `home` directory in `Base directory` display for `read` command

Add `Dirs.displayPath` utility that replaces the home directory prefix with `~` for display-friendly paths. It uses `stripPrefix` instead of `replace` to safely handle only the prefix, avoiding unintended replacements when the home path appears elsewhere in the path (e.g. `/Users/foo/blah/Users/foo/...`).

Replace the inline home-simplification logic and raw `toString` calls in `Read` (error "Searched:" block, non-interactive and interactive "Base directory" output) with the new `Dirs.displayPath`.

Add three test cases for `displayPath` in `DirsSpec`: global path, non-home path, and a path containing a duplicate of the home directory.