### PR TITLE
Close #120: Add the same metadata as `list`'s result to the result of the `read` command

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -159,7 +159,7 @@ object ListCmd {
       val locationLabel =
         s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
       println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
-      SkillDisplay.renderInfoBlock(skill)
+      SkillDisplay.renderInfoBlock(skill.path)
       println(s"    ${skill.description.dim}\n")
     }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -68,8 +68,8 @@ object Read {
       for ((name, skill), idx) <- resolvedList.zipWithIndex do {
         if idx > 0 then println(separator)
         val content = os.read(skill.path)
-        println("       Reading:".bold + s" ${name.blue.bold}")
-        println("Base directory:".bold + s" ${Dirs.displayPath(skill.baseDir).yellow.bold}")
+        println(SkillDisplay.padLabel("Reading:").bold + s" ${name.blue.bold}")
+        SkillDisplay.renderInfoBlock(skill.baseDir)
 
         println()
         println(content)
@@ -134,8 +134,8 @@ object Read {
                             if idx > 0 then println(separator)
                             val skillPath = skill.path / "SKILL.md"
                             val content   = os.read(skillPath)
-                            println("       Reading:".bold + s" ${skill.name.blue.bold}")
-                            println("Base directory:".bold + s" ${Dirs.displayPath(skill.path).yellow.bold}")
+                            println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
+                            SkillDisplay.renderInfoBlock(skill.path)
                             println()
                             println(content)
                             println()

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -264,8 +264,9 @@ object Search {
   private def readMarketplaceSkillsEnriched(cloned: List[ClonedSkill]): Unit = {
     for (c, idx) <- cloned.zipWithIndex do {
       if idx > 0 then println(separator)
-      println("       Reading:".bold + s" ${c.result.name.blue.bold}")
-      println("        Source:".bold + s" ${c.result.source.yellow.bold} [${c.result.marketplace}]")
+      println(SkillDisplay.padLabel("Reading:").bold + s" ${c.result.name.blue.bold}")
+      println(SkillDisplay.padLabel("Source:").bold + s" ${c.result.source.yellow.bold} [${c.result.marketplace}]")
+      renderMarketplaceInfoBlock(c)
       println()
       if c.skillMdPath.isDefined && c.content.nonEmpty then println(c.content)
       else println("(SKILL.md not found)".yellow)
@@ -609,6 +610,23 @@ object Search {
     (" " * pad) + label
   }
 
+  /** Render the marketplace metadata block (sourceType/source/subpath/name) for a cloned skill.
+    * Used by both marketplace list and marketplace read flows.
+    */
+  private def renderMarketplaceInfoBlock(c: ClonedSkill): Unit = {
+    val r = c.result
+    println(s"${padMarketplaceLabel("sourceType:").bold} git")
+    if r.source.nonEmpty then println(s"${padMarketplaceLabel("source:").bold} ${r.source}")
+    else ()
+
+    val subpathStr     = c.skillDir.relativeTo(c.repoDir).toString
+    val subpathDisplay =
+      if subpathStr.isEmpty || subpathStr === "." then "<root>"
+      else subpathStr
+    println(s"${padMarketplaceLabel("subpath:").bold} $subpathDisplay")
+    println(s"${padMarketplaceLabel("name:").bold} ${c.yamlName}")
+  }
+
   /** Marketplace list display using SKILL.md data from a pre-cloned selection.
     * Omits the `Base directory:` line because the skill is not installed.
     */
@@ -619,16 +637,7 @@ object Search {
       val installLabel = formatInstalls(r.installs)
       println(s"  ${r.name.bold.padTo(25, ' ')} ${r.source.cyan}")
 
-      println(s"${padMarketplaceLabel("sourceType:").bold} git")
-      if r.source.nonEmpty then println(s"${padMarketplaceLabel("source:").bold} ${r.source}")
-      else ()
-
-      val subpathStr     = c.skillDir.relativeTo(c.repoDir).toString
-      val subpathDisplay =
-        if subpathStr.isEmpty || subpathStr === "." then "<root>"
-        else subpathStr
-      println(s"${padMarketplaceLabel("subpath:").bold} $subpathDisplay")
-      println(s"${padMarketplaceLabel("name:").bold} ${c.yamlName}")
+      renderMarketplaceInfoBlock(c)
 
       val description =
         if c.description.nonEmpty then c.description
@@ -729,8 +738,8 @@ object Search {
       if idx > 0 then println(separator)
       val skillPath = skill.path / "SKILL.md"
       val content   = os.read(skillPath)
-      println("       Reading:".bold + s" ${skill.name.blue.bold}")
-      println("Base directory:".bold + s" ${Dirs.displayPath(skill.path).yellow.bold}")
+      println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
+      SkillDisplay.renderInfoBlock(skill.path)
       println()
       println(content)
       println()
@@ -767,7 +776,7 @@ object Search {
       val locationLabel =
         s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim
       println(s"  ${skill.name.padTo(25, ' ').bold} $locationLabel")
-      SkillDisplay.renderInfoBlock(skill)
+      SkillDisplay.renderInfoBlock(skill.path)
       println(s"    ${skill.description.dim}\n")
     }
     println(s"${skills.length} skill(s) shown".dim)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
@@ -1,6 +1,5 @@
 package aiskills.cli.commands
 
-import aiskills.core.Skill
 import aiskills.core.SkillSourceType
 import aiskills.core.utils.{Dirs, SkillMetadata, Yaml}
 import extras.scala.io.syntax.color.*
@@ -17,16 +16,16 @@ object SkillDisplay {
 
   private val ColonCol = 2 + BaseDirLabel.length // 17
 
-  private def padLabel(label: String): String = {
+  def padLabel(label: String): String = {
     val pad = ColonCol - label.length
     (" " * pad) + label
   }
 
-  def renderInfoBlock(skill: Skill): Unit = {
-    val baseDirDisplay = Dirs.displayPath(skill.path)
+  def renderInfoBlock(skillPath: os.Path): Unit = {
+    val baseDirDisplay = Dirs.displayPath(skillPath)
     println(s"${padLabel(BaseDirLabel).bold} ${baseDirDisplay.yellow.bold}")
 
-    val metadataOpt = SkillMetadata.readSkillMetadata(skill.path)
+    val metadataOpt = SkillMetadata.readSkillMetadata(skillPath)
 
     metadataOpt match {
       case None =>
@@ -55,7 +54,7 @@ object SkillDisplay {
         }
     }
 
-    val skillMdPath = skill.path / "SKILL.md"
+    val skillMdPath = skillPath / "SKILL.md"
     val yamlName    =
       if os.exists(skillMdPath) then Try(os.read(skillMdPath))
         .toOption


### PR DESCRIPTION
# Close #120: Add the same metadata as `list`'s result to the result of the `read` command

Unify the metadata block rendered by `read` with what `list` shows, so every `read` call site — installed (non-interactive and interactive), local `search` -> read, and marketplace `search` -> read — prints `Base directory`, `sourceType`, `source`, `subpath`, and `name`, with the `.aiskills.json`-missing fallback where applicable.

- Change `SkillDisplay.renderInfoBlock` to take `skillPath: os.Path` instead of a full `Skill`, so call sites that only hold a path (or a `SkillLocationInfo`) can reuse it without constructing a synthetic `Skill`. Update both existing callers (`ListCmd.displaySkills`, `Search.displayLocalResults`) to pass `skill.path`.
- `Read.readSkill` (non-interactive) and `Read.readInteractive` now call `renderInfoBlock` after the `Reading:` header; the standalone `Base directory:` line is removed because the info block prints it. The non-interactive path passes `skill.baseDir` (from `SkillLocationInfo`), the interactive path passes `skill.path` (from `Skill`).
- `Search.readLocalSkills` does the same for the local `search` -> read flow.
- Extract `Search.renderMarketplaceInfoBlock(ClonedSkill)` from the inlined block in `displayMarketplaceResultsEnriched` and call it from both that function (marketplace `list`) and `readMarketplaceSkillsEnriched` (marketplace `read`). Marketplace `read` also retains its distinctive `Source: <source> [<marketplace>]` line, since it carries marketplace-only info not in `.aiskills.json`.
- Make `SkillDisplay.padLabel` public and use it at the `Reading:` / `Source:` header lines (across `Read` and `Search`) so those labels share the same right-aligned column as the `Base directory:` / `sourceType:` / `source:` / `subpath:` / `name:` lines printed by the info block.