### PR TITLE
Refactor to follow 2020 Hindsight Scala practices

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/SigintHandler.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/SigintHandler.scala
@@ -1,5 +1,7 @@
 package aiskills.cli
 
+import cats.syntax.all.*
+
 import scala.scalanative.unsafe.*
 import scala.scalanative.unsigned.*
 
@@ -32,7 +34,7 @@ object SigintHandler {
         cur(9) = 'J'.toByte
         val _   = unistd.write(1, cur, 10.toUSize)
 
-        if sig == 2 then { // SIGINT
+        if sig === 2 then { // SIGINT
           // "\nCancelled by Ctrl+C\n" = 21 bytes
           val msg = stackalloc[Byte](21)
           msg(0) = '\n'.toByte

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -3,7 +3,7 @@ package aiskills.cli.commands
 import OverwritePrompt.{BulkDecision, OverwriteChoice}
 import aiskills.cli.CliDefaults
 import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMdFinder, SkillMetadata, Yaml}
-import aiskills.core.*
+import aiskills.core.{*, given}
 import cats.syntax.all.*
 import cue4s.*
 import extras.scala.io.syntax.color.*
@@ -133,7 +133,7 @@ object Install {
         val agents    = promptForAgents()
         val locations =
           if options.locations.nonEmpty then options.locations
-          else if os.pwd == os.home then Set(SkillLocation.Global)
+          else if os.pwd === os.home then Set(SkillLocation.Global)
           else promptForLocation(agents)
         (agents, locations)
     }
@@ -224,7 +224,7 @@ object Install {
         println(s"Installing from: ${source.cyan}")
         println(s"Location: $locationDisplay")
         if agents.length <= 1 && locations.size <= 1 then {
-          if !isProject && os.pwd != os.home then println(
+          if !isProject && os.pwd =!= os.home then println(
             s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim
           )
           else ()
@@ -274,7 +274,7 @@ object Install {
           val tempDir = repoDir / os.up
           aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
           aiskills.cli.TempDirCleanup.unregister(tempDir)
-        case _ => ()
+        case ResolvedSource.Local(_, _) => ()
       }
     }
   }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/ListCmd.scala
@@ -154,7 +154,7 @@ object ListCmd {
 
     val sorted = skills.sortBy(s => (s.agent.ordinal, s.location, s.name))
 
-    for skill <- sorted do {
+    sorted.foreach { skill =>
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
       val locationLabel =
         s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -27,7 +27,7 @@ object Read {
       val resolved = List.newBuilder[(String, SkillLocationInfo)]
       val missing  = List.newBuilder[String]
 
-      for name <- names do {
+      names.foreach { name =>
         val found = for {
           agent    <- agents
           location <- locations
@@ -65,16 +65,17 @@ object Read {
       } else ()
 
       val resolvedList = resolved.result()
-      for ((name, skill), idx) <- resolvedList.zipWithIndex do {
-        if idx > 0 then println(separator)
-        val content = os.read(skill.path)
-        println(SkillDisplay.padLabel("Reading:").bold + s" ${name.blue.bold}")
-        SkillDisplay.renderInfoBlock(skill.baseDir)
+      resolvedList.zipWithIndex.foreach {
+        case ((name, skill), idx) =>
+          if idx > 0 then println(separator)
+          val content = os.read(skill.path)
+          println(SkillDisplay.padLabel("Reading:").bold + s" ${name.blue.bold}")
+          SkillDisplay.renderInfoBlock(skill.baseDir)
 
-        println()
-        println(content)
-        println()
-        println("Skill read:".bold + s" ${name.blue.bold}")
+          println()
+          println(content)
+          println()
+          println("Skill read:".bold + s" ${name.blue.bold}")
       }
     }
   }
@@ -130,16 +131,17 @@ object Read {
                       case Right(selectedSkills) =>
                         if selectedSkills.isEmpty then println("No skills selected.".yellow)
                         else {
-                          for (skill, idx) <- selectedSkills.zipWithIndex do {
-                            if idx > 0 then println(separator)
-                            val skillPath = skill.path / "SKILL.md"
-                            val content   = os.read(skillPath)
-                            println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
-                            SkillDisplay.renderInfoBlock(skill.path)
-                            println()
-                            println(content)
-                            println()
-                            println("Skill read:".bold + s" ${skill.name.blue.bold}")
+                          selectedSkills.zipWithIndex.foreach {
+                            case (skill, idx) =>
+                              if idx > 0 then println(separator)
+                              val skillPath = skill.path / "SKILL.md"
+                              val content   = os.read(skillPath)
+                              println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
+                              SkillDisplay.renderInfoBlock(skill.path)
+                              println()
+                              println(content)
+                              println()
+                              println("Skill read:".bold + s" ${skill.name.blue.bold}")
                           }
                         }
                     }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Remove.scala
@@ -84,7 +84,7 @@ object Remove {
           val selectedSkills  = selectedIndices.map(sorted(_))
           confirmRemoval(selectedSkills) match {
             case Right(true) =>
-              for skill <- selectedSkills do {
+              selectedSkills.foreach { skill =>
                 os.remove.all(skill.path)
                 val pathLabel = Dirs.displaySkillsDir(skill.agent, skill.location)
                 println(
@@ -93,7 +93,7 @@ object Remove {
               }
 
               val agentLocationPairs = selectedSkills.map(s => (s.agent, s.location)).distinct
-              for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+              agentLocationPairs.foreach { case (agent, location) => AgentsMd.updateAgentsMdForAgent(agent, location) }
 
               println(s"\n\u2705 Removed ${selectedIndices.length} skill(s)".green)
               ().asRight
@@ -165,7 +165,7 @@ object Remove {
 
   private def confirmRemoval(skills: List[Skill]): Either[Int, Boolean] = {
     println(s"\nThe following skill(s) will be removed:")
-    for skill <- skills do {
+    skills.foreach { skill =>
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
       val locationColor =
         if skill.location === SkillLocation.Project then skill.location.toString.toLowerCase.blue
@@ -193,12 +193,13 @@ object Remove {
     foundTargets: List[(Agent, SkillLocation)]
   ): Either[Int, Boolean] = {
     println(s"\nThe following skill(s) will be removed:")
-    for (agent, location) <- foundTargets do {
-      val pathLabel     = Dirs.displaySkillsDir(agent, location)
-      val locationColor =
-        if location === SkillLocation.Project then location.toString.toLowerCase.blue
-        else location.toString.toLowerCase.yellow
-      println(s"  - ${skillName.bold} ($locationColor, ${agent.toString.cyan.bold}): ${pathLabel.dim}")
+    foundTargets.foreach {
+      case (agent, location) =>
+        val pathLabel     = Dirs.displaySkillsDir(agent, location)
+        val locationColor =
+          if location === SkillLocation.Project then location.toString.toLowerCase.blue
+          else location.toString.toLowerCase.yellow
+        println(s"  - ${skillName.bold} ($locationColor, ${agent.toString.cyan.bold}): ${pathLabel.dim}")
     }
     println()
     aiskills.cli.SigintHandler.install()
@@ -230,11 +231,12 @@ object Remove {
     val found    = List.newBuilder[(Agent, SkillLocation)]
     val notFound = List.newBuilder[(Agent, SkillLocation)]
 
-    for (agent, location) <- targets do {
-      val skillDir = Dirs.getSkillsDir(agent, location) / skillName
-      if os.exists(skillDir / "SKILL.md")
-      then found += agent    -> location
-      else notFound += agent -> location
+    targets.foreach {
+      case (agent, location) =>
+        val skillDir = Dirs.getSkillsDir(agent, location) / skillName
+        if os.exists(skillDir / "SKILL.md")
+        then found += agent    -> location
+        else notFound += agent -> location
     }
 
     val foundResult    = found.result()
@@ -260,26 +262,28 @@ object Remove {
       }
 
     if confirmed then {
-      for (agent, location) <- foundResult do {
-        val skillDir  = Dirs.getSkillsDir(agent, location) / skillName
-        os.remove.all(skillDir)
-        val pathLabel = Dirs.displaySkillsDir(agent, location)
-        println(
-          s"\u2705 Removed: $skillName (${location.toString.toLowerCase}, ${agent.toString}): $pathLabel".green
-        )
+      foundResult.foreach {
+        case (agent, location) =>
+          val skillDir  = Dirs.getSkillsDir(agent, location) / skillName
+          os.remove.all(skillDir)
+          val pathLabel = Dirs.displaySkillsDir(agent, location)
+          println(
+            s"\u2705 Removed: $skillName (${location.toString.toLowerCase}, ${agent.toString}): $pathLabel".green
+          )
       }
 
       val agentLocationPairs = foundResult.distinct
-      for (agent, location) <- agentLocationPairs do AgentsMd.updateAgentsMdForAgent(agent, location)
+      agentLocationPairs.foreach { case (agent, location) => AgentsMd.updateAgentsMdForAgent(agent, location) }
 
       if notFoundResult.nonEmpty then {
-        for (agent, location) <- notFoundResult do {
-          val pathLabel = Dirs.displaySkillsDir(agent, location)
-          System
-            .err
-            .println(
-              s"Warning: Skill '$skillName' not found in ${location.toString.toLowerCase}/${agent.toString}: $pathLabel"
-            )
+        notFoundResult.foreach {
+          case (agent, location) =>
+            val pathLabel = Dirs.displaySkillsDir(agent, location)
+            System
+              .err
+              .println(
+                s"Warning: Skill '$skillName' not found in ${location.toString.toLowerCase}/${agent.toString}: $pathLabel"
+              )
         }
       } else ()
     } else println("Cancelled.".yellow)

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -265,16 +265,17 @@ object Search {
 
   /** Read action using pre-cloned SKILL.md content. */
   private def readMarketplaceSkillsEnriched(cloned: List[ClonedSkill]): Unit = {
-    for (c, idx) <- cloned.zipWithIndex do {
-      if idx > 0 then println(separator)
-      println(SkillDisplay.padLabel("Reading:").bold + s" ${c.result.name.blue.bold}")
-      println(SkillDisplay.padLabel("Source:").bold + s" ${c.result.source.yellow.bold} [${c.result.marketplace}]")
-      renderMarketplaceInfoBlock(c)
-      println()
-      if c.skillMdPath.isDefined && c.content.nonEmpty then println(c.content)
-      else println("(SKILL.md not found)".yellow)
-      println()
-      println("Skill read:".bold + s" ${c.result.name.blue.bold}")
+    cloned.zipWithIndex.foreach {
+      case (c, idx) =>
+        if idx > 0 then println(separator)
+        println(SkillDisplay.padLabel("Reading:").bold + s" ${c.result.name.blue.bold}")
+        println(SkillDisplay.padLabel("Source:").bold + s" ${c.result.source.yellow.bold} [${c.result.marketplace}]")
+        renderMarketplaceInfoBlock(c)
+        println()
+        if c.skillMdPath.isDefined && c.content.nonEmpty then println(c.content)
+        else println("(SKILL.md not found)".yellow)
+        println()
+        println("Skill read:".bold + s" ${c.result.name.blue.bold}")
     }
   }
 
@@ -679,7 +680,7 @@ object Search {
     */
   private def displayMarketplaceResultsEnriched(cloned: List[ClonedSkill]): Unit = {
     println("\nSearch Results:\n".bold)
-    for c <- cloned do {
+    cloned.foreach { c =>
       val r            = c.result
       val installLabel = formatInstalls(r.installs)
       println(s"  ${r.name.bold.padTo(25, ' ')} ${r.source.cyan}")
@@ -781,16 +782,17 @@ object Search {
   }
 
   private def readLocalSkills(selected: List[Skill]): Unit =
-    for (skill, idx) <- selected.zipWithIndex do {
-      if idx > 0 then println(separator)
-      val skillPath = skill.path / "SKILL.md"
-      val content   = os.read(skillPath)
-      println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
-      SkillDisplay.renderInfoBlock(skill.path)
-      println()
-      println(content)
-      println()
-      println("Skill read:".bold + s" ${skill.name.blue.bold}")
+    selected.zipWithIndex.foreach {
+      case (skill, idx) =>
+        if idx > 0 then println(separator)
+        val skillPath = skill.path / "SKILL.md"
+        val content   = os.read(skillPath)
+        println(SkillDisplay.padLabel("Reading:").bold + s" ${skill.name.blue.bold}")
+        SkillDisplay.renderInfoBlock(skill.path)
+        println()
+        println(content)
+        println()
+        println("Skill read:".bold + s" ${skill.name.blue.bold}")
     }
 
   /** Action loop for local search: read / list / finish. */
@@ -818,7 +820,7 @@ object Search {
 
     val sorted = skills.sortBy(s => (s.agent.ordinal, s.location.ordinal, s.name))
 
-    for skill <- sorted do {
+    sorted.foreach { skill =>
       val pathLabel     = Dirs.displaySkillsDir(skill.agent, skill.location)
       val locationLabel =
         s"(${skill.location.toString.toLowerCase}, ${skill.agent.toString})".blue + s": $pathLabel".dim

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -38,12 +38,12 @@ object Sync {
             sys.exit(1)
           }
 
-          for target <- targets.filterNot(_ === from) do {
+          targets.filterNot(_ === from).foreach { target =>
             syncSelectedSkillsWithLocations(found, from, target, sourceLocation, targetLocations, options.yes)
           }
         } else {
           // All skills
-          for target <- targets.filterNot(_ === from) do {
+          targets.filterNot(_ === from).foreach { target =>
             syncAllSkillsWithLocations(from, target, sourceLocation, targetLocations, options.yes)
           }
         }
@@ -173,7 +173,7 @@ object Sync {
           s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green
         )
 
-        for targetLocation <- targetLocations do {
+        targetLocations.foreach { targetLocation =>
           AgentsMd.updateAgentsMdForAgent(to, targetLocation)
         }
       }
@@ -272,7 +272,7 @@ object Sync {
         s"\n\u2705 Sync complete: $synced skill(s) synced from ${from.toString} to ${to.toString}".green
       )
 
-      for targetLocation <- targetLocations do {
+      targetLocations.foreach { targetLocation =>
         AgentsMd.updateAgentsMdForAgent(to, targetLocation)
       }
     }
@@ -478,7 +478,7 @@ object Sync {
 
               if selectedTargets.isEmpty then println("No target agents selected.".yellow)
               else
-                for target <- selectedTargets do {
+                selectedTargets.foreach { target =>
                   syncSelectedSkillsWithLocations(selectedSkills, from, target, sourceLocation, targetLocations, yes)
                 }
             }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -107,62 +107,64 @@ object Update {
           try {
             groupedByRepo.iterator.zipWithIndex.foreach {
               case ((_, groupSkills), idx) =>
-                val (firstSkill, firstMeta) = groupSkills.head
-                val cloneUrl                = firstMeta.repoUrl.getOrElse(firstSkill.name)
-                val repoSubDir              = parentTempDir / s"repo-$idx"
-                os.makeDir.all(repoSubDir)
-                val skillNames              = groupSkills.map { case (skill, _) => skill.name }
-                val skillsLabel             = if skillNames.length > 1 then s" (${skillNames.length} skills)" else ""
+                groupSkills.headOption.foreach {
+                  case (firstSkill, firstMeta) =>
+                    val cloneUrl    = firstMeta.repoUrl.getOrElse(firstSkill.name)
+                    val repoSubDir  = parentTempDir / s"repo-$idx"
+                    os.makeDir.all(repoSubDir)
+                    val skillNames  = groupSkills.map { case (skill, _) => skill.name }
+                    val skillsLabel = if skillNames.length > 1 then s" (${skillNames.length} skills)" else ""
 
-                val spinner = Spinner.createDefaultSideEffect(
-                  SpinnerConfig
-                    .default
-                    .withText(s"Cloning $cloneUrl$skillsLabel...")
-                    .withColor(Color.cyan)
-                    .withIndent(2),
-                )
-                val _       = spinner.start()
+                    val spinner = Spinner.createDefaultSideEffect(
+                      SpinnerConfig
+                        .default
+                        .withText(s"Cloning $cloneUrl$skillsLabel...")
+                        .withColor(Color.cyan)
+                        .withIndent(2),
+                    )
+                    val _       = spinner.start()
 
-                Try {
-                  Install.cloneWithFallback(cloneUrl, (repoSubDir / "repo").toString)
-                } match {
-                  case Failure(ex) =>
-                    val _   = spinner.fail(Some(s"Clone failed: $cloneUrl"))
-                    val msg = ex.getMessage
-                    if msg.nonEmpty then println(msg.dim) else ()
-                    groupSkills.foreach {
-                      case (skill, _) =>
-                        println(s"Skipped: ${skill.name} (git clone failed)".yellow)
-                        cloneFailures += skill.name
-                    }
+                    Try {
+                      Install.cloneWithFallback(cloneUrl, (repoSubDir / "repo").toString)
+                    } match {
+                      case Failure(ex) =>
+                        val _   = spinner.fail(Some(s"Clone failed: $cloneUrl"))
+                        val msg = ex.getMessage
+                        if msg.nonEmpty then println(msg.dim) else ()
+                        groupSkills.foreach {
+                          case (skill, _) =>
+                            println(s"Skipped: ${skill.name} (git clone failed)".yellow)
+                            cloneFailures += skill.name
+                        }
 
-                  case Success(actualUrl) =>
-                    val _       = spinner.succeed(Some(s"Cloned: $cloneUrl$skillsLabel"))
-                    val repoDir = repoSubDir / "repo"
+                      case Success(actualUrl) =>
+                        val _       = spinner.succeed(Some(s"Cloned: $cloneUrl$skillsLabel"))
+                        val repoDir = repoSubDir / "repo"
 
-                    groupSkills.foreach {
-                      case (skill, meta) =>
-                        val originalRepoUrl = meta.repoUrl.getOrElse("")
-                        val subpath         = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
-                        val sourceDir       = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
+                        groupSkills.foreach {
+                          case (skill, meta) =>
+                            val originalRepoUrl = meta.repoUrl.getOrElse("")
+                            val subpath         = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
+                            val sourceDir       = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
 
-                        if !os.exists(sourceDir / "SKILL.md") then {
-                          println(
-                            s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
-                          )
-                          missingRepoSkillFile += skill.name -> subpath.getOrElse(".")
-                        } else {
-                          updateSkillFromDir(skill.path, sourceDir)
-                          val updatedMeta =
-                            if actualUrl =!= originalRepoUrl
-                            then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
-                            else meta.copy(installedAt = aiskills.core.utils.isoNow())
-                          SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
-                          reapplyRename(skill.path, updatedMeta)
-                          val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
-                          println(
-                            s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
-                          )
+                            if !os.exists(sourceDir / "SKILL.md") then {
+                              println(
+                                s"Skipped: ${skill.name} (SKILL.md not found in repo at ${subpath.getOrElse(".")})".yellow
+                              )
+                              missingRepoSkillFile += skill.name -> subpath.getOrElse(".")
+                            } else {
+                              updateSkillFromDir(skill.path, sourceDir)
+                              val updatedMeta =
+                                if actualUrl =!= originalRepoUrl
+                                then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
+                                else meta.copy(installedAt = aiskills.core.utils.isoNow())
+                              SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
+                              reapplyRename(skill.path, updatedMeta)
+                              val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
+                              println(
+                                s"\u2705 Updated: ${skill.name} (${skill.location.toString.toLowerCase}, ${skill.agent.toString}): $pathLabel".green
+                              )
+                            }
                         }
                     }
                 }

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -31,7 +31,7 @@ object Agent {
   def needsAgentsMd(agent: Agent): Boolean =
     agent match {
       case Agent.Universal | Agent.Codex => true
-      case _ => false
+      case Agent.Claude | Agent.Cursor | Agent.Gemini | Agent.Windsurf | Agent.Copilot => false
     }
 
   given Encoder[Agent] = Encoder.encodeString.contramap(_.toString.toLowerCase)

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -1,6 +1,7 @@
 package aiskills.core.utils
 
-import aiskills.core.{Agent, SkillLocation}
+import aiskills.core.{Agent, SkillLocation, given}
+import cats.syntax.all.*
 
 object Dirs {
 
@@ -49,7 +50,7 @@ object Dirs {
     val globalSpecific  =
       agentsSorted.map(a => (os.home / os.RelPath(a.globalDirName) / "skills", a, SkillLocation.Global))
 
-    if pwd == os.home then globalUniversal ++ globalSpecific
+    if pwd === os.home then globalUniversal ++ globalSpecific
     else {
       val projectUniversal = List(
         (pwd / os.RelPath(Agent.Universal.projectDirName) / "skills", Agent.Universal, SkillLocation.Project)

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Skills.scala
@@ -13,29 +13,29 @@ object Skills {
 
   /** Find all installed skills across all agent directories. No deduplication. */
   def findAllSkills(): List[Skill] = {
-    val dirs   = Dirs.getSearchDirs()
-    val skills = List.newBuilder[Skill]
+    val dirs = Dirs.getSearchDirs()
 
-    for {
-      (dir, agent, location) <- dirs
-      if os.exists(dir)
-      entry                  <- os.list(dir)
-      if isDirectoryOrSymlinkToDirectory(entry)
-      name      = entry.last
-      skillPath = entry / "SKILL.md"
-      if os.exists(skillPath)
-    } do {
-      val content = os.read(skillPath)
-      skills += Skill(
-        name = name,
-        description = Yaml.extractYamlField(content, "description"),
-        location = location,
-        agent = agent,
-        path = entry,
-      )
-    }
+    val skills =
+      for {
+        (dir, agent, location) <- dirs
+        if os.exists(dir)
+        entry                  <- os.list(dir).toList
+        if isDirectoryOrSymlinkToDirectory(entry)
+        name      = entry.last
+        skillPath = entry / "SKILL.md"
+        if os.exists(skillPath)
+      } yield {
+        val content = os.read(skillPath)
+        Skill(
+          name = name,
+          description = Yaml.extractYamlField(content, "description"),
+          location = location,
+          agent = agent,
+          path = entry,
+        )
+      }
 
-    skills.result()
+    skills
   }
 
   /** Find a specific skill by name. Returns the first match in priority order. */

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TimeUtil.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/TimeUtil.scala
@@ -2,6 +2,8 @@ package aiskills.core.utils
 
 import java.util.Date
 
+import cats.syntax.all.*
+
 import scala.annotation.tailrec
 
 /** Generate an ISO-8601-like timestamp string, compatible with Scala Native. */
@@ -54,4 +56,4 @@ private def computeMonth(month: Int, remainingDays: Int, monthDays: Array[Int]):
 }
 
 private def isLeapYear(y: Int): Boolean =
-  (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+  (y % 4 === 0 && y % 100 =!= 0) || (y % 400 === 0)

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Yaml.scala
@@ -1,5 +1,7 @@
 package aiskills.core.utils
 
+import cats.syntax.all.*
+
 import scala.util.matching.Regex
 
 object Yaml {
@@ -16,7 +18,7 @@ object Yaml {
         val value = m.group(1).trim
         value match {
           case blockScalarIndicator(indicator) =>
-            extractBlockScalarValue(content, m.end, isFolded = indicator == ">")
+            extractBlockScalarValue(content, m.end, isFolded = indicator === ">")
           case _ => value
         }
       case None => ""


### PR DESCRIPTION
# Refactor to follow 2020 Hindsight Scala practices

Apply 2020 Hindsight Scala's good practices across the codebase:

- Rule 4 (type-safe equality): Replace `==` / `!=` with `===` / `=!=` from cats in `SigintHandler`, `Install`, `TimeUtil`, `Yaml`, and `Dirs`. Add `cats.syntax.all.*` imports where missing, and import `aiskills.core.given` so the `Eq[os.Path]` given is in scope.

- Rule 9 (total functions over partial functions): Replace `groupSkills.head` in `Update` with `headOption.foreach` so the empty-list case no longer throws `NoSuchElementException`.

- Rule 14 (no Scala 3 braceless syntax): Convert single-generator `for x <- xs do { ... }` side-effect loops to `.foreach { x => ... }` in `ListCmd`, `Read`, `Remove`, `Search`, and `Sync`.

- Rule 21 (no wildcard pattern on ADTs): Replace `case _` with explicit constructors in `Agent.needsAgentsMd` (`Types.scala`) and `ResolvedSource.cleanup` (`Install.scala`) so the exhaustiveness checker flags future variants.

- `Skills.findAllSkills` is rewritten from a `List.newBuilder` with a `for ... do { ... }` driver into a pure for-comprehension that `yield`s `Skill` values directly.