### PR TITLE
ai-skills v2.6.0

### DIFF
--- a/changelogs/2.6.0.md
+++ b/changelogs/2.6.0.md
@@ -1,0 +1,337 @@
+## [2.6.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am10) - 2026-04-13
+
+### Table of contents
+
+- [Improvement](#improvement)
+  - [Add `search` command with local and marketplace search (#109) 🔎](#add-search-command-with-local-and-marketplace-search-109-)
+  - [All multiple-choice prompts should be mandatory (#106)](#all-multiple-choice-prompts-should-be-mandatory-106)
+  - [Improve `search` and `list`: actions for searched skills can be repeated and `list` has more metadata (#112)](#improve-search-and-list-actions-for-searched-skills-can-be-repeated-and-list-has-more-metadata-112)
+    - [For `search` enhancement:](#for-search-enhancement)
+      - [For `marketplace`:](#for-marketplace)
+      - [For `local`:](#for-local)
+    - [`list` with more metadata:](#list-with-more-metadata)
+  - [The `remove` command should ask for final confirmation before removing the selected skills (#116)](#the-remove-command-should-ask-for-final-confirmation-before-removing-the-selected-skills-116)
+  - [Add more metadata to the output of the `read` command (#120)](#add-more-metadata-to-the-output-of-the-read-command-120)
+    - [`read`](#read)
+      - [Ineractive:](#ineractive)
+      - [Non-interactive](#non-interactive)
+    - [`search`](#search)
+      - [Local](#local)
+      - [Marketplace](#marketplace)
+  - [Move the temporary directory to a safer, ephemeral location that is cleared on reboot (#122)](#move-the-temporary-directory-to-a-safer-ephemeral-location-that-is-cleared-on-reboot-122)
+- [Bug Fixed](#bug-fixed)
+  - [Fixed: When `pwd` is `$HOME`, interactive mode should not ask to choose a location as it's always global for `$HOME` (#111)](#fixed-when-pwd-is-home-interactive-mode-should-not-ask-to-choose-a-location-as-its-always-global-for-home-111)
+  - [Fixed: Skills in some GitHub repositories are not recognized (#113)](#fixed-skills-in-some-github-repositories-are-not-recognized-113)
+
+
+## Improvement
+
+### Add `search` command with local and marketplace search (#109) 🔎
+
+```
+aiskills search                              # interactive mode to search
+aiskills search <search-query>               # interactive mode with search-query provided.
+aiskills search <search-query> --marketplace # search from marketplace
+aiskills search <search-query> --local       # search from all agents, local skills (both global and project)
+
+aiskills search <search-query> --local --marketplace # error, it should be either --local or --marketplace
+aiskills search --local       # error, <search-query> should be provided for --local
+aiskills search --marketplace # error, <search-query> should be provided for --marketplace
+```
+
+e.g.)
+
+Marketplace search
+```bash
+$ aiskills search
+✔ Search from  … marketplace
+✔ Enter search query … pdf
+Searching marketplaces for: pdf
+
+   ✔ Found 39 skill(s)
+
+? Select skill(s) ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ pdf                       anthropics/skills              51.2K installs [skills.sh]
+ ◯ pdftk-server              github/awesome-copilot         6.5K installs [skills.sh]
+ ◯ nano-pdf                  steipete/clawdis               1.6K installs [skills.sh]
+ ...
+ ◯ pdf form filler           claude-office-skills/skills    422 installs [skills.sh]
+ ◯ pdf watermark             claude-office-skills/skills    419 installs [skills.sh]
+ ◯ react-pdf                 vercel-labs/json-render        415 installs [skills.sh]
+ ◯ pdf-generator             jwynia/agent-skills            403 installs [skills.sh]
+ ◯ view-pdf                  anthropics/knowledge-work-plugins 354 installs [skills.sh]
+ ↓ ai-pdf-filler-cli         askyourpdf/ai-pdf-filler       341 installs [skills.sh]
+```
+
+Local search
+```bash
+$ aiskills search
+✔ Search from  … local
+✔ Enter search query … pdf
+Found 19 matching skill(s) for 'pdf':
+
+? Select skill(s) ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ pdf                       (project, Gemini): .gemini/skills
+ ◯ pdf-converter             (project, Cursor): .cursor/skills
+ ◯ pdf-2                     (project, Gemini): .gemini/skills
+ ...
+ ◯ view-pdf                  (project, Gemini): .gemini/skills
+ ◯ canvas-design             (project, Gemini): .gemini/skills
+ ◯ docx                      (project, Gemini): .gemini/skills
+```
+
+
+***
+
+### All multiple-choice prompts should be mandatory (#106)
+
+e.g.)
+multiple-choice before this release:
+```bash
+$ aiskills install anthropics/skills
+? Select target agent(s) ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◯ Universal
+ ◯ Claude
+ ◯ Cursor
+ ◯ Codex
+ ◯ Gemini
+ ◯ Windsurf
+ ◯ Copilot
+```
+Hit enter, then it immediately terminates the operation and shows
+```
+✔ Select target agent(s)
+nothing selected
+No agents selected. Installation cancelled.
+```
+
+Users often hit enter by mistake, so the multiple-choice prompts should be mandatory.
+
+After this release:
+```bash
+$ aiskills install anthropics/skills
+? Select target agent(s) ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+Please select at least one, or press Ctrl+C to cancel.
+ ◯ Universal
+ ◯ Claude
+ ◯ Cursor
+ ◯ Codex
+ ◯ Gemini
+ ◯ Windsurf
+ ◯ Copilot
+```
+Now, you get `Please select at least one, or press Ctrl+C to cancel.` message instead of ending the operation.
+
+***
+
+### Improve `search` and `list`: actions for searched skills can be repeated and `list` has more metadata (#112)
+
+#### For `search` enhancement:
+
+##### For `marketplace`:
+In `search`, after skill selection is done, it should ask if a user wants to `read`, `install`, `list` or `finish`.
+* `read`: will read all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
+* `list`: will list all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
+* `install`: will install all selected skills then it finishes.
+* `finish`: will finish.
+
+##### For `local`:
+* `read`: will read all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
+* `list`: will list all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
+* `finish`: will finish.
+
+#### `list` with more metadata:
+
+1. Because some skills may have folder names that differ from the `name`s in `SKILL.md`, it's good to include the `name` field from `SKILL.md` in the list.
+2. It should have the base directory just like the `read` command.
+3. It should have the source info including `sourceType`, `source` and `subpath`.
+
+The current version before this release is like
+```bash
+  document-generation-pdf   (project, Gemini): .gemini/skills
+    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital
+
+  pdf                       (project, Gemini): .gemini/skills
+    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+```
+
+So, after this release, with the new info mentioned above, it looks like the following.
+```bash
+  document-generation-pdf   (project, Gemini): .gemini/skills
+  Base directory: ~/git/username/path/to/project/.gemini/skills/document-generation-pdf
+      sourceType: git
+          source: curiositech/some_claude_skills
+         subpath: .claude/skills/document-generation-pdf
+            name: document-generation-pdf
+    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital
+
+  pdf                       (project, Gemini): .gemini/skills
+  Base directory: ~/git/username/path/to/project/.gemini/skills/pdf
+      sourceType: git
+          source: anthropics/skills
+         subpath: skills/pdf
+            name: pdf
+    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+```
+
+For search:
+```
+Search Results:
+
+  document-generation-pdf curiositech/some_claude_skills
+      sourceType: git
+          source: curiositech/some_claude_skills
+         subpath: .claude/skills/document-generation-pdf
+            name: document-generation-pdf
+    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital
+    Installs: 0 installs  Marketplace: agentskill.sh
+
+  pdf               anthropics/skills
+      sourceType: git
+          source: anthropics/skills
+         subpath: skills/pdf
+            name: pdf
+    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+    Installs: 51.2K installs  Marketplace: skills.sh
+
+2 skill(s) shown
+```
+
+
+### The `remove` command should ask for final confirmation before removing the selected skills (#116)
+
+* Interactive mode: The current version removes the selected skills immediately, so it would be better to ask users for confirmation before removing them in case they press Enter by mistake.
+* Non-interactive mode: The skills could be removed by mistake, so it would be good to have a confirmation step, with a flag to bypass it, such as `--yes` or `-y`.
+
+After this release:
+```bash
+✔ Select skills to remove
+ ◉ ai-pdf-filler-cli         (project, Gemini): .gemini/skills
+
+The following skill(s) will be removed:
+  - ai-pdf-filler-cli (project, Gemini): .gemini/skills
+
+? Are you sure? › (y/N)
+```
+
+***
+
+### Add more metadata to the output of the `read` command (#120)
+
+#### `read`
+
+##### Ineractive:
+```
+         Reading: pdf
+  Base directory: ~/git/username/path/to/project/.gemini/skills/pdf
+      sourceType: git
+          source: anthropics/skills
+         subpath: skills/pdf
+            name: pdf
+```
+
+##### Non-interactive
+```
+         Reading: pdf-converter
+  Base directory: ~/git/username/path/to/project/.cursor/skills/pdf-converter
+      sourceType: git
+          source: claude-office-skills/skills
+         subpath: pdf-converter
+            name: PDF Converter
+```
+
+
+#### `search`
+
+##### Local
+```
+         Reading: pdf-converter
+  Base directory: ~/git/username/path/to/project/.cursor/skills/pdf-converter
+      sourceType: git
+          source: claude-office-skills/skills
+         subpath: pdf-converter
+            name: PDF Converter
+```
+
+##### Marketplace
+```
+         Reading: nano-pdf
+          Source: steipete/clawdis [skills.sh]
+      sourceType: git
+          source: steipete/clawdis
+         subpath: skills/nano-pdf
+            name: nano-pdf
+```
+***
+
+### Move the temporary directory to a safer, ephemeral location that is cleared on reboot (#122)
+
+Before this release, current temporary directory is located at `$HOME` with a nmae like
+```
+.aiskills-temp-TIMESTAMP
+```
+This should be moved to the system’s temporary directory, which is cleaned up on reboot. Although `ai-skills` removes it after cloning and when the operation is complete, keeping it in an ephemeral location is still safer.
+
+After this release, it uses the `$TMPDIR` environment variable to get the system's temporary directory, falling back to `/tmp` if it is not set.
+
+
+***
+
+## Bug Fixed
+
+### Fixed: When `pwd` is `$HOME`, interactive mode should not ask to choose a location as it's always global for `$HOME` (#111)
+
+Before this release version:
+```bash
+$ aiskills install kevin-lee/ai-dumping-ground
+✔ Select target agent(s)
+ ◉ Claude
+? Select install location ›
+  ‣ global  (~/.claude)
+    project (.claude)
+    both
+```
+
+`? Select install location ›` is unnecessary because there's no project scope in `$HOME`.
+
+After this release:
+```bash
+$ aiskills install kevin-lee/ai-dumping-ground
+✔ Select target agent(s)
+ ◉ Claude
+   ✔ Repository cloned
+Installing from: kevin-lee/ai-dumping-ground
+Location: global (~/.claude/skills)
+
+Found 2 skill(s)
+
+? Select skills to install ›
+Tab to toggle, Shift+Tab to toggle all, Enter to submit.
+ ◉ 2020-hindsight-scala      (skills/2020-hindsight-scala)      33.2KB
+ ◉ riper-5                   (skills/riper-5)                   5.2KB
+```
+It no longer asks to select install location (no more `? Select install location ›`).
+
+***
+
+### Fixed: Skills in some GitHub repositories are not recognized (#113)
+
+Before this release version:
+```
+SKILL.md not found for 'ai-pdf-filler-cli' in askyourpdf/ai-pdf-filler
+```
+The reason might be that `SKILL.md` is located in the root directory, not inside the `skills` directory.
+
+***
+
+```
+SKILL.md not found for 'Pdf' in danielmiessler/Personal_AI_Infrastructure
+```
+The reason might be that `SKILL.md` is located at `Packs/Utilities/src/Documents/Pdf/SKILL.md`, not inside the `skills` directory.
+***
+
+Now, they are recognized.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.5.1-SNAPSHOT"
+ThisBuild / version := "2.6.0"


### PR DESCRIPTION
# ai-skills v2.6.0
## [2.6.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am10) - 2026-04-13

## Improvement

### Add `search` command with local and marketplace search (#109) 🔎

```
aiskills search                              # interactive mode to search
aiskills search <search-query>               # interactive mode with search-query provided.
aiskills search <search-query> --marketplace # search from marketplace
aiskills search <search-query> --local       # search from all agents, local skills (both global and project)

aiskills search <search-query> --local --marketplace # error, it should be either --local or --marketplace
aiskills search --local       # error, <search-query> should be provided for --local
aiskills search --marketplace # error, <search-query> should be provided for --marketplace
```

e.g.)

Marketplace search
```bash
$ aiskills search
✔ Search from  … marketplace
✔ Enter search query … pdf
Searching marketplaces for: pdf

   ✔ Found 39 skill(s)

? Select skill(s) ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ pdf                       anthropics/skills              51.2K installs [skills.sh]
 ◯ pdftk-server              github/awesome-copilot         6.5K installs [skills.sh]
 ◯ nano-pdf                  steipete/clawdis               1.6K installs [skills.sh]
 ...
 ◯ pdf form filler           claude-office-skills/skills    422 installs [skills.sh]
 ◯ pdf watermark             claude-office-skills/skills    419 installs [skills.sh]
 ◯ react-pdf                 vercel-labs/json-render        415 installs [skills.sh]
 ◯ pdf-generator             jwynia/agent-skills            403 installs [skills.sh]
 ◯ view-pdf                  anthropics/knowledge-work-plugins 354 installs [skills.sh]
 ↓ ai-pdf-filler-cli         askyourpdf/ai-pdf-filler       341 installs [skills.sh]
```

Local search
```bash
$ aiskills search
✔ Search from  … local
✔ Enter search query … pdf
Found 19 matching skill(s) for 'pdf':

? Select skill(s) ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ pdf                       (project, Gemini): .gemini/skills
 ◯ pdf-converter             (project, Cursor): .cursor/skills
 ◯ pdf-2                     (project, Gemini): .gemini/skills
 ...
 ◯ view-pdf                  (project, Gemini): .gemini/skills
 ◯ canvas-design             (project, Gemini): .gemini/skills
 ◯ docx                      (project, Gemini): .gemini/skills
```


***

### All multiple-choice prompts should be mandatory (#106)

e.g.)
multiple-choice before this release:
```bash
$ aiskills install anthropics/skills
? Select target agent(s) ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◯ Universal
 ◯ Claude
 ◯ Cursor
 ◯ Codex
 ◯ Gemini
 ◯ Windsurf
 ◯ Copilot
```
Hit enter, then it immediately terminates the operation and shows
```
✔ Select target agent(s)
nothing selected
No agents selected. Installation cancelled.
```

Users often hit enter by mistake, so the multiple-choice prompts should be mandatory.

After this release:
```bash
$ aiskills install anthropics/skills
? Select target agent(s) ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
Please select at least one, or press Ctrl+C to cancel.
 ◯ Universal
 ◯ Claude
 ◯ Cursor
 ◯ Codex
 ◯ Gemini
 ◯ Windsurf
 ◯ Copilot
```
Now, you get `Please select at least one, or press Ctrl+C to cancel.` message instead of ending the operation.

***

### Improve `search` and `list`: actions for searched skills can be repeated and `list` has more metadata (#112)

#### For `search` enhancement:

##### For `marketplace`:
In `search`, after skill selection is done, it should ask if a user wants to `read`, `install`, `list` or `finish`.
* `read`: will read all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
* `list`: will list all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
* `install`: will install all selected skills then it finishes.
* `finish`: will finish.

##### For `local`:
* `read`: will read all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
* `list`: will list all selected skills then it should ask if the user wants to `read`, `install`, `list` or `finish`.
* `finish`: will finish.

#### `list` with more metadata:

1. Because some skills may have folder names that differ from the `name`s in `SKILL.md`, it's good to include the `name` field from `SKILL.md` in the list.
2. It should have the base directory just like the `read` command.
3. It should have the source info including `sourceType`, `source` and `subpath`.

The current version before this release is like
```bash
  document-generation-pdf   (project, Gemini): .gemini/skills
    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital

  pdf                       (project, Gemini): .gemini/skills
    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
```

So, after this release, with the new info mentioned above, it looks like the following.
```bash
  document-generation-pdf   (project, Gemini): .gemini/skills
  Base directory: ~/git/username/path/to/project/.gemini/skills/document-generation-pdf
      sourceType: git
          source: curiositech/some_claude_skills
         subpath: .claude/skills/document-generation-pdf
            name: document-generation-pdf
    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital

  pdf                       (project, Gemini): .gemini/skills
  Base directory: ~/git/username/path/to/project/.gemini/skills/pdf
      sourceType: git
          source: anthropics/skills
         subpath: skills/pdf
            name: pdf
    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
```

For search:
```
Search Results:

  document-generation-pdf curiositech/some_claude_skills
      sourceType: git
          source: curiositech/some_claude_skills
         subpath: .claude/skills/document-generation-pdf
            name: document-generation-pdf
    Generate, fill, and assemble PDF documents at scale. Handles legal forms, contracts, invoices, certificates. Supports form filling (pdf-lib), template rendering (Puppeteer, LaTeX), digital
    Installs: 0 installs  Marketplace: agentskill.sh

  pdf               anthropics/skills
      sourceType: git
          source: anthropics/skills
         subpath: skills/pdf
            name: pdf
    Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
    Installs: 51.2K installs  Marketplace: skills.sh

2 skill(s) shown
```


### The `remove` command should ask for final confirmation before removing the selected skills (#116)

* Interactive mode: The current version removes the selected skills immediately, so it would be better to ask users for confirmation before removing them in case they press Enter by mistake.
* Non-interactive mode: The skills could be removed by mistake, so it would be good to have a confirmation step, with a flag to bypass it, such as `--yes` or `-y`.

After this release:
```bash
✔ Select skills to remove
 ◉ ai-pdf-filler-cli         (project, Gemini): .gemini/skills

The following skill(s) will be removed:
  - ai-pdf-filler-cli (project, Gemini): .gemini/skills

? Are you sure? › (y/N)
```

***

### Add more metadata to the output of the `read` command (#120)

#### `read`

##### Ineractive:
```
         Reading: pdf
  Base directory: ~/git/username/path/to/project/.gemini/skills/pdf
      sourceType: git
          source: anthropics/skills
         subpath: skills/pdf
            name: pdf
```

##### Non-interactive
```
         Reading: pdf-converter
  Base directory: ~/git/username/path/to/project/.cursor/skills/pdf-converter
      sourceType: git
          source: claude-office-skills/skills
         subpath: pdf-converter
            name: PDF Converter
```


#### `search`

##### Local
```
         Reading: pdf-converter
  Base directory: ~/git/username/path/to/project/.cursor/skills/pdf-converter
      sourceType: git
          source: claude-office-skills/skills
         subpath: pdf-converter
            name: PDF Converter
```

##### Marketplace
```
         Reading: nano-pdf
          Source: steipete/clawdis [skills.sh]
      sourceType: git
          source: steipete/clawdis
         subpath: skills/nano-pdf
            name: nano-pdf
```
***

### Move the temporary directory to a safer, ephemeral location that is cleared on reboot (#122)

Before this release, current temporary directory is located at `$HOME` with a nmae like
```
.aiskills-temp-TIMESTAMP
```
This should be moved to the system’s temporary directory, which is cleaned up on reboot. Although `ai-skills` removes it after cloning and when the operation is complete, keeping it in an ephemeral location is still safer.

After this release, it uses the `$TMPDIR` environment variable to get the system's temporary directory, falling back to `/tmp` if it is not set.


***

## Bug Fixed

### Fixed: When `pwd` is `$HOME`, interactive mode should not ask to choose a location as it's always global for `$HOME` (#111)

Before this release version:
```bash
$ aiskills install kevin-lee/ai-dumping-ground
✔ Select target agent(s)
 ◉ Claude
? Select install location ›
  ‣ global  (~/.claude)
    project (.claude)
    both
```

`? Select install location ›` is unnecessary because there's no project scope in `$HOME`.

After this release:
```bash
$ aiskills install kevin-lee/ai-dumping-ground
✔ Select target agent(s)
 ◉ Claude
   ✔ Repository cloned
Installing from: kevin-lee/ai-dumping-ground
Location: global (~/.claude/skills)

Found 2 skill(s)

? Select skills to install ›
Tab to toggle, Shift+Tab to toggle all, Enter to submit.
 ◉ 2020-hindsight-scala      (skills/2020-hindsight-scala)      33.2KB
 ◉ riper-5                   (skills/riper-5)                   5.2KB
```
It no longer asks to select install location (no more `? Select install location ›`).

***

### Fixed: Skills in some GitHub repositories are not recognized (#113)

Before this release version:
```
SKILL.md not found for 'ai-pdf-filler-cli' in askyourpdf/ai-pdf-filler
```
The reason might be that `SKILL.md` is located in the root directory, not inside the `skills` directory.

***

```
SKILL.md not found for 'Pdf' in danielmiessler/Personal_AI_Infrastructure
```
The reason might be that `SKILL.md` is located at `Packs/Utilities/src/Documents/Pdf/SKILL.md`, not inside the `skills` directory.
***

Now, they are recognized.
