### PR TITLE
Close #100: Fix duplicate skills when `pwd` is the `home` directory

### DIFF
--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -33,22 +33,32 @@ object Dirs {
     *   2. Project agent-specific (alphabetical by agent name)
     *   3. Global universal (~/.agents)
     *   4. Global agent-specific (alphabetical by agent name)
+    *
+    * When pwd is the home directory, project entries are omitted
+    * because they would resolve to the same paths as global entries.
     */
-  def getSearchDirs(): List[(os.Path, Agent, SkillLocation)] = {
+  def getSearchDirs(): List[(os.Path, Agent, SkillLocation)] =
+    getSearchDirs(os.pwd)
+
+  def getSearchDirs(pwd: os.Path): List[(os.Path, Agent, SkillLocation)] = {
     val agentsSorted = Agent.allNonUniversal.sortBy(_.toString)
 
-    val projectUniversal = List(
-      (os.pwd / os.RelPath(Agent.Universal.projectDirName) / "skills", Agent.Universal, SkillLocation.Project)
-    )
-    val projectSpecific  =
-      agentsSorted.map(a => (os.pwd / os.RelPath(a.projectDirName) / "skills", a, SkillLocation.Project))
-    val globalUniversal  = List(
+    val globalUniversal = List(
       (os.home / os.RelPath(Agent.Universal.globalDirName) / "skills", Agent.Universal, SkillLocation.Global)
     )
-    val globalSpecific   =
+    val globalSpecific  =
       agentsSorted.map(a => (os.home / os.RelPath(a.globalDirName) / "skills", a, SkillLocation.Global))
 
-    projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific
+    if pwd == os.home then globalUniversal ++ globalSpecific
+    else {
+      val projectUniversal = List(
+        (pwd / os.RelPath(Agent.Universal.projectDirName) / "skills", Agent.Universal, SkillLocation.Project)
+      )
+      val projectSpecific  =
+        agentsSorted.map(a => (pwd / os.RelPath(a.projectDirName) / "skills", a, SkillLocation.Project))
+
+      projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific
+    }
   }
 
 }

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -33,6 +33,9 @@ object DirsSpec extends Properties {
     example("getSearchDirs: returns 14 dirs", testSearchDirsCount),
     example("getSearchDirs: correct priority order", testSearchDirsOrder),
     example("getSearchDirs: first is project universal", testSearchDirsFirst),
+    example("getSearchDirs: returns 7 global-only dirs when pwd is home", testSearchDirsPwdIsHome),
+    example("getSearchDirs: returns 14 dirs when pwd is not home", testSearchDirsPwdIsNotHome),
+    example("getSearchDirs: no-arg delegates to overload with os.pwd", testSearchDirsNoArgDelegates),
   )
 
   private def testProjectUniversal: Result =
@@ -106,13 +109,15 @@ object DirsSpec extends Properties {
     Dirs.displayPath(path) ==== expected
   }
 
+  private val nonHomePwd = os.root / "some" / "project"
+
   private def testSearchDirsCount: Result = {
-    val dirs = Dirs.getSearchDirs()
+    val dirs = Dirs.getSearchDirs(nonHomePwd)
     dirs.length ==== 14
   }
 
   private def testSearchDirsOrder: Result = {
-    val dirs   = Dirs.getSearchDirs()
+    val dirs   = Dirs.getSearchDirs(nonHomePwd)
     val agents = dirs.map { case (_, agent, _) => agent }
     // 1. Project universal
     // 2-7. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini, Windsurf)
@@ -121,7 +126,7 @@ object DirsSpec extends Properties {
     Result.all(
       List(
         // Project universal
-        dirs(0) ==== (os.pwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project),
+        dirs(0) ==== (nonHomePwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project),
         // Project agent-specific (alphabetical)
         agents(1) ==== Agent.Claude,
         agents(2) ==== Agent.Codex,
@@ -147,15 +152,42 @@ object DirsSpec extends Properties {
   }
 
   private def testSearchDirsFirst: Result = {
-    val dirs                    = Dirs.getSearchDirs()
+    val dirs                    = Dirs.getSearchDirs(nonHomePwd)
     val (path, agent, location) = dirs.head
     Result.all(
       List(
-        path ==== (os.pwd / ".agents" / "skills"),
+        path ==== (nonHomePwd / ".agents" / "skills"),
         agent ==== Agent.Universal,
         location ==== SkillLocation.Project,
       )
     )
+  }
+
+  private def testSearchDirsPwdIsHome: Result = {
+    val dirs = Dirs.getSearchDirs(os.home)
+    Result.all(
+      List(
+        dirs.length ==== 7,
+        Result.assert(dirs.forall { case (_, _, location) => location === SkillLocation.Global }),
+      )
+    )
+  }
+
+  private def testSearchDirsPwdIsNotHome: Result = {
+    val dirs = Dirs.getSearchDirs(nonHomePwd)
+    Result.all(
+      List(
+        dirs.length ==== 14,
+        Result.assert(dirs.take(7).forall { case (_, _, location) => location === SkillLocation.Project }),
+        Result.assert(dirs.drop(7).forall { case (_, _, location) => location === SkillLocation.Global }),
+      )
+    )
+  }
+
+  private def testSearchDirsNoArgDelegates: Result = {
+    val noArg   = Dirs.getSearchDirs()
+    val withPwd = Dirs.getSearchDirs(os.pwd)
+    noArg ==== withPwd
   }
 
 }


### PR DESCRIPTION
# Close #100: Fix duplicate skills when `pwd` is the `home` directory

When running `aiskills` from `$HOME`, global skills appeared as both "project" and "global" because `getSearchDirs()` built project paths using `os.pwd` and global paths using `os.home`, which resolve to the same filesystem paths when `os.pwd == os.home`.

Add a `getSearchDirs(pwd: os.Path)` overload that skips project entries when `pwd == os.home`, returning only the 7 global directories instead of 14. The no-arg `getSearchDirs()` delegates to the overload with `os.pwd`.

Update existing `DirsSpec` tests to use an explicit non-home pwd for deterministic behavior, and add 3 new tests covering: pwd-is-home returns global-only, pwd-is-not-home returns all 14, and no-arg delegation.