### PR TITLE
Close #122: Move the base directory for temporary clone directories from `$HOME` to the system-standard temp dir

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/TempDirCleanup.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/TempDirCleanup.scala
@@ -3,15 +3,25 @@ package aiskills.cli
 import aiskills.core.given
 import cats.syntax.all.*
 
+import java.nio.file.Files
+
 import scala.scalanative.libc.stdlib
 import scala.scalanative.unsafe.*
+import scala.util.Try
 
 object TempDirCleanup {
 
-  val TempDirPrefix: String = ".aiskills-temp-"
+  val TempDirPrefix: String = "aiskills-temp-"
+
+  private lazy val baseDir: os.Path = {
+    val fromEnv = sys.env.get("TMPDIR").filter(_.nonEmpty)
+    fromEnv.flatMap(v => Try(os.Path(v)).toOption).getOrElse(os.Path("/tmp"))
+  }
+
+  def tempBaseDir: os.Path = baseDir
 
   def isTempDir(dir: os.Path): Boolean =
-    (dir / os.up) === os.home && dir.last.startsWith(TempDirPrefix)
+    (dir / os.up) === baseDir && dir.last.startsWith(TempDirPrefix)
 
   def safeRemoveAll(dir: os.Path): Unit =
     if isTempDir(dir) then os.remove.all(dir) else ()
@@ -24,6 +34,14 @@ object TempDirCleanup {
 
   def unregister(dir: os.Path): Unit = {
     val _ = dirs.remove(dir)
+  }
+
+  def createTempDir(): os.Path = {
+    os.makeDir.all(baseDir)
+    val nioPath = Files.createTempDirectory(baseDir.toNIO, TempDirPrefix)
+    val path    = os.Path(nioPath)
+    register(path)
+    path
   }
 
   def clearAll(): Unit = {

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -311,9 +311,7 @@ object Install {
     } else {
       val (repoUrl, skillSubpath) = parseGitSource(source)
 
-      val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
-      os.makeDir.all(tempDir)
-      aiskills.cli.TempDirCleanup.register(tempDir)
+      val tempDir = aiskills.cli.TempDirCleanup.createTempDir()
 
       val spinner = Spinner.createDefaultSideEffect(
         SpinnerConfig

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -182,9 +182,7 @@ object Search {
       case (source, results) =>
         val repoUrl = s"https://github.com/$source"
 
-        val tempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}-${Integer.toHexString(source.hashCode)}"
-        os.makeDir.all(tempDir)
-        aiskills.cli.TempDirCleanup.register(tempDir)
+        val tempDir = aiskills.cli.TempDirCleanup.createTempDir()
 
         val spinner = Spinner.createDefaultSideEffect(
           SpinnerConfig

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -102,9 +102,7 @@ object Update {
               meta.repoUrl.fold("")(normalizeRepoUrl)
           }
 
-          val parentTempDir = os.home / s".aiskills-temp-${System.currentTimeMillis()}"
-          os.makeDir.all(parentTempDir)
-          aiskills.cli.TempDirCleanup.register(parentTempDir)
+          val parentTempDir = aiskills.cli.TempDirCleanup.createTempDir()
 
           try {
             groupedByRepo.iterator.zipWithIndex.foreach {
@@ -119,7 +117,7 @@ object Update {
                 val spinner = Spinner.createDefaultSideEffect(
                   SpinnerConfig
                     .default
-                    .withText(s"Cloning ${cloneUrl}${skillsLabel}...")
+                    .withText(s"Cloning $cloneUrl$skillsLabel...")
                     .withColor(Color.cyan)
                     .withIndent(2),
                 )


### PR DESCRIPTION
# Close #122: Move the base directory for temporary clone directories from `$HOME` to the system-standard temp dir

Previously, temporary directories used for cloning repositories were created under the user's home directory (`~/.aiskills-temp-<timestamp>`). This change moves them to the system-standard temp directory, resolved via the `TMPDIR` env var with a `/tmp` fallback, so they are cleaned up by the OS (e.g. on reboot on Linux, periodically on macOS) and no longer clutter the home directory.

Key changes in `TempDirCleanup`:
- Add `baseDir`, computed once from `TMPDIR` (falling back to `/tmp`), and expose it via `tempBaseDir`.
- Drop the leading dot from `TempDirPrefix` (`.aiskills-temp-` => `aiskills-temp-`). Hidden-file convention is only meaningful in `$HOME`; without the dot, temp dirs are easier to discover for manual cleanup (e.g. `ls $TMPDIR | grep aiskills-temp-`).
- Update the `isTempDir` safety guard to check `baseDir` instead of `os.home`, keeping `safeRemoveAll` strictly scoped to directories this tool created.
- Add `createTempDir()` which uses `java.nio.file.Files.createTempDirectory` for atomic, race-free creation with POSIX `0700` permissions, and registers the directory for atexit cleanup.

Call-site simplification in `Install`, `Search`, and `Update`:
- Replace the three-line pattern (`os.home / ...` + `os.makeDir.all` + `register`) with a single call to `TempDirCleanup.createTempDir()`.
- The per-source hash suffix in `Search` is no longer needed; `Files.createTempDirectory` guarantees uniqueness via its random suffix.