### PR TITLE
Close #109: Add `search` command for discovering skills from marketplaces and local installations

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -21,6 +21,7 @@ object Main {
                |  aiskills install anthropics/skills               # Install skills from a GitHub repo
                |  aiskills list                                    # See what's installed
                |  aiskills read commit                             # Output a skill (for AI agents)
+               |  aiskills search commit                           # Search for skills
                |  aiskills update                                  # Update all skills from source
                |  aiskills sync --from claude --to cursor          # Copy skills between agents
                |  aiskills remove                                  # Interactive removal
@@ -472,12 +473,75 @@ object Main {
         }
       }
 
+      val searchCommand = Opts.subcommand(
+        "search",
+        """Search for skills from marketplaces or local installations
+          |
+          |Search skills.sh and agentskill.sh marketplaces, or fuzzy-search
+          |your locally installed skills by name and description.
+          |
+          |Interactive mode:
+          |  aiskills search                              # Choose location, enter query interactively
+          |  aiskills search <query>                      # Choose location, search immediately
+          |
+          |Non-interactive mode:
+          |  aiskills search <query> --marketplace        # Search marketplaces (skills.sh, agentskill.sh)
+          |  aiskills search <query> --local              # Search installed skills (fuzzy match)
+          |""".stripMargin,
+      ) {
+        val query       = Opts.argument[String](metavar = "query").orNone
+        val marketplace =
+          Opts.flag("marketplace", "Search from marketplaces (skills.sh, agentskill.sh)", short = "m").orFalse
+        val local       = Opts.flag("local", "Search from local installed skills", short = "l").orFalse
+        (query, marketplace, local).mapN { (q, m, l) =>
+          if m && l then {
+            System.err.println("Error: --marketplace and --local are mutually exclusive.")
+            System.err.println()
+            System.err.println("  Use --marketplace to search from online marketplaces")
+            System.err.println("  Use --local to search from installed skills")
+            sys.exit(1)
+          } else ()
+
+          val hasLocationFlag = m || l
+
+          if hasLocationFlag && q.isEmpty then {
+            System.err.println("Error: Must specify a search query when using --marketplace or --local.")
+            System.err.println()
+            System.err.println("  Example: aiskills search commit --marketplace")
+            System.err.println("  Example: aiskills search commit --local")
+            System.err.println()
+            System.err.println("For interactive search, run without flags:")
+            System.err.println("  aiskills search")
+            sys.exit(1)
+          } else ()
+
+          q match {
+            case Some(query) if query.trim.length < 2 =>
+              System.err.println("Error: Search query must be at least 2 characters.")
+              sys.exit(1)
+
+            case Some(query) if m =>
+              Search.searchMarketplace(query.trim)
+
+            case Some(query) if l =>
+              Search.searchLocal(query.trim)
+
+            case Some(query) =>
+              Search.searchWithQuery(query.trim)
+
+            case None =>
+              Search.searchInteractive()
+          }
+        }
+      }
+
       listCommand
         .orElse(installCommand)
         .orElse(readCommand)
         .orElse(updateCommand)
         .orElse(syncCommand)
         .orElse(removeCommand)
+        .orElse(searchCommand)
     }
   )
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -1,0 +1,712 @@
+package aiskills.cli.commands
+
+import aiskills.cli.CliDefaults
+import aiskills.core.utils.{AgentsMd, Dirs, LocalSearch, MarketplaceSearch, SkillMetadata, Skills, TerminalWidth, Yaml}
+import aiskills.core.*
+import cats.syntax.all.*
+import cue4s.*
+import extras.scala.io.syntax.color.*
+import just.spinner.*
+
+import scala.util.Try
+
+object Search {
+
+  private val MinQueryLength = 2
+
+  private def generateSeparator(separatorChar: Char) =
+    "\n" + (separatorChar.toString * TerminalWidth.getTerminalWidth()).green.bold + "\n"
+
+  private val separator = generateSeparator('=')
+
+  // ── Entry points ──────────────────────────────────────────────────
+
+  /** Full interactive mode: choose location, enter query, select results, choose action. */
+  def searchInteractive(): Unit =
+    promptForLocation() match {
+      case Left(code) => sys.exit(code)
+      case Right(location) =>
+        promptForQuery() match {
+          case Left(code) => sys.exit(code)
+          case Right(query) =>
+            location match {
+              case SearchLocation.Marketplace => runMarketplaceSearch(query)
+              case SearchLocation.Local => runLocalSearch(query)
+            }
+        }
+    }
+
+  /** Interactive with pre-filled query: choose location, search immediately. */
+  def searchWithQuery(query: String): Unit =
+    promptForLocation() match {
+      case Left(code) => sys.exit(code)
+      case Right(location) =>
+        location match {
+          case SearchLocation.Marketplace => runMarketplaceSearch(query)
+          case SearchLocation.Local => runLocalSearch(query)
+        }
+    }
+
+  /** Direct marketplace search. */
+  def searchMarketplace(query: String): Unit =
+    runMarketplaceSearch(query)
+
+  /** Direct local search. */
+  def searchLocal(query: String): Unit =
+    runLocalSearch(query)
+
+  // ── Marketplace search flow ───────────────────────────────────────
+
+  private def runMarketplaceSearch(query: String): Unit = {
+    println(s"Searching marketplaces for: ${query.cyan.bold}\n")
+
+    val spinner = Spinner.createDefaultSideEffect(
+      SpinnerConfig
+        .default
+        .withText("Searching skills.sh and agentskill.sh...")
+        .withColor(Color.cyan)
+        .withIndent(2),
+    )
+    val _       = spinner.start()
+
+    val results = MarketplaceSearch.searchAll(query)
+
+    if results.isEmpty then {
+      val _ = spinner.fail(Some("No results found"))
+      println(s"\nNo skills found matching '$query'.".yellow)
+      println(s"Try a different search term or browse:")
+      println(s"  ${"https://skills.sh".cyan}")
+      println(s"  ${"https://agentskill.sh".cyan}")
+    } else {
+      val _ = spinner.succeed(Some(s"Found ${results.length} skill(s)"))
+      println()
+
+      promptForMarketplaceResults(results) match {
+        case Left(code) => sys.exit(code)
+        case Right(selected) =>
+          if selected.isEmpty then println("No skills selected.".yellow)
+          else
+            promptForMarketplaceAction() match {
+              case Left(code) => sys.exit(code)
+              case Right(action) => executeMarketplaceAction(action, selected)
+            }
+      }
+    }
+  }
+
+  private def promptForMarketplaceResults(results: List[MarketplaceResult]): Either[Int, List[MarketplaceResult]] = {
+    val labels = results.map { r =>
+      val installLabel = formatInstalls(r.installs)
+      s"${r.name.padTo(25, ' ')} ${r.source.padTo(30, ' ')} ${installLabel.padTo(12, ' ')} [${r.marketplace}]"
+    }
+
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select skill(s)", labels, CliDefaults.multiChoiceModify) match {
+        case Completion.Finished(selectedLabels) =>
+          val selectedIndices = selectedLabels.flatMap { label =>
+            labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
+          }
+          selectedIndices.map(results(_)).asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private enum MarketplaceAction {
+    case ReadSkill, InstallSkill, ListSkill
+  }
+
+  private def promptForMarketplaceAction(): Either[Int, MarketplaceAction] = {
+    val options = List(
+      "read    — Read skill content (clones repo temporarily)",
+      "install — Install selected skill(s)",
+      "list    — Display skill details",
+    )
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("What would you like to do?", options) match {
+        case Completion.Finished(selected) =>
+          if selected.startsWith("read") then MarketplaceAction.ReadSkill.asRight
+          else if selected.startsWith("install") then MarketplaceAction.InstallSkill.asRight
+          else MarketplaceAction.ListSkill.asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def executeMarketplaceAction(action: MarketplaceAction, selected: List[MarketplaceResult]): Unit =
+    action match {
+      case MarketplaceAction.ListSkill =>
+        displayMarketplaceResults(selected)
+
+      case MarketplaceAction.InstallSkill =>
+        installMarketplaceSkills(selected)
+
+      case MarketplaceAction.ReadSkill =>
+        readMarketplaceSkills(selected)
+    }
+
+  private def readMarketplaceSkills(selected: List[MarketplaceResult]): Unit = {
+    aiskills.cli.TempDirCleanup.ensureAtexitRegistered()
+
+    for (result, idx) <- selected.zipWithIndex do {
+      if idx > 0 then println(separator)
+
+      val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+      os.makeDir.all(tempDir)
+      aiskills.cli.TempDirCleanup.register(tempDir)
+
+      val spinner = Spinner.createDefaultSideEffect(
+        SpinnerConfig
+          .default
+          .withText(s"Cloning ${result.source}...")
+          .withColor(Color.cyan)
+          .withIndent(2),
+      )
+      val _       = spinner.start()
+
+      Try {
+        Install.cloneWithFallback(s"https://github.com/${result.source}", (tempDir / "repo").toString)
+      } match {
+        case scala.util.Failure(_) =>
+          val _ = spinner.fail(Some(s"Failed to clone ${result.source}"))
+          System.err.println(s"Could not clone repository: ${result.source}".red)
+
+        case scala.util.Success(_) =>
+          val _ = spinner.succeed(Some(s"Cloned ${result.source}"))
+
+          val repoDir = tempDir / "repo"
+          findSkillMd(repoDir, result.name) match {
+            case Some(skillMdPath) =>
+              val content = os.read(skillMdPath)
+              println("       Reading:".bold + s" ${result.name.blue.bold}")
+              println("        Source:".bold + s" ${result.source.yellow.bold} [${result.marketplace}]")
+              println()
+              println(content)
+              println()
+              println("Skill read:".bold + s" ${result.name.blue.bold}")
+
+            case None =>
+              System.err.println(s"SKILL.md not found for '${result.name}' in ${result.source}".yellow)
+          }
+      }
+
+      aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
+      aiskills.cli.TempDirCleanup.unregister()
+    }
+  }
+
+  private def installMarketplaceSkills(selected: List[MarketplaceResult]): Unit = {
+    // 1. Prompt for agents and location once
+    val agents = promptForAgents() match {
+      case Left(code) => sys.exit(code)
+      case Right(a) => a
+    }
+    if agents.isEmpty then println("No agents selected. Installation cancelled.".yellow)
+    else {
+      val locations = promptForInstallLocation(agents) match {
+        case Left(code) => sys.exit(code)
+        case Right(l) => l
+      }
+
+      // 2. Group by source to clone each repo only once
+      val bySource = selected.groupBy(_.source)
+
+      aiskills.cli.TempDirCleanup.ensureAtexitRegistered()
+
+      import OverwritePrompt.BulkDecision
+
+      val (installedCount, _) = bySource.foldLeft((0, BulkDecision.Undecided: BulkDecision)) {
+        case ((count, bulk), (source, results)) =>
+          val skillNames = results.map(_.name)
+          val repoUrl    = s"https://github.com/$source"
+
+          val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
+          os.makeDir.all(tempDir)
+          aiskills.cli.TempDirCleanup.register(tempDir)
+
+          val spinner = Spinner.createDefaultSideEffect(
+            SpinnerConfig
+              .default
+              .withText(s"Cloning $source...")
+              .withColor(Color.cyan)
+              .withIndent(2),
+          )
+          val _       = spinner.start()
+
+          val cloneResult = Try {
+            Install.cloneWithFallback(repoUrl, (tempDir / "repo").toString)
+          }
+
+          val (repoCount, newBulk) = cloneResult match {
+            case scala.util.Failure(_) =>
+              val _ = spinner.fail(Some(s"Failed to clone $source"))
+              System.err.println(s"Could not clone repository: $source".red)
+              (0, bulk)
+
+            case scala.util.Success(actualUrl) =>
+              val _ = spinner.succeed(Some(s"Cloned $source"))
+
+              val repoDir = tempDir / "repo"
+
+              // Build list of (skillDir, metadata) for all found skills, then install across all agent×location combos
+              val skillEntries = skillNames.flatMap { name =>
+                findSkillMd(repoDir, name) match {
+                  case Some(skillMdPath) =>
+                    val skillDir = skillMdPath / os.up
+                    val subpath  = skillDir.relativeTo(repoDir).toString
+                    val metadata = SkillSourceMetadata(
+                      source = source,
+                      sourceType = SkillSourceType.Git,
+                      repoUrl = actualUrl.some,
+                      subpath = subpath.some,
+                      localPath = none[String],
+                      installedAt = aiskills.core.utils.isoNow(),
+                    )
+                    List((skillDir, metadata))
+
+                  case None =>
+                    System.err.println(s"SKILL.md not found for '$name' in $source".yellow)
+                    Nil
+                }
+              }
+
+              // Install each skill across all agent×location combos, threading BulkDecision
+              val installTargets = for {
+                (skillDir, metadata) <- skillEntries
+                agent                <- agents
+                location             <- locations.toList
+              } yield (skillDir, agent, location, metadata)
+
+              installTargets.foldLeft((0, bulk)) {
+                case ((skillCount, currentBulk), (skillDir, agent, location, metadata)) =>
+                  val (installed, nextBulk) = installSingleSkill(skillDir, agent, location, metadata, currentBulk)
+                  (skillCount + (if installed then 1 else 0), nextBulk)
+              }
+          }
+
+          aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
+          aiskills.cli.TempDirCleanup.unregister()
+
+          (count + repoCount, newBulk)
+      }
+
+      if installedCount > 0 then {
+        println(s"\n\u2705 Installation complete: $installedCount skill(s) installed".green)
+        println(s"\n${"Read skill:".dim} ${"aiskills read <skill-name>".cyan}")
+        if locations.contains(SkillLocation.Project) then println(
+          s"${"Sync to other agents:".dim} ${"aiskills sync <skill-name> --from <agent> --to <agent>".cyan}"
+        )
+        else ()
+      } else ()
+    }
+  }
+
+  /** Install a single skill directory to a specific agent and location.
+    * Returns (installed, nextBulkDecision).
+    */
+  private def installSingleSkill(
+    skillDir: os.Path,
+    agent: Agent,
+    location: SkillLocation,
+    metadata: SkillSourceMetadata,
+    bulk: OverwritePrompt.BulkDecision,
+  ): (Boolean, OverwritePrompt.BulkDecision) = {
+    import OverwritePrompt.{BulkDecision, OverwriteChoice}
+
+    val isProject = location === SkillLocation.Project
+    val folder    =
+      if isProject then s"${agent.projectDirName}/skills"
+      else s"${agent.globalDirName}/skills"
+    val targetDir =
+      if isProject then os.pwd / os.RelPath(folder)
+      else os.home / os.RelPath(folder)
+
+    val skillName     = skillDir.last
+    val targetPath    = targetDir / skillName
+    val locationLabel = s"(${location.toString.toLowerCase}, ${agent.toString})"
+
+    os.makeDir.all(targetDir)
+
+    val (installed, nextBulk) =
+      if !Install.isPathInside(targetPath, targetDir) then {
+        System.err.println("Security error: Installation path outside target directory".red)
+        (false, bulk)
+      } else if !os.exists(targetPath) then {
+        copyAndWriteMetadata(skillDir, targetPath, metadata)
+        println(s"\u2705 Installed: $skillName $locationLabel".green)
+        (true, bulk)
+      } else {
+        bulk match {
+          case BulkDecision.OverwriteAll =>
+            overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+            (true, bulk)
+
+          case BulkDecision.SkipAll =>
+            println(s"Skipped: $skillName $locationLabel".yellow)
+            (false, bulk)
+
+          case BulkDecision.Undecided =>
+            OverwritePrompt.askOverwriteChoice(
+              skillName,
+              s"Skill '$skillName' already exists at $locationLabel. What would you like to do?",
+            ) match {
+              case Left(code) =>
+                sys.exit(code)
+
+              case Right(OverwriteChoice.Yes) =>
+                overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+                (true, BulkDecision.Undecided)
+
+              case Right(OverwriteChoice.No) =>
+                println(s"Skipped: $skillName $locationLabel".yellow)
+                (false, BulkDecision.Undecided)
+
+              case Right(OverwriteChoice.Rename) =>
+                OverwritePrompt.askNewSkillName(skillName, targetDir) match {
+                  case Left(code) =>
+                    sys.exit(code)
+                  case Right(newName) =>
+                    val newTargetPath = targetDir / newName
+                    os.copy(skillDir, newTargetPath, replaceExisting = true)
+                    val skillMdPath   = newTargetPath / "SKILL.md"
+                    if os.exists(skillMdPath) then {
+                      val content = os.read(skillMdPath)
+                      val updated = Yaml.replaceYamlField(content, "name", newName)
+                      os.write.over(skillMdPath, updated)
+                    } else ()
+                    SkillMetadata.writeSkillMetadata(newTargetPath, metadata.copy(name = newName.some))
+                    println(s"\u2705 Installed: $skillName as $newName $locationLabel".green)
+                    (true, BulkDecision.Undecided)
+                }
+
+              case Right(OverwriteChoice.YesToAll) =>
+                overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+                (true, BulkDecision.OverwriteAll)
+
+              case Right(OverwriteChoice.NoToAll) =>
+                println(s"Skipped: $skillName $locationLabel".yellow)
+                (false, BulkDecision.SkipAll)
+            }
+        }
+      }
+
+    if installed then AgentsMd.updateAgentsMdForAgent(agent, location)
+    else ()
+    (installed, nextBulk)
+  }
+
+  private def copyAndWriteMetadata(
+    skillDir: os.Path,
+    targetPath: os.Path,
+    metadata: SkillSourceMetadata,
+  ): Unit = {
+    os.copy(skillDir, targetPath, replaceExisting = true)
+    SkillMetadata.writeSkillMetadata(targetPath, metadata)
+  }
+
+  private def overwriteAndInstall(
+    skillDir: os.Path,
+    targetPath: os.Path,
+    skillName: String,
+    locationLabel: String,
+    metadata: SkillSourceMetadata,
+  ): Unit = {
+    println(s"Overwriting: $skillName $locationLabel".dim)
+    os.remove.all(targetPath)
+    copyAndWriteMetadata(skillDir, targetPath, metadata)
+    println(s"\u2705 Installed: $skillName $locationLabel".green)
+  }
+
+  private def promptForAgents(): Either[Int, List[Agent]] = {
+    val agentLabels = Agent.all.map(_.toString)
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels, CliDefaults.multiChoiceModify) match {
+        case Completion.Finished(selectedLabels) =>
+          Agent.all.filter(a => selectedLabels.contains(a.toString)).asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForInstallLocation(agents: List[Agent]): Either[Int, Set[SkillLocation]] = {
+    val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
+    val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
+    val locationLabels = List(
+      s"global  ($globalPaths)",
+      s"project ($projectPaths)",
+      "both",
+    )
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("Select install location", locationLabels) match {
+        case Completion.Finished(selected) =>
+          if selected.startsWith("project") then Set(SkillLocation.Project).asRight
+          else if selected.startsWith("global") then Set(SkillLocation.Global).asRight
+          else Set(SkillLocation.Global, SkillLocation.Project).asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  /** Find a SKILL.md in a repo by skill name.
+    *
+    * Matching strategy (in priority order):
+    *  1. Direct path: repoDir/skillName/SKILL.md
+    *  2. Under skills/: repoDir/skills/skillName/SKILL.md
+    *  3. Directory name match (recursive): any dir whose name equals skillName
+    *  4. YAML name match: any SKILL.md whose frontmatter `name` field matches (case-insensitive).
+    *     This handles marketplace names like "pdf merge & split" where the directory is "pdf-merge-split".
+    */
+  private[commands] def findSkillMd(repoDir: os.Path, skillName: String): Option[os.Path] = {
+    val directPath = repoDir / skillName / "SKILL.md"
+    val skillsPath = repoDir / "skills" / skillName / "SKILL.md"
+
+    if os.exists(directPath) then directPath.some
+    else if os.exists(skillsPath) then skillsPath.some
+    else {
+      // Collect all SKILL.md files in the repo
+      val allSkillMds = collectSkillMds(repoDir)
+
+      // Try matching by directory name
+      allSkillMds
+        .find { md => (md / os.up).last === skillName }
+        .orElse {
+          // Try matching by YAML name field (case-insensitive)
+          val normalizedQuery = skillName.toLowerCase.trim
+          allSkillMds.find { md =>
+            val content  = Try(os.read(md)).getOrElse("")
+            val yamlName = Yaml.extractYamlField(content, "name")
+            yamlName.toLowerCase.trim === normalizedQuery
+          }
+        }
+    }
+  }
+
+  /** Collect all SKILL.md files under a directory (non-recursive into SKILL.md subdirs). */
+  private[commands] def collectSkillMds(dir: os.Path): List[os.Path] =
+    Try(os.list(dir)).toOption match {
+      case None => Nil
+      case Some(entries) =>
+        entries.toList.flatMap { entry =>
+          if Try(os.isDir(entry)).getOrElse(false) then {
+            val md = entry / "SKILL.md"
+            if os.exists(md) then List(md)
+            else collectSkillMds(entry)
+          } else Nil
+        }
+    }
+
+  private def displayMarketplaceResults(results: List[MarketplaceResult]): Unit = {
+    println("\nSearch Results:\n".bold)
+    for result <- results do {
+      val installLabel = formatInstalls(result.installs)
+      println(s"  ${result.name.bold.padTo(25, ' ')} ${result.source.cyan}")
+      if result.description.nonEmpty then println(s"    ${result.description.dim}")
+      else ()
+      println(s"    ${"Installs:".dim} $installLabel  ${"Marketplace:".dim} ${result.marketplace}")
+      println()
+    }
+    println(s"${results.length} skill(s) shown".dim)
+  }
+
+  // ── Local search flow ─────────────────────────────────────────────
+
+  private def runLocalSearch(query: String): Unit = {
+    val allSkills = Skills.findAllSkills()
+
+    if allSkills.isEmpty then {
+      println("No skills installed.\n")
+      println("Install skills:")
+      println(s"  ${"aiskills install anthropics/skills".cyan}   ${"# Install from GitHub".dim}")
+    } else {
+      val results = LocalSearch.fuzzySearch(query, allSkills)
+
+      if results.isEmpty then {
+        println(s"No local skills found matching '$query'.".yellow)
+        println(s"${allSkills.length} skill(s) installed. Try a different search term.".dim)
+      } else {
+        println(s"Found ${results.length} matching skill(s) for '${query.cyan.bold}':\n")
+
+        promptForLocalResults(results) match {
+          case Left(code) => sys.exit(code)
+          case Right(selected) =>
+            if selected.isEmpty then println("No skills selected.".yellow)
+            else
+              promptForLocalAction() match {
+                case Left(code) => sys.exit(code)
+                case Right(action) => executeLocalAction(action, selected)
+              }
+        }
+      }
+    }
+  }
+
+  private def promptForLocalResults(results: List[LocalSearchResult]): Either[Int, List[Skill]] = {
+    val labels = results.map { r =>
+      val pathLabel     = Dirs.displaySkillsDir(r.skill.agent, r.skill.location)
+      val locationLabel = s"(${r.skill.location.toString.toLowerCase}, ${r.skill.agent.toString}): $pathLabel"
+      s"${r.skill.name.padTo(25, ' ')} $locationLabel"
+    }
+
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.multiChoiceNoneSelected("Select skill(s)", labels, CliDefaults.multiChoiceModify) match {
+        case Completion.Finished(selectedLabels) =>
+          val selectedIndices = selectedLabels.flatMap { label =>
+            labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
+          }
+          selectedIndices.map(i => results(i).skill).asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private enum LocalAction {
+    case ReadSkill, ListSkill
+  }
+
+  private def promptForLocalAction(): Either[Int, LocalAction] = {
+    val options = List(
+      "read — Read skill content",
+      "list — Display skill details",
+    )
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("What would you like to do?", options) match {
+        case Completion.Finished(selected) =>
+          if selected.startsWith("read") then LocalAction.ReadSkill.asRight
+          else LocalAction.ListSkill.asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def executeLocalAction(action: LocalAction, selected: List[Skill]): Unit =
+    action match {
+      case LocalAction.ListSkill =>
+        displayLocalResults(selected)
+
+      case LocalAction.ReadSkill =>
+        for (skill, idx) <- selected.zipWithIndex do {
+          if idx > 0 then println(separator)
+          val skillPath = skill.path / "SKILL.md"
+          val content   = os.read(skillPath)
+          println("       Reading:".bold + s" ${skill.name.blue.bold}")
+          println("Base directory:".bold + s" ${Dirs.displayPath(skill.path).yellow.bold}")
+          println()
+          println(content)
+          println()
+          println("Skill read:".bold + s" ${skill.name.blue.bold}")
+        }
+    }
+
+  private def displayLocalResults(skills: List[Skill]): Unit = {
+    println("\nSearch Results:\n".bold)
+
+    val sorted = skills.sortBy(s => (s.agent.ordinal, s.location.ordinal, s.name))
+
+    for skill <- sorted do {
+      val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+      val locationLabel =
+        s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
+      println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
+      println(s"    ${skill.description.dim}\n")
+    }
+    println(s"${skills.length} skill(s) shown".dim)
+  }
+
+  // ── Shared prompts ────────────────────────────────────────────────
+
+  private def promptForLocation(): Either[Int, SearchLocation] = {
+    val options = List("marketplace", "local")
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.singleChoice("Search from", options) match {
+        case Completion.Finished(selected) =>
+          if selected === "marketplace" then SearchLocation.Marketplace.asRight
+          else SearchLocation.Local.asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def promptForQuery(): Either[Int, String] = {
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.text(
+        "Enter search query",
+        _.validate { s =>
+          if s.trim.length < MinQueryLength
+          then Some(PromptError(s"Query must be at least $MinQueryLength characters"))
+          else None
+        },
+      ) match {
+        case Completion.Finished(query) =>
+          query.trim.asRight
+
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  // ── Utilities ─────────────────────────────────────────────────────
+
+  private[commands] def formatInstalls(count: Long): String =
+    if count >= 1_000_000 then f"${count / 1_000_000.0}%.1fM installs"
+    else if count >= 1_000 then f"${count / 1_000.0}%.1fK installs"
+    else s"$count installs"
+}

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
@@ -1,0 +1,173 @@
+package aiskills.cli.commands
+
+import hedgehog.*
+import hedgehog.runner.*
+
+object SearchSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    // formatInstalls
+    example("formatInstalls: formats millions", testFormatMillions),
+    example("formatInstalls: formats thousands", testFormatThousands),
+    example("formatInstalls: formats small numbers", testFormatSmall),
+    example("formatInstalls: formats zero", testFormatZero),
+    example("formatInstalls: formats boundary at 1000", testFormatBoundaryThousand),
+    example("formatInstalls: formats boundary at 1000000", testFormatBoundaryMillion),
+    // collectSkillMds
+    example("collectSkillMds: finds SKILL.md in direct subdirectories", testCollectDirect),
+    example("collectSkillMds: finds SKILL.md in nested directories", testCollectNested),
+    example("collectSkillMds: returns empty for non-existent directory", testCollectNonExistent),
+    example("collectSkillMds: returns empty for empty directory", testCollectEmpty),
+    example("collectSkillMds: ignores files (non-directories)", testCollectIgnoresFiles),
+    // findSkillMd
+    example("findSkillMd: finds by direct path", testFindDirectPath),
+    example("findSkillMd: finds under skills/ directory", testFindUnderSkills),
+    example("findSkillMd: finds by directory name recursively", testFindByDirName),
+    example("findSkillMd: finds by YAML name field (case-insensitive)", testFindByYamlName),
+    example("findSkillMd: returns None when skill not found", testFindNotFound),
+    example("findSkillMd: prefers direct path over recursive match", testFindPrefersDirectPath),
+  )
+
+  // --- formatInstalls ---
+
+  private def testFormatMillions: Result =
+    Result.all(
+      List(
+        Search.formatInstalls(1_500_000L) ==== "1.5M installs",
+        Search.formatInstalls(2_000_000L) ==== "2.0M installs",
+        Search.formatInstalls(10_300_000L) ==== "10.3M installs",
+      )
+    )
+
+  private def testFormatThousands: Result =
+    Result.all(
+      List(
+        Search.formatInstalls(1_500L) ==== "1.5K installs",
+        Search.formatInstalls(18_002L) ==== "18.0K installs",
+        Search.formatInstalls(999_999L) ==== "1000.0K installs",
+      )
+    )
+
+  private def testFormatSmall: Result =
+    Result.all(
+      List(
+        Search.formatInstalls(1L) ==== "1 installs",
+        Search.formatInstalls(42L) ==== "42 installs",
+        Search.formatInstalls(999L) ==== "999 installs",
+      )
+    )
+
+  private def testFormatZero: Result =
+    Search.formatInstalls(0L) ==== "0 installs"
+
+  private def testFormatBoundaryThousand: Result =
+    Search.formatInstalls(1000L) ==== "1.0K installs"
+
+  private def testFormatBoundaryMillion: Result =
+    Search.formatInstalls(1_000_000L) ==== "1.0M installs"
+
+  // --- collectSkillMds ---
+
+  private def withTempDir[A](f: os.Path => A): A = {
+    val dir = os.temp.dir(prefix = "search-test-")
+    try f(dir)
+    finally os.remove.all(dir)
+  }
+
+  private def createSkillMd(dir: os.Path, name: String, yamlName: String): os.Path = {
+    val skillDir = dir / name
+    os.makeDir.all(skillDir)
+    val mdPath   = skillDir / "SKILL.md"
+    os.write(
+      mdPath,
+      s"""---
+         |name: $yamlName
+         |description: A test skill
+         |---
+         |Content here
+         |""".stripMargin,
+    )
+    mdPath
+  }
+
+  private def testCollectDirect: Result =
+    withTempDir { dir =>
+      val _       = createSkillMd(dir, "skill-a", "Skill A")
+      val _       = createSkillMd(dir, "skill-b", "Skill B")
+      val results = Search.collectSkillMds(dir)
+      results.length ==== 2
+    }
+
+  private def testCollectNested: Result =
+    withTempDir { dir =>
+      val nested  = dir / "subdir"
+      os.makeDir.all(nested)
+      val _       = createSkillMd(nested, "nested-skill", "Nested Skill")
+      val results = Search.collectSkillMds(dir)
+      results.length ==== 1
+    }
+
+  private def testCollectNonExistent: Result =
+    Search.collectSkillMds(os.pwd / "non-existent-dir-xyz") ==== Nil
+
+  private def testCollectEmpty: Result =
+    withTempDir { dir =>
+      Search.collectSkillMds(dir) ==== Nil
+    }
+
+  private def testCollectIgnoresFiles: Result =
+    withTempDir { dir =>
+      os.write(dir / "README.md", "Not a skill")
+      val _       = createSkillMd(dir, "real-skill", "Real Skill")
+      val results = Search.collectSkillMds(dir)
+      results.length ==== 1
+    }
+
+  // --- findSkillMd ---
+
+  private def testFindDirectPath: Result =
+    withTempDir { dir =>
+      val md = createSkillMd(dir, "commit", "commit")
+      Search.findSkillMd(dir, "commit") ==== Some(md)
+    }
+
+  private def testFindUnderSkills: Result =
+    withTempDir { dir =>
+      val skillsDir = dir / "skills"
+      os.makeDir.all(skillsDir)
+      val md        = createSkillMd(skillsDir, "commit", "commit")
+      Search.findSkillMd(dir, "commit") ==== Some(md)
+    }
+
+  private def testFindByDirName: Result =
+    withTempDir { dir =>
+      val nested = dir / "some" / "path"
+      os.makeDir.all(nested)
+      val md     = createSkillMd(nested, "commit", "commit")
+      Search.findSkillMd(dir, "commit") ==== Some(md)
+    }
+
+  private def testFindByYamlName: Result =
+    withTempDir { dir =>
+      // Directory name is kebab-case, but YAML name has spaces
+      val md = createSkillMd(dir, "pdf-merge-split", "PDF Merge & Split")
+      Search.findSkillMd(dir, "pdf merge & split") ==== Some(md)
+    }
+
+  private def testFindNotFound: Result =
+    withTempDir { dir =>
+      val _ = createSkillMd(dir, "commit", "commit")
+      Search.findSkillMd(dir, "nonexistent") ==== None
+    }
+
+  private def testFindPrefersDirectPath: Result =
+    withTempDir { dir =>
+      // Create both a direct match and a nested match
+      val directMd  = createSkillMd(dir, "commit", "commit")
+      val nestedDir = dir / "other"
+      os.makeDir.all(nestedDir)
+      val _         = createSkillMd(nestedDir, "commit", "commit")
+      // Direct path should be preferred
+      Search.findSkillMd(dir, "commit") ==== Some(directMd)
+    }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/SearchTypes.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/SearchTypes.scala
@@ -1,0 +1,29 @@
+package aiskills.core
+
+import cats.*
+import cats.derived.*
+
+enum SearchLocation derives Eq, Show {
+  case Marketplace, Local
+}
+
+final case class SearchOptions(
+  query: Option[String],
+  location: Option[SearchLocation],
+) derives Eq,
+      Show
+
+final case class MarketplaceResult(
+  name: String,
+  source: String,
+  description: String,
+  installs: Long,
+  marketplace: String,
+) derives Eq,
+      Show
+
+final case class LocalSearchResult(
+  skill: Skill,
+  score: Int,
+) derives Eq,
+      Show

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/LocalSearch.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/LocalSearch.scala
@@ -1,0 +1,47 @@
+package aiskills.core.utils
+
+import aiskills.core.{LocalSearchResult, Skill}
+import cats.syntax.all.*
+
+object LocalSearch {
+
+  /** Fuzzy search installed skills by matching query against name and description.
+    *
+    * Scoring:
+    *  - Exact name match: 100
+    *  - Name starts with query: 80
+    *  - Name contains query: 60
+    *  - Description contains query: 30
+    *
+    * Returns results sorted by score descending, filtered to score > 0.
+    */
+  def fuzzySearch(query: String, skills: List[Skill]): List[LocalSearchResult] = {
+    val q = query.toLowerCase.trim
+    if q.length < 2 then Nil
+    else
+      skills
+        .map { skill =>
+          val score = scoreSkill(q, skill)
+          LocalSearchResult(skill, score)
+        }
+        .filter(_.score > 0)
+        .sortBy(-_.score)
+  }
+
+  private def scoreSkill(query: String, skill: Skill): Int = {
+    val name = skill.name.toLowerCase
+    val desc = skill.description.toLowerCase
+
+    val nameScore =
+      if name === query then 100
+      else if name.startsWith(query) then 80
+      else if name.contains(query) then 60
+      else 0
+
+    val descScore =
+      if desc.contains(query) then 30
+      else 0
+
+    math.max(nameScore, descScore)
+  }
+}

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/MarketplaceSearch.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/MarketplaceSearch.scala
@@ -1,0 +1,140 @@
+package aiskills.core.utils
+
+import aiskills.core.MarketplaceResult
+import io.circe.{Decoder, HCursor}
+
+import scala.util.Try
+
+object MarketplaceSearch {
+
+  private val SkillsShBaseUrl     = "https://skills.sh/api/search"
+  private val AgentSkillShBaseUrl = "https://agentskill.sh/api/skills"
+  private val CurlTimeout         = "10"
+  private val SkillsShLimit       = 20
+
+  // --- skills.sh ---
+
+  final private case class SkillsShSkill(
+    name: String,
+    installs: Long,
+    source: String,
+  )
+  private object SkillsShSkill {
+    given Decoder[SkillsShSkill] = (c: HCursor) =>
+      for {
+        name     <- c.get[String]("name")
+        installs <- c.get[Long]("installs")
+        source   <- c.get[String]("source")
+      } yield SkillsShSkill(name, installs, source)
+  }
+
+  final private case class SkillsShResponse(skills: List[SkillsShSkill])
+  private object SkillsShResponse {
+    given Decoder[SkillsShResponse] = (c: HCursor) => c.get[List[SkillsShSkill]]("skills").map(SkillsShResponse(_))
+  }
+
+  def searchSkillsSh(query: String): List[MarketplaceResult] = {
+    val url = s"$SkillsShBaseUrl?q=${urlEncode(query)}&limit=$SkillsShLimit"
+    curlJson(url)
+      .flatMap(parseSkillsShJson)
+      .getOrElse(Nil)
+  }
+
+  /** Parse skills.sh API JSON response into MarketplaceResult list. */
+  def parseSkillsShJson(json: String): Option[List[MarketplaceResult]] =
+    io.circe.parser.decode[SkillsShResponse](json).toOption.map { response =>
+      response.skills.map { skill =>
+        MarketplaceResult(
+          name = skill.name,
+          source = skill.source,
+          description = "",
+          installs = skill.installs,
+          marketplace = "skills.sh",
+        )
+      }
+    }
+
+  // --- agentskill.sh ---
+
+  final private case class AgentSkillShSkill(
+    name: String,
+    owner: String,
+    description: String,
+    installCount: Long,
+    githubRepo: String,
+  )
+  private object AgentSkillShSkill {
+    given Decoder[AgentSkillShSkill] = (c: HCursor) =>
+      for {
+        name         <- c.get[String]("name")
+        owner        <- c.get[String]("owner")
+        description  <- c.getOrElse[String]("description")("")
+        installCount <- c.getOrElse[Long]("installCount")(0L)
+        githubRepo   <- c.getOrElse[String]("githubRepo")("")
+      } yield AgentSkillShSkill(name, owner, description, installCount, githubRepo)
+  }
+
+  final private case class AgentSkillShResponse(data: List[AgentSkillShSkill])
+  private object AgentSkillShResponse {
+    given Decoder[AgentSkillShResponse] =
+      (c: HCursor) => c.get[List[AgentSkillShSkill]]("data").map(AgentSkillShResponse(_))
+  }
+
+  def searchAgentSkillSh(query: String): List[MarketplaceResult] = {
+    val url = s"$AgentSkillShBaseUrl?q=${urlEncode(query)}"
+    curlJson(url)
+      .flatMap(parseAgentSkillShJson)
+      .getOrElse(Nil)
+  }
+
+  /** Parse agentskill.sh API JSON response into MarketplaceResult list. */
+  def parseAgentSkillShJson(json: String): Option[List[MarketplaceResult]] =
+    io.circe.parser.decode[AgentSkillShResponse](json).toOption.map { response =>
+      response.data.map { skill =>
+        val source =
+          if skill.githubRepo.nonEmpty then s"${skill.owner}/${skill.githubRepo}"
+          else skill.owner
+        MarketplaceResult(
+          name = skill.name,
+          source = source,
+          description = skill.description,
+          installs = skill.installCount,
+          marketplace = "agentskill.sh",
+        )
+      }
+    }
+
+  // --- Combined search ---
+
+  /** Search both marketplaces and deduplicate by (name, source). */
+  def searchAll(query: String): List[MarketplaceResult] = {
+    val skillsSh   = searchSkillsSh(query)
+    val agentSkill = searchAgentSkillSh(query)
+    deduplicateResults(skillsSh ++ agentSkill)
+  }
+
+  /** Deduplicate results by (name, source), preferring higher installs and longer descriptions. */
+  def deduplicateResults(results: List[MarketplaceResult]): List[MarketplaceResult] =
+    results
+      .groupBy(r => (r.name.toLowerCase, r.source.toLowerCase))
+      .values
+      .map { group =>
+        group.maxBy(r => (r.installs, r.description.length))
+      }
+      .toList
+      .sortBy(-_.installs)
+
+  // --- Utilities ---
+
+  private def curlJson(url: String): Option[String] =
+    Try {
+      os.proc("curl", "-s", "-f", "--max-time", CurlTimeout, url)
+        .call(stderr = os.Pipe)
+        .out
+        .text()
+        .trim
+    }.toOption.filter(_.nonEmpty)
+
+  private def urlEncode(s: String): String =
+    java.net.URLEncoder.encode(s, "UTF-8")
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/LocalSearchSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/LocalSearchSpec.scala
@@ -1,0 +1,167 @@
+package aiskills.core.utils
+
+import aiskills.core.{Agent, Skill, SkillLocation}
+import hedgehog.*
+import hedgehog.runner.*
+
+object LocalSearchSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("fuzzySearch: exact name match scores 100", testExactNameMatch),
+    example("fuzzySearch: name prefix match scores 80", testNamePrefixMatch),
+    example("fuzzySearch: name contains match scores 60", testNameContainsMatch),
+    example("fuzzySearch: description contains match scores 30", testDescriptionContainsMatch),
+    example("fuzzySearch: name match takes priority over description match", testNameOverDescription),
+    example("fuzzySearch: case insensitive matching", testCaseInsensitive),
+    example("fuzzySearch: returns empty for query shorter than 2 chars", testShortQuery),
+    example("fuzzySearch: returns empty when no skills match", testNoMatch),
+    example("fuzzySearch: returns empty for empty skills list", testEmptySkills),
+    example("fuzzySearch: results sorted by score descending", testSortedByScore),
+    example("fuzzySearch: filters out zero-score results", testFiltersZeroScore),
+    example("fuzzySearch: trims and lowercases query", testTrimsQuery),
+    example("fuzzySearch: multiple skills with different scores", testMultipleSkills),
+  )
+
+  private def skill(name: String, description: String): Skill =
+    Skill(
+      name = name,
+      description = description,
+      location = SkillLocation.Project,
+      agent = Agent.Claude,
+      path = os.pwd / ".claude" / "skills" / name,
+    )
+
+  private def testExactNameMatch: Result = {
+    val skills  = List(skill("commit", "Create git commits"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 100,
+      )
+    )
+  }
+
+  private def testNamePrefixMatch: Result = {
+    val skills  = List(skill("commit-work", "Commit and push work"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 80,
+      )
+    )
+  }
+
+  private def testNameContainsMatch: Result = {
+    val skills  = List(skill("git-commit-helper", "Helps with git"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 60,
+      )
+    )
+  }
+
+  private def testDescriptionContainsMatch: Result = {
+    val skills  = List(skill("helper", "Helps you commit code"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 30,
+      )
+    )
+  }
+
+  private def testNameOverDescription: Result = {
+    val skills  = List(skill("commit", "Does commit things"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    // Name exact match (100) should win over description match (30)
+    results.head.score ==== 100
+  }
+
+  private def testCaseInsensitive: Result = {
+    val skills  = List(skill("Git-Commit", "A tool"))
+    val results = LocalSearch.fuzzySearch("git-commit", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 100,
+      )
+    )
+  }
+
+  private def testShortQuery: Result = {
+    val skills = List(skill("a-skill", "description"))
+    Result.all(
+      List(
+        LocalSearch.fuzzySearch("", skills) ==== Nil,
+        LocalSearch.fuzzySearch("a", skills) ==== Nil,
+      )
+    )
+  }
+
+  private def testNoMatch: Result = {
+    val skills  = List(skill("pdf-reader", "Reads PDF files"))
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    results ==== Nil
+  }
+
+  private def testEmptySkills: Result =
+    LocalSearch.fuzzySearch("commit", Nil) ==== Nil
+
+  private def testSortedByScore: Result = {
+    val skills  = List(
+      skill("helper-commit-tool", "A tool"), // contains -> 60
+      skill("commit", "Create commits"), // exact -> 100
+      skill("commit-work", "Does work"), // prefix -> 80
+      skill("something", "Helps you commit changes"), // desc only -> 30
+    )
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    val scores  = results.map(_.score)
+    scores ==== List(100, 80, 60, 30)
+  }
+
+  private def testFiltersZeroScore: Result = {
+    val skills  = List(
+      skill("commit", "A tool"),
+      skill("unrelated", "Nothing relevant here"),
+      skill("pdf-reader", "Reads files"),
+    )
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    results.length ==== 1
+  }
+
+  private def testTrimsQuery: Result = {
+    val skills  = List(skill("commit", "A tool"))
+    val results = LocalSearch.fuzzySearch("  commit  ", skills)
+    Result.all(
+      List(
+        results.length ==== 1,
+        results.head.score ==== 100,
+      )
+    )
+  }
+
+  private def testMultipleSkills: Result = {
+    val skills  = List(
+      skill("commit", "Exact match"),
+      skill("commit-msg", "Prefix match"),
+      skill("auto-commit", "Contains match"),
+    )
+    val results = LocalSearch.fuzzySearch("commit", skills)
+    Result.all(
+      List(
+        results.length ==== 3,
+        results(0).skill.name ==== "commit",
+        results(0).score ==== 100,
+        results(1).skill.name ==== "commit-msg",
+        results(1).score ==== 80,
+        results(2).skill.name ==== "auto-commit",
+        results(2).score ==== 60,
+      )
+    )
+  }
+}

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/MarketplaceSearchSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/MarketplaceSearchSpec.scala
@@ -1,0 +1,175 @@
+package aiskills.core.utils
+
+import aiskills.core.MarketplaceResult
+import hedgehog.*
+import hedgehog.runner.*
+
+object MarketplaceSearchSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    // skills.sh JSON parsing
+    example("parseSkillsShJson: parses valid response", testParseSkillsShValid),
+    example("parseSkillsShJson: returns None for invalid JSON", testParseSkillsShInvalid),
+    example("parseSkillsShJson: returns None for empty string", testParseSkillsShEmpty),
+    example("parseSkillsShJson: handles empty skills array", testParseSkillsShEmptyArray),
+    // agentskill.sh JSON parsing
+    example("parseAgentSkillShJson: parses valid response", testParseAgentSkillShValid),
+    example("parseAgentSkillShJson: constructs source from owner and githubRepo", testParseAgentSkillShSource),
+    example("parseAgentSkillShJson: uses owner when githubRepo is empty", testParseAgentSkillShOwnerOnly),
+    example("parseAgentSkillShJson: returns None for invalid JSON", testParseAgentSkillShInvalid),
+    example("parseAgentSkillShJson: handles missing optional fields", testParseAgentSkillShOptionalFields),
+    // Deduplication
+    example("deduplicateResults: removes duplicates by name and source", testDeduplicateRemovesDuplicates),
+    example("deduplicateResults: prefers higher installs", testDeduplicatePrefersHigherInstalls),
+    example("deduplicateResults: prefers longer description on tie", testDeduplicatePrefersLongerDesc),
+    example("deduplicateResults: case-insensitive deduplication", testDeduplicateCaseInsensitive),
+    example("deduplicateResults: sorts by installs descending", testDeduplicateSortOrder),
+    example("deduplicateResults: returns empty for empty input", testDeduplicateEmpty),
+    example("deduplicateResults: keeps distinct skills", testDeduplicateKeepsDistinct),
+  )
+
+  // --- skills.sh ---
+
+  private def testParseSkillsShValid: Result = {
+    val json    =
+      """{"query":"commit","searchType":"fuzzy","skills":[{"id":"owner/repo/skill","skillId":"skill","name":"git-commit","installs":1000,"source":"owner/repo"}],"count":1}"""
+    val results = MarketplaceSearch.parseSkillsShJson(json)
+    Result.all(
+      List(
+        Result.assert(results.isDefined),
+        results.get.length ==== 1,
+        results.get.head.name ==== "git-commit",
+        results.get.head.source ==== "owner/repo",
+        results.get.head.installs ==== 1000L,
+        results.get.head.marketplace ==== "skills.sh",
+        results.get.head.description ==== "",
+      )
+    )
+  }
+
+  private def testParseSkillsShInvalid: Result =
+    MarketplaceSearch.parseSkillsShJson("not json") ==== None
+
+  private def testParseSkillsShEmpty: Result =
+    MarketplaceSearch.parseSkillsShJson("") ==== None
+
+  private def testParseSkillsShEmptyArray: Result = {
+    val json    = """{"skills":[],"count":0}"""
+    val results = MarketplaceSearch.parseSkillsShJson(json)
+    Result.all(
+      List(
+        Result.assert(results.isDefined),
+        results.get ==== Nil,
+      )
+    )
+  }
+
+  // --- agentskill.sh ---
+
+  private def testParseAgentSkillShValid: Result = {
+    val json    =
+      """{"data":[{"name":"commit","owner":"test-user","description":"A commit skill","installCount":500,"githubRepo":"my-skills"}],"total":1}"""
+    val results = MarketplaceSearch.parseAgentSkillShJson(json)
+    Result.all(
+      List(
+        Result.assert(results.isDefined),
+        results.get.length ==== 1,
+        results.get.head.name ==== "commit",
+        results.get.head.installs ==== 500L,
+        results.get.head.marketplace ==== "agentskill.sh",
+        results.get.head.description ==== "A commit skill",
+      )
+    )
+  }
+
+  private def testParseAgentSkillShSource: Result = {
+    val json    =
+      """{"data":[{"name":"skill","owner":"alice","description":"","installCount":0,"githubRepo":"agent-skills"}]}"""
+    val results = MarketplaceSearch.parseAgentSkillShJson(json)
+    results.get.head.source ==== "alice/agent-skills"
+  }
+
+  private def testParseAgentSkillShOwnerOnly: Result = {
+    val json    =
+      """{"data":[{"name":"skill","owner":"alice","description":"","installCount":0,"githubRepo":""}]}"""
+    val results = MarketplaceSearch.parseAgentSkillShJson(json)
+    results.get.head.source ==== "alice"
+  }
+
+  private def testParseAgentSkillShInvalid: Result =
+    MarketplaceSearch.parseAgentSkillShJson("{invalid}") ==== None
+
+  private def testParseAgentSkillShOptionalFields: Result = {
+    // description, installCount, githubRepo all have defaults
+    val json    =
+      """{"data":[{"name":"skill","owner":"bob"}]}"""
+    val results = MarketplaceSearch.parseAgentSkillShJson(json)
+    Result.all(
+      List(
+        Result.assert(results.isDefined),
+        results.get.head.description ==== "",
+        results.get.head.installs ==== 0L,
+        results.get.head.source ==== "bob",
+      )
+    )
+  }
+
+  // --- Deduplication ---
+
+  private def testDeduplicateRemovesDuplicates: Result = {
+    val results = List(
+      MarketplaceResult("commit", "owner/repo", "desc1", 100, "skills.sh"),
+      MarketplaceResult("commit", "owner/repo", "desc2", 200, "agentskill.sh"),
+    )
+    MarketplaceSearch.deduplicateResults(results).length ==== 1
+  }
+
+  private def testDeduplicatePrefersHigherInstalls: Result = {
+    val results = List(
+      MarketplaceResult("commit", "owner/repo", "", 100, "skills.sh"),
+      MarketplaceResult("commit", "owner/repo", "", 500, "agentskill.sh"),
+    )
+    val deduped = MarketplaceSearch.deduplicateResults(results)
+    deduped.head.installs ==== 500L
+  }
+
+  private def testDeduplicatePrefersLongerDesc: Result = {
+    val results = List(
+      MarketplaceResult("commit", "owner/repo", "", 100, "skills.sh"),
+      MarketplaceResult("commit", "owner/repo", "A useful skill", 100, "agentskill.sh"),
+    )
+    val deduped = MarketplaceSearch.deduplicateResults(results)
+    deduped.head.description ==== "A useful skill"
+  }
+
+  private def testDeduplicateCaseInsensitive: Result = {
+    val results = List(
+      MarketplaceResult("Commit", "Owner/Repo", "", 100, "skills.sh"),
+      MarketplaceResult("commit", "owner/repo", "", 200, "agentskill.sh"),
+    )
+    MarketplaceSearch.deduplicateResults(results).length ==== 1
+  }
+
+  private def testDeduplicateSortOrder: Result = {
+    val results = List(
+      MarketplaceResult("alpha", "a/repo", "", 50, "skills.sh"),
+      MarketplaceResult("beta", "b/repo", "", 200, "skills.sh"),
+      MarketplaceResult("gamma", "c/repo", "", 100, "skills.sh"),
+    )
+    val deduped = MarketplaceSearch.deduplicateResults(results)
+    val names   = deduped.map(_.name)
+    names ==== List("beta", "gamma", "alpha")
+  }
+
+  private def testDeduplicateEmpty: Result =
+    MarketplaceSearch.deduplicateResults(Nil) ==== Nil
+
+  private def testDeduplicateKeepsDistinct: Result = {
+    val results = List(
+      MarketplaceResult("commit", "owner/repo-a", "", 100, "skills.sh"),
+      MarketplaceResult("commit", "owner/repo-b", "", 200, "skills.sh"),
+      MarketplaceResult("pdf", "owner/repo-a", "", 50, "skills.sh"),
+    )
+    MarketplaceSearch.deduplicateResults(results).length ==== 3
+  }
+}


### PR DESCRIPTION
# Close #109: Add `search` command for discovering skills from marketplaces and local installations

Add a new `search` command that lets users find skills from two sources:

- Marketplace search: queries `skills.sh` and `agentskill.sh` public APIs via curl, parses JSON responses with circe, deduplicates results by (name, source), and sorts by install count.
- Local search: fuzzy matches installed skills by scoring against name (exact=100, prefix=80, contains=60) and description (contains=30), returning results sorted by score.

Supported CLI modes:
  - `aiskills search` — full interactive (pick location, enter query, select results)
  - `aiskills search <query>` — interactive with pre-filled query
  - `aiskills search <query> --marketplace` — direct marketplace search
  - `aiskills search <query> --local` — direct local fuzzy search
  - `--local` and `--marketplace` are mutually exclusive

After selecting results, users choose an action:
  - Marketplace: `read` (clone + display `SKILL.md`), `install`, or `list`
  - Local: `read` or `list`

Marketplace install clones each repo once (grouped by source), resolves skill directories by matching YAML `name` fields (handles cases where marketplace names like "pdf merge & split" differ from directory names like "pdf-merge-split"), prompts for agents and location once upfront, and writes proper git metadata (sourceType, repoUrl, subpath) to `.aiskills.json`.

New files:
  - `SearchTypes.scala` — `SearchLocation`, `MarketplaceResult`, `LocalSearchResult`
  - `MarketplaceSearch.scala` — HTTP search via curl for both marketplaces
  - `LocalSearch.scala` — fuzzy scoring on installed skills
  - `Search.scala` — CLI command with interactive flows and install logic