### PR TITLE
ai-skills v2.5.0

### DIFF
--- a/changelogs/2.5.0.md
+++ b/changelogs/2.5.0.md
@@ -1,0 +1,73 @@
+## [2.5.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am9) - 2026-04-11
+
+## Changes
+
+### Simplify the home directory in the `Base directory` from the result of the `read` command. (#101)
+
+`Base directory` in the result of `read` command is currently an absolute path.
+
+e.g.)
+```
+       Reading: riper-5
+Base directory: /Users/username/.claude/skills/riper-5
+```
+
+After this release it will be:
+```
+       Reading: riper-5
+Base directory: ~/.claude/skills/riper-5
+```
+
+### Location selection should all be `SingleChoice` (#102)
+
+Current location selection in `install`:
+```
+? Select install location ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ global  (~/.claude)
+ ◯ project (.claude)
+```
+
+After this release it will be:
+```
+? Select install location ›
+  ‣ global  (~/.claude)
+    project (.claude)
+    both 
+```
+
+
+***
+
+## Bug Fixed
+
+### If `pwd` is `$HOME`, `ai-skills` treats global skills as both global and project skills (#100)
+
+In the home directory, `ai-skills` treats global skills as both global and project skills.
+e.g.)
+```
+$ aiskills read
+✔ Select scope  … both
+✔ Select agent(s)
+ ◉ Claude          (4 skill(s))  (global, Claude): ~/.claude/skills, (project, Claude): .claude/skills
+ ◯ Windsurf        (2 skill(s))  (global, Windsurf): ~/.codeium/windsurf/skills
+? Select skill(s) to read ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ 2020-hindsight-scala      (project, Claude): .claude/skills
+ ◯ riper-5                   (project, Claude): .claude/skills
+ ◯ 2020-hindsight-scala      (global, Claude): ~/.claude/skills
+ ◯ riper-5                   (global, Claude): ~/.claude/skills
+```
+
+After this release it will be:
+```
+$ aiskills read
+No project skills found. Reading from global scope.
+✔ Select agent(s)
+ ◉ Claude          (2 skill(s))  (global, Claude): ~/.claude/skills
+ ◯ Windsurf        (2 skill(s))  (global, Windsurf): ~/.codeium/windsurf/skills
+? Select skill(s) to read ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ 2020-hindsight-scala      (global, Claude): ~/.claude/skills
+ ◯ riper-5                   (global, Claude): ~/.claude/skills
+```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.4.1-SNAPSHOT"
+ThisBuild / version := "2.5.0"


### PR DESCRIPTION
# ai-skills v2.5.0
## [2.5.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am9) - 2026-04-11

## Changes

### Simplify the home directory in the `Base directory` from the result of the `read` command. (#101)

`Base directory` in the result of `read` command is currently an absolute path.

e.g.)
```
       Reading: riper-5
Base directory: /Users/username/.claude/skills/riper-5
```

After this release it will be:
```
       Reading: riper-5
Base directory: ~/.claude/skills/riper-5
```

### Location selection should all be `SingleChoice` (#102)

Current location selection in `install`:
```
? Select install location ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ global  (~/.claude)
 ◯ project (.claude)
```

After this release it will be:
```
? Select install location ›
  ‣ global  (~/.claude)
    project (.claude)
    both 
```


***

## Bug Fixed

### If `pwd` is `$HOME`, `ai-skills` treats global skills as both global and project skills (#100)

In the home directory, `ai-skills` treats global skills as both global and project skills.
e.g.)
```
$ aiskills read
✔ Select scope  … both
✔ Select agent(s)
 ◉ Claude          (4 skill(s))  (global, Claude): ~/.claude/skills, (project, Claude): .claude/skills
 ◯ Windsurf        (2 skill(s))  (global, Windsurf): ~/.codeium/windsurf/skills
? Select skill(s) to read ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ 2020-hindsight-scala      (project, Claude): .claude/skills
 ◯ riper-5                   (project, Claude): .claude/skills
 ◯ 2020-hindsight-scala      (global, Claude): ~/.claude/skills
 ◯ riper-5                   (global, Claude): ~/.claude/skills
```

After this release it will be:
```
$ aiskills read
No project skills found. Reading from global scope.
✔ Select agent(s)
 ◉ Claude          (2 skill(s))  (global, Claude): ~/.claude/skills
 ◯ Windsurf        (2 skill(s))  (global, Windsurf): ~/.codeium/windsurf/skills
? Select skill(s) to read ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ 2020-hindsight-scala      (global, Claude): ~/.claude/skills
 ◯ riper-5                   (global, Claude): ~/.claude/skills
```
