### PR TITLE
Fix #126: Fix marketplace `search` failing to find `SKILL.md` when the API `skillId` differs in punctuation from the repo directory or YAML name

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -209,7 +209,7 @@ object Search {
             val repoDir = tempDir / "repo"
 
             results.flatMap { result =>
-              findSkillMd(repoDir, result.skillId) match {
+              findSkillMd(repoDir, result.skillId, result.name) match {
                 case Some(skillMdPath) =>
                   val skillDir    = skillMdPath / os.up
                   val content     = Try(os.read(skillMdPath)).getOrElse("")
@@ -230,7 +230,12 @@ object Search {
                   )
 
                 case None =>
-                  System.err.println(s"SKILL.md not found for '${result.skillId}' in $source".yellow)
+                  val trimmedName = result.name.trim
+                  val notFoundMsg =
+                    if trimmedName.nonEmpty && trimmedName =!= result.skillId.trim
+                    then s"SKILL.md not found for '${result.skillId}' (name: '${result.name}') in $source"
+                    else s"SKILL.md not found for '${result.skillId}' in $source"
+                  System.err.println(notFoundMsg.yellow)
                   List(
                     ClonedSkill(
                       result = result,
@@ -560,37 +565,81 @@ object Search {
     candidates.find(_.trim.nonEmpty).getOrElse(dirName)
   }
 
-  /** Find a SKILL.md in a repo by skill name.
+  private def alnumNormalize(s: String): String =
+    s.toLowerCase.filter(_.isLetterOrDigit)
+
+  /** Find a SKILL.md in a repo by marketplace skillId and display name.
     *
     * Matching strategy (in priority order):
-    *  1. Direct path: repoDir/skillName/SKILL.md
-    *  2. Under skills/: repoDir/skills/skillName/SKILL.md
-    *  3. Directory name match (recursive): any dir whose name equals skillName
-    *  4. YAML name match: any SKILL.md whose frontmatter `name` field matches (case-insensitive).
-    *     This handles marketplace names like "pdf merge & split" where the directory is "pdf-merge-split".
+    *  1. Direct path: repoDir/skillId/SKILL.md
+    *  2. Under skills/: repoDir/skills/skillId/SKILL.md
+    *  3. Directory name match (recursive): any dir whose name equals skillId, then displayName
+    *  4. YAML name match (case-insensitive, trimmed): any SKILL.md whose frontmatter `name`
+    *     matches skillId, then displayName.
+    *  5. Alphanumeric-only fuzzy match (last resort): any SKILL.md whose directory name or YAML
+    *     `name` collapses (lowercase, letters/digits only) to the same string as skillId or
+    *     displayName. Returns None on ambiguity (more than one distinct SKILL.md matches).
+    *
+    * This handles marketplace names like "pdf-ocr-extraction" (where only displayName
+    * "pdf ocr extraction" matches the YAML "PDF OCR Extraction") and "pdf-merge-&-split"
+    * (where dir "pdf-merge-split" only matches after alphanumeric normalization).
     */
-  private[commands] def findSkillMd(repoDir: os.Path, skillName: String): Option[os.Path] = {
-    val directPath = repoDir / skillName / "SKILL.md"
-    val skillsPath = repoDir / "skills" / skillName / "SKILL.md"
+  private[commands] def findSkillMd(
+    repoDir: os.Path,
+    skillId: String,
+    displayName: String,
+  ): Option[os.Path] = {
+    val directPath = repoDir / skillId / "SKILL.md"
+    val skillsPath = repoDir / "skills" / skillId / "SKILL.md"
 
     if os.exists(directPath) then directPath.some
     else if os.exists(skillsPath) then skillsPath.some
     else {
-      // Collect all SKILL.md files in the repo
       val allSkillMds = collectSkillMds(repoDir)
 
-      // Try matching by directory name
-      allSkillMds
-        .find { md => (md / os.up).last === skillName }
+      // Tier 3: Directory name exact match (skillId first, then displayName)
+      val tier3 = allSkillMds
+        .find { md => (md / os.up).last === skillId }
         .orElse {
-          // Try matching by YAML name field (case-insensitive)
-          val normalizedQuery = skillName.toLowerCase.trim
-          allSkillMds.find { md =>
-            val content  = Try(os.read(md)).getOrElse("")
-            val yamlName = Yaml.extractYamlField(content, "name")
-            yamlName.toLowerCase.trim === normalizedQuery
+          allSkillMds.find { md => (md / os.up).last === displayName }
+        }
+
+      tier3.orElse {
+        // Cache YAML name reads for tiers 4 and 5
+        val yamlNames: Map[os.Path, String] = allSkillMds.map { md =>
+          val content = Try(os.read(md)).getOrElse("")
+          md -> Yaml.extractYamlField(content, "name")
+        }.toMap
+
+        // Tier 4: YAML name exact match (case-insensitive, trimmed), skillId first then displayName
+        val skillIdNorm     = skillId.toLowerCase.trim
+        val displayNameNorm = displayName.toLowerCase.trim
+        val tier4           = allSkillMds
+          .find { md => yamlNames(md).toLowerCase.trim === skillIdNorm }
+          .orElse {
+            allSkillMds.find { md => yamlNames(md).toLowerCase.trim === displayNameNorm }
+          }
+
+        tier4.orElse {
+          // Tier 5: Alphanumeric-only fuzzy match, ambiguity returns None
+          val skillIdAlnum     = alnumNormalize(skillId)
+          val displayNameAlnum = alnumNormalize(displayName)
+          val targets          = Set(skillIdAlnum, displayNameAlnum).filter(_.nonEmpty)
+
+          if targets.isEmpty then none[os.Path]
+          else {
+            val candidates = allSkillMds.filter { md =>
+              val dirAlnum  = alnumNormalize((md / os.up).last)
+              val yamlAlnum = alnumNormalize(yamlNames(md))
+              targets.contains(dirAlnum) || targets.contains(yamlAlnum)
+            }
+            candidates match {
+              case single :: Nil => single.some
+              case _ => none[os.Path]
+            }
           }
         }
+      }
     }
   }
 

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/SearchSpec.scala
@@ -31,6 +31,18 @@ object SearchSpec extends Properties {
     example("findSkillMd: prefers direct path over recursive match", testFindPrefersDirectPath),
     example("findSkillMd: finds root-level SKILL.md by YAML name", testFindRootLevelByYamlName),
     example("findSkillMd: finds deeply nested skill past an ancestor SKILL.md", testFindNestedPastAncestor),
+    example(
+      "findSkillMd: matches tier 4 via displayName when skillId differs by punctuation",
+      testFindByDisplayNameYamlMatch
+    ),
+    example("findSkillMd: matches tier 5 via alphanumeric fuzzy normalization", testFindByAlnumDirMatch),
+    example("findSkillMd: returns None when tier 5 produces ambiguous matches", testFindAlnumAmbiguityReturnsNone),
+    example("findSkillMd: strict tiers preempt tier 5 fuzzy match", testFindStrictTierPreemptsAlnum),
+    example(
+      "findSkillMd: within a tier, skillId candidate is tried before displayName",
+      testFindSkillIdTakesPrecedenceOverDisplayName
+    ),
+    example("findSkillMd: empty displayName falls back cleanly to skillId", testFindEmptyDisplayNameFallsBackToSkillId),
     // resolveInstallName
     example("resolveInstallName: non-root uses skillDir.last", testResolveNameNonRootUsesDirName),
     example(
@@ -194,7 +206,7 @@ object SearchSpec extends Properties {
   private def testFindDirectPath: Result =
     withTempDir { dir =>
       val md = createSkillMd(dir, "commit", "commit")
-      Search.findSkillMd(dir, "commit") ==== Some(md)
+      Search.findSkillMd(dir, "commit", "commit") ==== Some(md)
     }
 
   private def testFindUnderSkills: Result =
@@ -202,7 +214,7 @@ object SearchSpec extends Properties {
       val skillsDir = dir / "skills"
       os.makeDir.all(skillsDir)
       val md        = createSkillMd(skillsDir, "commit", "commit")
-      Search.findSkillMd(dir, "commit") ==== Some(md)
+      Search.findSkillMd(dir, "commit", "commit") ==== Some(md)
     }
 
   private def testFindByDirName: Result =
@@ -210,20 +222,20 @@ object SearchSpec extends Properties {
       val nested = dir / "some" / "path"
       os.makeDir.all(nested)
       val md     = createSkillMd(nested, "commit", "commit")
-      Search.findSkillMd(dir, "commit") ==== Some(md)
+      Search.findSkillMd(dir, "commit", "commit") ==== Some(md)
     }
 
   private def testFindByYamlName: Result =
     withTempDir { dir =>
       // Directory name is kebab-case, but YAML name has spaces
       val md = createSkillMd(dir, "pdf-merge-split", "PDF Merge & Split")
-      Search.findSkillMd(dir, "pdf merge & split") ==== Some(md)
+      Search.findSkillMd(dir, "pdf merge & split", "pdf merge & split") ==== Some(md)
     }
 
   private def testFindNotFound: Result =
     withTempDir { dir =>
       val _ = createSkillMd(dir, "commit", "commit")
-      Search.findSkillMd(dir, "nonexistent") ==== None
+      Search.findSkillMd(dir, "nonexistent", "nonexistent") ==== None
     }
 
   private def testFindPrefersDirectPath: Result =
@@ -234,13 +246,13 @@ object SearchSpec extends Properties {
       os.makeDir.all(nestedDir)
       val _         = createSkillMd(nestedDir, "commit", "commit")
       // Direct path should be preferred
-      Search.findSkillMd(dir, "commit") ==== Some(directMd)
+      Search.findSkillMd(dir, "commit", "commit") ==== Some(directMd)
     }
 
   private def testFindRootLevelByYamlName: Result =
     withTempDir { dir =>
       val md = createSkillMdAt(dir, "ai-pdf-filler-cli")
-      Search.findSkillMd(dir, "ai-pdf-filler-cli") ==== Some(md)
+      Search.findSkillMd(dir, "ai-pdf-filler-cli", "ai-pdf-filler-cli") ==== Some(md)
     }
 
   private def testFindNestedPastAncestor: Result =
@@ -251,8 +263,59 @@ object SearchSpec extends Properties {
       val _            = createSkillMdAt(srcDir, "utilities-src")
       val _            = createSkillMdAt(documentsDir, "documents")
       val pdfMd        = createSkillMdAt(pdfDir, "Pdf")
-      Search.findSkillMd(dir, "Pdf") ==== Some(pdfMd)
+      Search.findSkillMd(dir, "Pdf", "Pdf") ==== Some(pdfMd)
     }
+
+  private def testFindByDisplayNameYamlMatch: Result =
+    withTempDir { dir =>
+      // skills.sh case: skillId "pdf-ocr-extraction" differs from YAML name "PDF OCR Extraction"
+      // by hyphen-vs-space, but displayName "pdf ocr extraction" matches via tier 4.
+      val md = createSkillMd(dir, "pdf-ocr", "PDF OCR Extraction")
+      Search.findSkillMd(dir, "pdf-ocr-extraction", "pdf ocr extraction") ==== Some(md)
+    }
+
+  private def testFindByAlnumDirMatch: Result =
+    withTempDir { dir =>
+      // skills.sh case: skillId "pdf-merge-&-split" has an '&' that the dir "pdf-merge-split"
+      // lacks. Only tier 5 (alphanumeric collapse) resolves this.
+      val md = createSkillMd(dir, "pdf-merge-split", "PDF Merge & Split")
+      Search.findSkillMd(dir, "pdf-merge-&-split", "pdf merge & split") ==== Some(md)
+    }
+
+  private def testFindAlnumAmbiguityReturnsNone: Result =
+    withTempDir { dir =>
+      val _ = createSkillMd(dir, "pdf-merge-split", "Alpha")
+      val _ = createSkillMd(dir, "pdf.merge.split", "Beta")
+      Search.findSkillMd(dir, "pdf-merge-&-split", "pdf merge & split") ==== None
+    }
+
+  private def testFindStrictTierPreemptsAlnum: Result =
+    withTempDir { dir =>
+      val commitMd = createSkillMd(dir, "commit", "commit")
+      val _        = createSkillMd(dir, "comm-it", "comm it")
+      Search.findSkillMd(dir, "commit", "commit") ==== Some(commitMd)
+    }
+
+  private def testFindSkillIdTakesPrecedenceOverDisplayName: Result =
+    withTempDir { dir =>
+      val fooMd = createSkillMd(dir, "foo", "foo")
+      val _     = createSkillMd(dir, "bar", "baz")
+      Search.findSkillMd(dir, "foo", "baz") ==== Some(fooMd)
+    }
+
+  private def testFindEmptyDisplayNameFallsBackToSkillId: Result =
+    Result.all(
+      List(
+        withTempDir { dir =>
+          val md = createSkillMd(dir, "commit", "commit")
+          Search.findSkillMd(dir, "commit", "") ==== Some(md)
+        },
+        withTempDir { dir =>
+          val _ = createSkillMd(dir, "commit", "commit")
+          Search.findSkillMd(dir, "nonexistent", "") ==== None
+        },
+      )
+    )
 
   // --- resolveInstallName ---
 


### PR DESCRIPTION
# Fix #126: Fix marketplace `search` failing to find `SKILL.md` when the API `skillId` differs in punctuation from the repo directory or YAML name

When `search` retrieves skills from `skills.sh`, some entries whose `skillId` differs from the on-disk directory name or YAML `name` field by punctuation were reported as missing,

e.g.:

```
SKILL.md not found for 'pdf-ocr-extraction' in claude-office-skills/skills
SKILL.md not found for 'pdf-merge-&-split' in claude-office-skills/skills
```

Both skills exist in the cloned repo (as `pdf-ocr/` and `pdf-merge-split/`), but the previous `findSkillMd` only consulted `result.skillId` and normalized YAML names via `.toLowerCase.trim`, so hyphen-vs-space and stray `&` differences caused misses.

Changes:
- `findSkillMd` now takes both `skillId` and the API `displayName`, and uses a five-tier strategy:
  1. Direct path `repoDir/skillId/SKILL.md` (unchanged).
  2. `repoDir/skills/skillId/SKILL.md` (unchanged).
  3. Directory-name exact match against `skillId`, then `displayName`.
  4. YAML `name` exact match (case-insensitive, trimmed) against `skillId`, then `displayName`.
  5. Alphanumeric-only fuzzy match (`toLowerCase.filter(_.isLetterOrDigit)`) of directory name and YAML `name` against `skillId` and `displayName`; returns `None` on ambiguity to avoid guessing.
- The "SKILL.md not found" warning now also shows `result.name` when it differs from `skillId`, making diagnostics clearer.
- YAML name reads are cached once per SKILL.md and reused across tiers 4 and 5.
- Added tests for: tier 4 via `displayName`, tier 5 via alphanumeric collapse, tier 5 ambiguity returns `None`, strict tiers preempt tier 5, `skillId` precedence over `displayName` within a tier, and empty `displayName` fallback.