### PR TITLE
Close #102: Change `install` location selection from `MultipleChoice` to `SingleChoice`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -164,22 +164,16 @@ object Install {
     val locationLabels = List(
       s"global  ($globalPaths)",
       s"project ($projectPaths)",
+      "both",
     )
 
     aiskills.cli.SigintHandler.install()
     val result = Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select install location", locationLabels, CliDefaults.multiChoiceModify) match {
-        case Completion.Finished(selectedLabels) =>
-          if selectedLabels.isEmpty then {
-            println("No location selected. Defaulting to project.".yellow)
-            Set(SkillLocation.Project).asRight
-          } else {
-            val locs = selectedLabels.foldLeft(Set.empty[SkillLocation]) { (acc, label) =>
-              if label.startsWith("project") then acc + SkillLocation.Project
-              else acc + SkillLocation.Global
-            }
-            locs.asRight
-          }
+      prompts.singleChoice("Select install location", locationLabels) match {
+        case Completion.Finished(selected) =>
+          if selected.startsWith("project") then Set(SkillLocation.Project).asRight
+          else if selected.startsWith("global") then Set(SkillLocation.Global).asRight
+          else Set(SkillLocation.Global, SkillLocation.Project).asRight
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
           0.asLeft


### PR DESCRIPTION
# Close #102: Change `install` location selection from `MultipleChoice` to `SingleChoice`

Replace `multiChoiceNoneSelected` with `singleChoice` in the `promptForLocation` method of the `install` command. The toggle-based multi-select prompt is replaced with a single-select prompt that includes a "both" option for installing to both `global` and `project` locations.

- Add "both" as a third option in the location labels list
- Switch from `multiChoiceNoneSelected` to `singleChoice`, removing the `CliDefaults.multiChoiceModify` argument
- Simplify the `Completion.Finished` handler from empty-check + `foldLeft` over multiple labels to straightforward `startsWith` matching on the single selected string
- Remove the "No location selected. Defaulting to project." fallback, which is no longer needed since `singleChoice` always returns exactly one selection