### PR TITLE
Close #116: Add confirmation prompt before removing skills

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/Main.scala
@@ -401,6 +401,7 @@ object Main {
           |  aiskills remove commit --agent claude --project --global  # Both scopes, Claude
           |  aiskills remove commit --agent all --project              # Project, all agents
           |  aiskills remove commit --agent all --project --global     # Everywhere, all agents
+          |  aiskills remove commit --agent claude --project -y        # Skip confirmation
           |""".stripMargin,
       ) {
         val skillName = Opts.argument[String](metavar = "skill-name").orNone
@@ -413,11 +414,14 @@ object Main {
             short = "a",
           )
           .orNone
-        (skillName, project, global, agent).mapN { (sn, p, g, a) =>
+        val yes       = Opts.flag("yes", "Skip removal confirmation", short = "y").orFalse
+        (skillName, project, global, agent, yes).mapN { (sn, p, g, a, y) =>
           sn match {
             case None =>
-              if p || g || a.isDefined then {
-                System.err.println("Error: Must specify a skill name when using --project, --global, or --agent.")
+              if p || g || a.isDefined || y then {
+                System
+                  .err
+                  .println("Error: Must specify a skill name when using --project, --global, --agent, or --yes.")
                 System.err.println()
                 System.err.println("  Example: aiskills remove commit --project --agent claude")
                 System.err.println()
@@ -468,7 +472,7 @@ object Main {
                 }
                 .getOrElse(Nil)
 
-              Remove.removeSkill(name, RemoveOptions(locations = locations, agent = parsedAgents.some))
+              Remove.removeSkill(name, RemoveOptions(locations = locations, agent = parsedAgents.some, yes = y))
           }
         }
       }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -78,25 +78,31 @@ object Remove {
     Prompts.sync.use { prompts =>
       prompts.run(CliDefaults.mandatoryMultiChoiceNoneSelected("Select skills to remove", labels)) match {
         case Completion.Finished(selectedLabels) =>
-          {
-            val selectedIndices = selectedLabels.flatMap { label =>
-              labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
-            }
-            val removedSkills   = selectedIndices.map(sorted(_))
-            for skill <- removedSkills do {
-              os.remove.all(skill.path)
-              val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
-              println(
-                s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
-              )
-            }
-
-            val agentLocationPairs = removedSkills.map(s => (s.agent, s.location)).distinct
-            for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
-
-            println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
+          val selectedIndices = selectedLabels.flatMap { label =>
+            labels.zipWithIndex.find { case (l, _) => l === label }.map { case (_, idx) => idx }
           }
-          ().asRight
+          val selectedSkills  = selectedIndices.map(sorted(_))
+          confirmRemoval(selectedSkills) match {
+            case Right(true) =>
+              for skill <- selectedSkills do {
+                os.remove.all(skill.path)
+                val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
+                println(
+                  s"\u2705 Removed: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
+                )
+              }
+
+              val agentLocationPairs = selectedSkills.map(s => (s.agent, s.location)).distinct
+              for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+
+              println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
+              ().asRight
+            case Right(false) =>
+              println("Cancelled.".yellow)
+              ().asRight
+            case Left(code) =>
+              code.asLeft
+          }
 
         case Completion.Fail(CompletionError.Interrupted) =>
           println("\n\nCancelled by user".yellow)
@@ -157,6 +163,59 @@ object Remove {
     }
   }
 
+  private def confirmRemoval(skills: List[Skill]): Either[Int, Boolean] = {
+    println(s"\nThe following skill(s) will be removed:")
+    for skill <- skills do {
+      val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
+      val locationColor =
+        if skill.location === SkillLocation.Project then skill.location.toString.toLowerCase.blue
+        else skill.location.toString.toLowerCase.yellow
+      println(s"  - ${skill.name.bold} ($locationColor, ${skill.agent.toString.cyan.bold}): ${pathLabel.dim}")
+    }
+    println()
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.confirm("Are you sure?", default = false) match {
+        case Completion.Finished(confirmed) =>
+          confirmed.asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
+  private def confirmRemovalNonInteractive(
+    skillName: String,
+    foundTargets: List[(Agent, SkillLocation)]
+  ): Either[Int, Boolean] = {
+    println(s"\nThe following skill(s) will be removed:")
+    for (agent, location) <- foundTargets do {
+      val pathLabel     = Dirs.displaySkillsDir(agent, location)
+      val locationColor =
+        if location === SkillLocation.Project then location.toString.toLowerCase.blue
+        else location.toString.toLowerCase.yellow
+      println(s"  - ${skillName.bold} ($locationColor, ${agent.toString.cyan.bold}): ${pathLabel.dim}")
+    }
+    println()
+    aiskills.cli.SigintHandler.install()
+    Prompts.sync.use { prompts =>
+      prompts.confirm("Are you sure?", default = false) match {
+        case Completion.Finished(confirmed) =>
+          confirmed.asRight
+        case Completion.Fail(CompletionError.Interrupted) =>
+          println("\n\nCancelled by user".yellow)
+          0.asLeft
+        case Completion.Fail(CompletionError.Error(msg)) =>
+          System.err.println(s"Error: $msg")
+          1.asLeft
+      }
+    }
+  }
+
   /** Remove a specific skill by name from the specified agent(s) and location(s). */
   def removeSkill(skillName: String, options: RemoveOptions): Unit = {
     val locations: List[SkillLocation] = options.locations.toList
@@ -168,30 +227,20 @@ object Remove {
       location <- locations
     } yield (agent, location)
 
-    val removed  = List.newBuilder[(aiskills.core.Agent, SkillLocation)]
-    val notFound = List.newBuilder[(aiskills.core.Agent, SkillLocation)]
+    val found    = List.newBuilder[(Agent, SkillLocation)]
+    val notFound = List.newBuilder[(Agent, SkillLocation)]
 
     for (agent, location) <- targets do {
       val skillDir = Dirs.getSkillsDir(agent, location) / skillName
-      if os.exists(skillDir / "SKILL.md") then {
-        os.remove.all(skillDir)
-        val pathLabel = Dirs.displaySkillsDir(agent, location)
-        println(
-          s"\u2705 Removed: $skillName (${location.toString.toLowerCase}, ${agent.toString}): $pathLabel".green
-        )
-        removed += agent -> location
-      } else {
-        notFound += agent -> location
-      }
+      if os.exists(skillDir / "SKILL.md")
+      then found += agent    -> location
+      else notFound += agent -> location
     }
 
-    val removedResult  = removed.result()
+    val foundResult    = found.result()
     val notFoundResult = notFound.result()
 
-    val agentLocationPairs = removedResult.distinct
-    for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
-
-    if removedResult.isEmpty then {
+    if foundResult.isEmpty then {
       val targetDescs = notFoundResult
         .map { (agent, location) =>
           s"${location.toString.toLowerCase}/${agent.toString}"
@@ -199,15 +248,40 @@ object Remove {
         .mkString(", ")
       System.err.println(s"Error: Skill '$skillName' not found in: $targetDescs")
       sys.exit(1)
-    } else if notFoundResult.nonEmpty then {
-      for (agent, location) <- notFoundResult do {
-        val pathLabel = Dirs.displaySkillsDir(agent, location)
-        System
-          .err
-          .println(
-            s"Warning: Skill '$skillName' not found in ${location.toString.toLowerCase}/${agent.toString}: $pathLabel"
-          )
+    }
+
+    val confirmed =
+      if options.yes then { true }
+      else {
+        confirmRemovalNonInteractive(skillName, foundResult) match {
+          case Right(c) => c
+          case Left(code) => sys.exit(code)
+        }
       }
-    } else ()
+
+    if confirmed then {
+      for (agent, location) <- foundResult do {
+        val skillDir  = Dirs.getSkillsDir(agent, location) / skillName
+        os.remove.all(skillDir)
+        val pathLabel = Dirs.displaySkillsDir(agent, location)
+        println(
+          s"\u2705 Removed: $skillName (${location.toString.toLowerCase}, ${agent.toString}): $pathLabel".green
+        )
+      }
+
+      val agentLocationPairs = foundResult.distinct
+      for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+
+      if notFoundResult.nonEmpty then {
+        for (agent, location) <- notFoundResult do {
+          val pathLabel = Dirs.displaySkillsDir(agent, location)
+          System
+            .err
+            .println(
+              s"Warning: Skill '$skillName' not found in ${location.toString.toLowerCase}/${agent.toString}: $pathLabel"
+            )
+        }
+      } else ()
+    } else println("Cancelled.".yellow)
   }
 }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -184,6 +184,7 @@ object AiSkillsError {
 final case class RemoveOptions(
   locations: Set[SkillLocation],
   agent: Option[List[Agent]],
+  yes: Boolean,
 ) derives Eq,
       Show
 


### PR DESCRIPTION
# Close #116: Add confirmation prompt before removing skills

The `remove` command now asks for final confirmation (y/N) before deleting any skills, preventing accidental removals from a premature Enter press.

- Add a y/N confirmation prompt using cue4s `Prompt.Confirmation` (default: No) that displays a styled summary of skills to be removed before deletion, in both interactive and non-interactive flows.
- Confirmation summary uses colored output: skill name in bold, location in blue (project) or yellow (global), agent in cyan bold, and path in dim.
- Add `--yes` / `-y` flag to the non-interactive `remove` command to skip the confirmation prompt for scripting/automation use cases.
- Add `yes: Boolean` field to `RemoveOptions` in Types.scala.
- Refactor `removeSkill` (non-interactive) into two passes: first collect which targets exist, then confirm, then delete.
- Update validation to reject `--yes` without a skill name.