### PR TITLE
Fix #113: Recognize skills in repositories with root-level or deeply nested `SKILL.md`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -2,7 +2,7 @@ package aiskills.cli.commands
 
 import OverwritePrompt.{BulkDecision, OverwriteChoice}
 import aiskills.cli.CliDefaults
-import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMetadata, Yaml}
+import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMdFinder, SkillMetadata, Yaml}
 import aiskills.core.*
 import cats.syntax.all.*
 import cue4s.*
@@ -105,9 +105,13 @@ object Install {
   def skillLabel(skillName: String, subpath: String, size: Long): String =
     s"${skillName.padTo(25, ' ')} ($subpath)".padTo(60, ' ') + s" ${formatSize(size)}"
 
-  /** Format a skill name with its subpath for display in messages. */
-  def skillNameWithSubpath(skillName: String, subpath: String): String =
-    s"$skillName ($subpath)"
+  /** Format a skill name with its subpath for display in messages.
+    * Empty or whitespace-only subpath renders as `<root>` to distinguish root-level skills.
+    */
+  def skillNameWithSubpath(skillName: String, subpath: String): String = {
+    val shown = if subpath.trim.isEmpty then "<root>" else subpath
+    s"$skillName ($shown)"
+  }
 
   /** Read the subpath of an already-installed skill from its metadata. */
   def existingSubpathLabel(targetPath: os.Path): String =
@@ -515,15 +519,7 @@ object Install {
     val skillInfos: List[SkillInfo] =
       if rootSkillInfos.nonEmpty then rootSkillInfos
       else {
-        def findSkills(dir: os.Path): List[os.Path] =
-          os.list(dir).toList.flatMap { entry =>
-            if os.isDir(entry) then {
-              if os.exists(entry / "SKILL.md") then List(entry)
-              else findSkills(entry)
-            } else Nil
-          }
-
-        val skillDirs = findSkills(repoDir)
+        val skillDirs = SkillMdFinder.listSkillMds(repoDir).map(_ / os.up)
 
         if skillDirs.isEmpty then {
           System.err.println("Error: No SKILL.md files found in repository".red)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -1,8 +1,19 @@
 package aiskills.cli.commands
 
 import aiskills.cli.CliDefaults
-import aiskills.core.utils.{AgentsMd, Dirs, LocalSearch, MarketplaceSearch, SkillMetadata, Skills, TerminalWidth, Yaml}
+import aiskills.core.utils.{
+  AgentsMd,
+  Dirs,
+  LocalSearch,
+  MarketplaceSearch,
+  SkillMdFinder,
+  SkillMetadata,
+  Skills,
+  TerminalWidth,
+  Yaml
+}
 import aiskills.core.*
+import aiskills.core.given
 import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
@@ -261,13 +272,16 @@ object Search {
 
               val repoDir = tempDir / "repo"
 
-              // Build list of (skillDir, metadata) for all found skills, then install across all agent×location combos
+              // Build list of (skillDir, installName, metadata) for all found skills, then install across all agent×location combos
               val skillEntries = skillNames.flatMap { name =>
                 findSkillMd(repoDir, name) match {
                   case Some(skillMdPath) =>
-                    val skillDir = skillMdPath / os.up
-                    val subpath  = skillDir.relativeTo(repoDir).toString
-                    val metadata = SkillSourceMetadata(
+                    val skillDir    = skillMdPath / os.up
+                    val subpath     = skillDir.relativeTo(repoDir).toString
+                    val content     = Try(os.read(skillMdPath)).getOrElse("")
+                    val yamlName    = Yaml.extractYamlField(content, "name")
+                    val installName = resolveInstallName(skillDir, repoDir, yamlName, name)
+                    val metadata    = SkillSourceMetadata(
                       source = source,
                       sourceType = SkillSourceType.Git,
                       repoUrl = actualUrl.some,
@@ -275,7 +289,7 @@ object Search {
                       localPath = none[String],
                       installedAt = aiskills.core.utils.isoNow(),
                     )
-                    List((skillDir, metadata))
+                    List((skillDir, installName, metadata))
 
                   case None =>
                     System.err.println(s"SKILL.md not found for '$name' in $source".yellow)
@@ -285,14 +299,15 @@ object Search {
 
               // Install each skill across all agent×location combos, threading BulkDecision
               val installTargets = for {
-                (skillDir, metadata) <- skillEntries
-                agent                <- agents
-                location             <- locations.toList
-              } yield (skillDir, agent, location, metadata)
+                (skillDir, installName, metadata) <- skillEntries
+                agent                             <- agents
+                location                          <- locations.toList
+              } yield (skillDir, installName, agent, location, metadata)
 
               installTargets.foldLeft((0, bulk)) {
-                case ((skillCount, currentBulk), (skillDir, agent, location, metadata)) =>
-                  val (installed, nextBulk) = installSingleSkill(skillDir, agent, location, metadata, currentBulk)
+                case ((skillCount, currentBulk), (skillDir, installName, agent, location, metadata)) =>
+                  val (installed, nextBulk) =
+                    installSingleSkill(skillDir, installName, agent, location, metadata, currentBulk)
                   (skillCount + (if installed then 1 else 0), nextBulk)
               }
           }
@@ -319,6 +334,7 @@ object Search {
     */
   private def installSingleSkill(
     skillDir: os.Path,
+    installName: String,
     agent: Agent,
     location: SkillLocation,
     metadata: SkillSourceMetadata,
@@ -334,7 +350,9 @@ object Search {
       if isProject then os.pwd / os.RelPath(folder)
       else os.home / os.RelPath(folder)
 
-    val skillName     = skillDir.last
+    val skillName     = installName
+    val subpath       = metadata.subpath.getOrElse("")
+    val labeledName   = Install.skillNameWithSubpath(skillName, subpath)
     val targetPath    = targetDir / skillName
     val locationLabel = s"(${location.toString.toLowerCase}, ${agent.toString})"
 
@@ -346,32 +364,35 @@ object Search {
         (false, bulk)
       } else if !os.exists(targetPath) then {
         copyAndWriteMetadata(skillDir, targetPath, metadata)
-        println(s"\u2705 Installed: $skillName $locationLabel".green)
+        println(s"\u2705 Installed: $labeledName $locationLabel".green)
         (true, bulk)
       } else {
         bulk match {
           case BulkDecision.OverwriteAll =>
-            overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+            overwriteAndInstall(skillDir, targetPath, labeledName, locationLabel, metadata)
             (true, bulk)
 
           case BulkDecision.SkipAll =>
-            println(s"Skipped: $skillName $locationLabel".yellow)
+            println(s"Skipped: $labeledName $locationLabel".yellow)
             (false, bulk)
 
           case BulkDecision.Undecided =>
+            val existingSubpath = Install.existingSubpathLabel(targetPath)
+            println(s"   Existing: ${Install.skillNameWithSubpath(skillName, existingSubpath)}".dim)
+            println(s"   New:      $labeledName".dim)
             OverwritePrompt.askOverwriteChoice(
               skillName,
-              s"Skill '$skillName' already exists at $locationLabel. What would you like to do?",
+              s"Skill '$skillName' already exists at $locationLabel. Replace with '$labeledName'?",
             ) match {
               case Left(code) =>
                 sys.exit(code)
 
               case Right(OverwriteChoice.Yes) =>
-                overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+                overwriteAndInstall(skillDir, targetPath, labeledName, locationLabel, metadata)
                 (true, BulkDecision.Undecided)
 
               case Right(OverwriteChoice.No) =>
-                println(s"Skipped: $skillName $locationLabel".yellow)
+                println(s"Skipped: $labeledName $locationLabel".yellow)
                 (false, BulkDecision.Undecided)
 
               case Right(OverwriteChoice.Rename) =>
@@ -388,16 +409,16 @@ object Search {
                       os.write.over(skillMdPath, updated)
                     } else ()
                     SkillMetadata.writeSkillMetadata(newTargetPath, metadata.copy(name = newName.some))
-                    println(s"\u2705 Installed: $skillName as $newName $locationLabel".green)
+                    println(s"\u2705 Installed: $labeledName as $newName $locationLabel".green)
                     (true, BulkDecision.Undecided)
                 }
 
               case Right(OverwriteChoice.YesToAll) =>
-                overwriteAndInstall(skillDir, targetPath, skillName, locationLabel, metadata)
+                overwriteAndInstall(skillDir, targetPath, labeledName, locationLabel, metadata)
                 (true, BulkDecision.OverwriteAll)
 
               case Right(OverwriteChoice.NoToAll) =>
-                println(s"Skipped: $skillName $locationLabel".yellow)
+                println(s"Skipped: $labeledName $locationLabel".yellow)
                 (false, BulkDecision.SkipAll)
             }
         }
@@ -420,14 +441,14 @@ object Search {
   private def overwriteAndInstall(
     skillDir: os.Path,
     targetPath: os.Path,
-    skillName: String,
+    labeledName: String,
     locationLabel: String,
     metadata: SkillSourceMetadata,
   ): Unit = {
-    println(s"Overwriting: $skillName $locationLabel".dim)
+    println(s"Overwriting: $labeledName $locationLabel".dim)
     os.remove.all(targetPath)
     copyAndWriteMetadata(skillDir, targetPath, metadata)
-    println(s"\u2705 Installed: $skillName $locationLabel".green)
+    println(s"\u2705 Installed: $labeledName $locationLabel".green)
   }
 
   private def promptForAgents(): Either[Int, List[Agent]] = {
@@ -472,6 +493,28 @@ object Search {
     }
   }
 
+  /** Compute the install folder name for a skill discovered under a cloned repo.
+    *
+    * Preference order:
+    *   - Root-level skill (`skillDir == repoDir`): YAML `name:` -> marketplaceName -> `skillDir.last`
+    *   - Non-root skill: `skillDir.last` -> YAML `name:` -> marketplaceName
+    *
+    * Blank (whitespace-only) candidates are skipped. Falls back to `skillDir.last` if no candidate is non-blank.
+    */
+  private[commands] def resolveInstallName(
+    skillDir: os.Path,
+    repoDir: os.Path,
+    yamlName: String,
+    marketplaceName: String,
+  ): String = {
+    val dirName    = skillDir.last
+    val isRoot     = skillDir === repoDir
+    val candidates =
+      if isRoot then List(yamlName, marketplaceName, dirName)
+      else List(dirName, yamlName, marketplaceName)
+    candidates.find(_.trim.nonEmpty).getOrElse(dirName)
+  }
+
   /** Find a SKILL.md in a repo by skill name.
     *
     * Matching strategy (in priority order):
@@ -506,19 +549,11 @@ object Search {
     }
   }
 
-  /** Collect all SKILL.md files under a directory (non-recursive into SKILL.md subdirs). */
+  /** Collect every SKILL.md under a directory. Uses 'git ls-files' when the directory is a git working tree
+    * (honors .gitignore and never enters .git); falls back to a filesystem walk that skips .git otherwise.
+    */
   private[commands] def collectSkillMds(dir: os.Path): List[os.Path] =
-    Try(os.list(dir)).toOption match {
-      case None => Nil
-      case Some(entries) =>
-        entries.toList.flatMap { entry =>
-          if Try(os.isDir(entry)).getOrElse(false) then {
-            val md = entry / "SKILL.md"
-            if os.exists(md) then List(md)
-            else collectSkillMds(entry)
-          } else Nil
-        }
-    }
+    SkillMdFinder.listSkillMds(dir)
 
   private def displayMarketplaceResults(results: List[MarketplaceResult]): Unit = {
     println("\nSearch Results:\n".bold)

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
@@ -62,6 +62,11 @@ object InstallSpec extends Properties {
     // skillNameWithSubpath
     example("skillNameWithSubpath: formats name with subpath", testSkillNameWithSubpath),
     example("skillNameWithSubpath: distinguishes duplicate names by subpath", testSkillNameWithSubpathDuplicates),
+    example("skillNameWithSubpath: empty subpath renders as <root>", testSkillNameWithSubpathEmpty),
+    example(
+      "skillNameWithSubpath: whitespace-only subpath renders as <root>",
+      testSkillNameWithSubpathWhitespaceOnly,
+    ),
     // existingSubpathLabel
     example("existingSubpathLabel: returns subpath from metadata", testExistingSubpathLabelWithMetadata),
     example("existingSubpathLabel: returns empty when no metadata", testExistingSubpathLabelNoMetadata),
@@ -345,6 +350,12 @@ object InstallSpec extends Properties {
       )
     )
   }
+
+  private def testSkillNameWithSubpathEmpty: Result =
+    Install.skillNameWithSubpath("foo", "") ==== "foo (<root>)"
+
+  private def testSkillNameWithSubpathWhitespaceOnly: Result =
+    Install.skillNameWithSubpath("foo", "   ") ==== "foo (<root>)"
 
   // existingSubpathLabel tests
   private def testExistingSubpathLabelWithMetadata: Result = {

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
@@ -19,6 +19,9 @@ object SearchSpec extends Properties {
     example("collectSkillMds: returns empty for non-existent directory", testCollectNonExistent),
     example("collectSkillMds: returns empty for empty directory", testCollectEmpty),
     example("collectSkillMds: ignores files (non-directories)", testCollectIgnoresFiles),
+    example("collectSkillMds: finds SKILL.md at the root of the directory", testCollectRootLevel),
+    example("collectSkillMds: finds nested SKILL.md past an ancestor SKILL.md", testCollectNestedPastAncestor),
+    example("collectSkillMds: skips .git directory", testCollectSkipsDotGit),
     // findSkillMd
     example("findSkillMd: finds by direct path", testFindDirectPath),
     example("findSkillMd: finds under skills/ directory", testFindUnderSkills),
@@ -26,6 +29,27 @@ object SearchSpec extends Properties {
     example("findSkillMd: finds by YAML name field (case-insensitive)", testFindByYamlName),
     example("findSkillMd: returns None when skill not found", testFindNotFound),
     example("findSkillMd: prefers direct path over recursive match", testFindPrefersDirectPath),
+    example("findSkillMd: finds root-level SKILL.md by YAML name", testFindRootLevelByYamlName),
+    example("findSkillMd: finds deeply nested skill past an ancestor SKILL.md", testFindNestedPastAncestor),
+    // resolveInstallName
+    example("resolveInstallName: non-root uses skillDir.last", testResolveNameNonRootUsesDirName),
+    example(
+      "resolveInstallName: non-root prefers dirName over yamlName",
+      testResolveNameNonRootPrefersDirNameOverYaml,
+    ),
+    example("resolveInstallName: root uses yamlName first", testResolveNameRootUsesYaml),
+    example(
+      "resolveInstallName: root falls back to marketplaceName when yamlName is blank",
+      testResolveNameRootFallsBackToMarketplaceWhenYamlBlank,
+    ),
+    example(
+      "resolveInstallName: root falls back to skillDir.last when yamlName and marketplaceName are blank",
+      testResolveNameRootFallsBackToDirNameWhenYamlAndMarketBlank,
+    ),
+    example(
+      "resolveInstallName: root prefers yamlName over marketplaceName",
+      testResolveNameRootPrefersYamlOverMarketplace,
+    ),
   )
 
   // --- formatInstalls ---
@@ -90,6 +114,21 @@ object SearchSpec extends Properties {
     mdPath
   }
 
+  private def createSkillMdAt(dir: os.Path, yamlName: String): os.Path = {
+    os.makeDir.all(dir)
+    val mdPath = dir / "SKILL.md"
+    os.write(
+      mdPath,
+      s"""---
+         |name: $yamlName
+         |description: A test skill
+         |---
+         |Content here
+         |""".stripMargin,
+    )
+    mdPath
+  }
+
   private def testCollectDirect: Result =
     withTempDir { dir =>
       val _       = createSkillMd(dir, "skill-a", "Skill A")
@@ -121,6 +160,33 @@ object SearchSpec extends Properties {
       val _       = createSkillMd(dir, "real-skill", "Real Skill")
       val results = Search.collectSkillMds(dir)
       results.length ==== 1
+    }
+
+  private def testCollectRootLevel: Result =
+    withTempDir { dir =>
+      val _ = createSkillMdAt(dir, "root-skill")
+      Search.collectSkillMds(dir) ==== List(dir / "SKILL.md")
+    }
+
+  private def testCollectNestedPastAncestor: Result =
+    withTempDir { dir =>
+      val _ = createSkillMdAt(dir / "a", "a-skill")
+      val _ = createSkillMdAt(dir / "a" / "b", "b-skill")
+      val _ = createSkillMdAt(dir / "a" / "b" / "c", "c-skill")
+      Search.collectSkillMds(dir).length ==== 3
+    }
+
+  private def testCollectSkipsDotGit: Result =
+    withTempDir { dir =>
+      val _       = createSkillMdAt(dir / ".git", "hidden")
+      val realMd  = createSkillMd(dir, "real-skill", "real-skill")
+      val results = Search.collectSkillMds(dir)
+      Result.all(
+        List(
+          results.length ==== 1,
+          results ==== List(realMd),
+        )
+      )
     }
 
   // --- findSkillMd ---
@@ -169,5 +235,81 @@ object SearchSpec extends Properties {
       val _         = createSkillMd(nestedDir, "commit", "commit")
       // Direct path should be preferred
       Search.findSkillMd(dir, "commit") ==== Some(directMd)
+    }
+
+  private def testFindRootLevelByYamlName: Result =
+    withTempDir { dir =>
+      val md = createSkillMdAt(dir, "ai-pdf-filler-cli")
+      Search.findSkillMd(dir, "ai-pdf-filler-cli") ==== Some(md)
+    }
+
+  private def testFindNestedPastAncestor: Result =
+    withTempDir { dir =>
+      val srcDir       = dir / "Packs" / "Utilities" / "src"
+      val documentsDir = srcDir / "Documents"
+      val pdfDir       = documentsDir / "Pdf"
+      val _            = createSkillMdAt(srcDir, "utilities-src")
+      val _            = createSkillMdAt(documentsDir, "documents")
+      val pdfMd        = createSkillMdAt(pdfDir, "Pdf")
+      Search.findSkillMd(dir, "Pdf") ==== Some(pdfMd)
+    }
+
+  // --- resolveInstallName ---
+
+  private def testResolveNameNonRootUsesDirName: Result =
+    withTempDir { repoDir =>
+      val skillDir = repoDir / "foo"
+      Search.resolveInstallName(skillDir, repoDir, yamlName = "Y", marketplaceName = "M") ==== "foo"
+    }
+
+  private def testResolveNameNonRootPrefersDirNameOverYaml: Result =
+    withTempDir { repoDir =>
+      val skillDir = repoDir / "kebab-case"
+      Search.resolveInstallName(
+        skillDir,
+        repoDir,
+        yamlName = "Human Readable",
+        marketplaceName = "m",
+      ) ==== "kebab-case"
+    }
+
+  private def testResolveNameRootUsesYaml: Result =
+    withTempDir { repoDir =>
+      Search.resolveInstallName(
+        repoDir,
+        repoDir,
+        yamlName = "ai-pdf-filler-cli",
+        marketplaceName = "ai-pdf-filler-cli",
+      ) ==== "ai-pdf-filler-cli"
+    }
+
+  private def testResolveNameRootFallsBackToMarketplaceWhenYamlBlank: Result =
+    withTempDir { repoDir =>
+      Search.resolveInstallName(
+        repoDir,
+        repoDir,
+        yamlName = "",
+        marketplaceName = "my-skill",
+      ) ==== "my-skill"
+    }
+
+  private def testResolveNameRootFallsBackToDirNameWhenYamlAndMarketBlank: Result =
+    withTempDir { repoDir =>
+      Search.resolveInstallName(
+        repoDir,
+        repoDir,
+        yamlName = "",
+        marketplaceName = "",
+      ) ==== repoDir.last
+    }
+
+  private def testResolveNameRootPrefersYamlOverMarketplace: Result =
+    withTempDir { repoDir =>
+      Search.resolveInstallName(
+        repoDir,
+        repoDir,
+        yamlName = "from-yaml",
+        marketplaceName = "from-market",
+      ) ==== "from-yaml"
     }
 }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMdFinder.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMdFinder.scala
@@ -1,0 +1,53 @@
+package aiskills.core.utils
+
+import cats.syntax.all.*
+
+import scala.util.Try
+
+object SkillMdFinder {
+
+  /** Collect every SKILL.md under a directory. Uses 'git ls-files' when the directory is a git working tree
+    * (honors .gitignore and never enters .git); falls back to a filesystem walk that skips .git otherwise.
+    */
+  def listSkillMds(dir: os.Path): List[os.Path] =
+    listSkillMdsViaGit(dir).getOrElse(listSkillMdsViaFs(dir))
+
+  /** Use `git ls-files` to enumerate every SKILL.md under a git working tree.
+    * Returns None when the directory is not a git repo, git is unavailable, or the command fails.
+    */
+  private def listSkillMdsViaGit(repoDir: os.Path): Option[List[os.Path]] =
+    Try {
+      val result = os
+        .proc("git", "-C", repoDir.toString, "ls-files", "-z", "--cached", "--others", "--exclude-standard")
+        .call(check = false, stderr = os.Pipe, mergeErrIntoOut = false)
+      if result.exitCode =!= 0 then {
+        none[List[os.Path]]
+      } else {
+        val paths = result
+          .out
+          .text()
+          .split('\u0000')
+          .iterator
+          .filter(_.nonEmpty)
+          .map(segment => repoDir / os.RelPath(segment))
+          .filter(p => p.last === "SKILL.md")
+          .filter(p => Try(os.exists(p)).getOrElse(false))
+          .toList
+        paths.some
+      }
+    }.toOption.flatten
+
+  /** Filesystem fallback: collect every SKILL.md under `dir`, skipping `.git` directories. */
+  def listSkillMdsViaFs(dir: os.Path): List[os.Path] = {
+    val here     = {
+      val md = dir / "SKILL.md"
+      if os.exists(md) && Try(os.isFile(md)).getOrElse(false) then List(md) else Nil
+    }
+    val children = Try(os.list(dir)).toOption.getOrElse(Vector.empty).toList
+    val nested   = children.flatMap { entry =>
+      if Try(os.isDir(entry)).getOrElse(false) && entry.last =!= ".git" then listSkillMdsViaFs(entry)
+      else Nil
+    }
+    here ++ nested
+  }
+}


### PR DESCRIPTION
# Fix #113: Recognize skills in repositories with root-level or deeply nested `SKILL.md`

Previously, `search` + `install` and direct `install` failed to recognize skills when the `SKILL.md` sat at the repository root (e.g. `askyourpdf/ai-pdf-filler`) or was nested beneath another `SKILL.md` (e.g. `danielmiessler/Personal_AI_Infrastructure` where `Packs/Utilities/src/Documents/Pdf/SKILL.md` was blocked by the ancestor `Packs/Utilities/src/SKILL.md`). The discovery logic only inspected subdirectories (missing root-level files) and short-circuited as soon as a `SKILL.md` was found at any level (missing nested skills).

Introduce a shared `SkillMdFinder` utility that enumerates every `SKILL.md` under a directory, used by both `Search.collectSkillMds` and `Install.installFromRepo`. When the directory is a git working tree, it shells out to `git ls-files --cached --others --exclude-standard` to honor `.gitignore` and to never enter `.git`; otherwise it falls back to a filesystem walk that always checks the directory itself, always recurses, and skips `.git`.

Also fix a related bug where a skill installed from a repository with a root-level `SKILL.md` was installed under the temporary clone folder name `repo` instead of the skill's actual name. A new `resolveInstallName` helper picks the install folder name from `skillDir.last` -> YAML `name:` -> marketplace-queried name (non-root), or YAML `name:` -> marketplace-queried name -> `skillDir.last` (root).

Tests cover root-level discovery, nested-past-ancestor discovery, `.git` skipping, and each branch of `resolveInstallName`.