### PR TITLE
Fix #111: Skip install location prompt when `pwd` is `$HOME`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -127,7 +127,10 @@ object Install {
       case Some(agents) => (agents, options.locations)
       case None =>
         val agents    = promptForAgents()
-        val locations = if options.locations.nonEmpty then options.locations else promptForLocation(agents)
+        val locations =
+          if options.locations.nonEmpty then options.locations
+          else if os.pwd == os.home then Set(SkillLocation.Global)
+          else promptForLocation(agents)
         (agents, locations)
     }
   }
@@ -217,7 +220,9 @@ object Install {
         println(s"Installing from: ${source.cyan}")
         println(s"Location: $locationDisplay")
         if agents.length <= 1 && locations.size <= 1 then {
-          if !isProject then println(s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim)
+          if !isProject && os.pwd != os.home then println(
+            s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim
+          )
           else ()
         } else ()
         println()


### PR DESCRIPTION
# Fix #111: Skip install location prompt when `pwd` is `$HOME`

When the current working directory is `$HOME`, the "Select install location" interactive prompt (global/project/both) is unnecessary because project and global scopes resolve to the same directories.

In `resolveAgentsAndLocation`, when no `--global`/`--project` flags are provided and `os.pwd == os.home`, automatically default to `Set(SkillLocation.Global)` without prompting.

Also suppress the "Omit --global for ./$folder" hint message in that case, since the suggestion would be misleading — the project path is identical to the global path when `pwd` is `$HOME`.