### PR TITLE
Close #106: Make `MultipleChoice` mandatory requiring at least one selection

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/CliDefaults.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/CliDefaults.scala
@@ -1,10 +1,22 @@
 package aiskills.cli
 
-import cue4s.Prompt
+import cue4s.{Prompt, PromptError}
 
 object CliDefaults {
   val MultiChoiceWindowSize: Int = 20
 
   val multiChoiceModify: Prompt.MultipleChoice => Prompt.MultipleChoice =
     _.withWindowSize(MultiChoiceWindowSize)
+
+  def mandatoryMultiChoiceNoneSelected(label: String, options: List[String]): Prompt[List[String]] =
+    multiChoiceModify(Prompt.MultipleChoice.withNoneSelected(label, options))
+      .mapValidated(ls =>
+        Either.cond(ls.nonEmpty, ls, PromptError("Please select at least one, or press Ctrl+C to cancel."))
+      )
+
+  def mandatoryMultiChoiceAllSelected(label: String, options: List[String]): Prompt[List[String]] =
+    multiChoiceModify(Prompt.MultipleChoice.withAllSelected(label, options))
+      .mapValidated(ls =>
+        Either.cond(ls.nonEmpty, ls, PromptError("Please select at least one, or press Ctrl+C to cancel."))
+      )
 }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -137,13 +137,9 @@ object Install {
 
     aiskills.cli.SigintHandler.install()
     val result = Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select target agent(s)", agentLabels)) match {
         case Completion.Finished(selectedLabels) =>
-          val selected = Agent.all.filter(a => selectedLabels.contains(a.toString))
-          if selected.isEmpty then {
-            println("No agents selected. Installation cancelled.".yellow)
-            0.asLeft
-          } else selected.asRight
+          Agent.all.filter(a => selectedLabels.contains(a.toString)).asRight
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
           0.asLeft
@@ -561,13 +557,9 @@ object Install {
 
         aiskills.cli.SigintHandler.install()
         val result = Prompts.sync.use { prompts =>
-          prompts.multiChoiceAllSelected("Select skills to install", labels, CliDefaults.multiChoiceModify) match {
+          prompts.run(CliDefaults.mandatoryMultiChoiceAllSelected("Select skills to install", labels)) match {
             case Completion.Finished(selectedLabels) =>
-              if selectedLabels.isEmpty then {
-                println("No skills selected. Installation cancelled.".yellow)
-                List.empty[SkillInfo].asRight
-              } else
-                selectByLabel(labels, skillInfos, selectedLabels).asRight
+              selectByLabel(labels, skillInfos, selectedLabels).asRight
 
             case Completion.Fail(CompletionError.Interrupted) =>
               println("\n\nCancelled by user".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -119,7 +119,7 @@ object ListCmd {
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select agent(s)", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selected = agentsWithCounts
             .filter { (agent, _) =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -181,7 +181,7 @@ object Read {
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select agent(s)", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selected = agentsWithCounts
             .filter { (agent, _) =>
@@ -212,7 +212,7 @@ object Read {
 
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skill(s) to read", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select skill(s) to read", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selectedIndices = selectedLabels.flatMap { label =>
             labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -76,10 +76,9 @@ object Remove {
 
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skills to remove", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select skills to remove", labels)) match {
         case Completion.Finished(selectedLabels) =>
-          if selectedLabels.isEmpty then println("No skills selected for removal.".yellow)
-          else {
+          {
             val selectedIndices = selectedLabels.flatMap { label =>
               labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
             }
@@ -140,7 +139,7 @@ object Remove {
     }
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select agent(s)", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select agent(s)", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selected = agentsWithCounts
             .filter { (agent, _) =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -84,12 +84,10 @@ object Search {
       promptForMarketplaceResults(results) match {
         case Left(code) => sys.exit(code)
         case Right(selected) =>
-          if selected.isEmpty then println("No skills selected.".yellow)
-          else
-            promptForMarketplaceAction() match {
-              case Left(code) => sys.exit(code)
-              case Right(action) => executeMarketplaceAction(action, selected)
-            }
+          promptForMarketplaceAction() match {
+            case Left(code) => sys.exit(code)
+            case Right(action) => executeMarketplaceAction(action, selected)
+          }
       }
     }
   }
@@ -102,7 +100,7 @@ object Search {
 
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skill(s)", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select skill(s)", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selectedIndices = selectedLabels.flatMap { label =>
             labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
@@ -217,8 +215,7 @@ object Search {
       case Left(code) => sys.exit(code)
       case Right(a) => a
     }
-    if agents.isEmpty then println("No agents selected. Installation cancelled.".yellow)
-    else {
+    {
       val locations = promptForInstallLocation(agents) match {
         case Left(code) => sys.exit(code)
         case Right(l) => l
@@ -437,7 +434,7 @@ object Search {
     val agentLabels = Agent.all.map(_.toString)
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select target agent(s)", agentLabels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select target agent(s)", agentLabels)) match {
         case Completion.Finished(selectedLabels) =>
           Agent.all.filter(a => selectedLabels.contains(a.toString)).asRight
         case Completion.Fail(CompletionError.Interrupted) =>
@@ -557,12 +554,10 @@ object Search {
         promptForLocalResults(results) match {
           case Left(code) => sys.exit(code)
           case Right(selected) =>
-            if selected.isEmpty then println("No skills selected.".yellow)
-            else
-              promptForLocalAction() match {
-                case Left(code) => sys.exit(code)
-                case Right(action) => executeLocalAction(action, selected)
-              }
+            promptForLocalAction() match {
+              case Left(code) => sys.exit(code)
+              case Right(action) => executeLocalAction(action, selected)
+            }
         }
       }
     }
@@ -577,7 +572,7 @@ object Search {
 
     aiskills.cli.SigintHandler.install()
     Prompts.sync.use { prompts =>
-      prompts.multiChoiceNoneSelected("Select skill(s)", labels, CliDefaults.multiChoiceModify) match {
+      prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select skill(s)", labels)) match {
         case Completion.Finished(selectedLabels) =>
           val selectedIndices = selectedLabels.flatMap { label =>
             labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -405,11 +405,7 @@ object Sync {
             val selectedSkills = {
               aiskills.cli.SigintHandler.install()
               val result = Prompts.sync.use { prompts =>
-                prompts.multiChoiceAllSelected(
-                  "Select skills to sync",
-                  skillLabels,
-                  CliDefaults.multiChoiceModify
-                ) match {
+                prompts.run(CliDefaults.mandatoryMultiChoiceAllSelected("Select skills to sync", skillLabels)) match {
                   case Completion.Finished(selectedLabels) =>
                     sourceSkills.filter(s => selectedLabels.exists(_.startsWith(s.name))).asRight
                   case Completion.Fail(CompletionError.Interrupted) =>
@@ -461,10 +457,8 @@ object Sync {
               val selectedTargets = {
                 aiskills.cli.SigintHandler.install()
                 val result = Prompts.sync.use { prompts =>
-                  prompts.multiChoiceNoneSelected(
-                    "Select target agent(s)",
-                    targetLabels,
-                    CliDefaults.multiChoiceModify
+                  prompts.run(
+                    CliDefaults.mandatoryMultiChoiceNoneSelected("Select target agent(s)", targetLabels)
                   ) match {
                     case Completion.Finished(selectedLabels) =>
                       targetAgents.filter(a => selectedLabels.contains(a.toString)).asRight


### PR DESCRIPTION
# Close #106: Make `MultipleChoice` mandatory requiring at least one selection

Add `mandatoryMultiChoiceNoneSelected` and `mandatoryMultiChoiceAllSelected`
helpers in `CliDefaults` that use `mapValidated` to enforce at least one
selection before the prompt can be dismissed.

Replace all `multiChoiceNoneSelected` / `multiChoiceAllSelected` call sites
across all commands with `prompts.run(CliDefaults.mandatoryMultiChoice...(...))`:
- `Install`: agent selection and skills-to-install selection
- `Remove`: skills-to-remove and agent selection
- `ListCmd`: agent selection
- `Read`: agent and skill selection
- `Sync`: skills-to-sync and target agent selection
- `Search`: marketplace results, local results, and agent selection

Remove now-unreachable empty-selection guard branches (`if selected.isEmpty`)
since the mandatory prompt guarantees at least one item is chosen. Users who
want to cancel can press Ctrl+C instead.