### PR TITLE
Close #131: Add macOS 15 Intel target to native build and release workflows

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -26,6 +26,7 @@ jobs:
         os:
           - { name: "macOS 26 Apple Silicon", value: "macOS-26",         bin-suffix: "-macos-26-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+          - { name: "macOS 15 Intel",         value: "macos-15-intel",   bin-suffix: "-macos-15-intel" }
           - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
           - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         os:
           - { name: "macOS 26 Apple Silicon", value: "macOS-26",         bin-suffix: "-macos-26-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+          - { name: "macOS 15 Intel",         value: "macos-15-intel",   bin-suffix: "-macos-15-intel" }
           - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
           - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
 
@@ -109,6 +110,7 @@ jobs:
         os:
           - { name: "macOS 26 Apple Silicon", value: "macOS-26",         bin-suffix: "-macos-26-arm64" }
           - { name: "macOS 15 Apple Silicon", value: "macos-15",         bin-suffix: "-macos-15-arm64" }
+          - { name: "macOS 15 Intel",         value: "macos-15-intel",   bin-suffix: "-macos-15-intel" }
           - { name: "Ubuntu ARM64",           value: "ubuntu-24.04-arm", bin-suffix: "-linux-arm64" }
           - { name: "Ubuntu Latest (x86_64)", value: "ubuntu-latest",    bin-suffix: "-linux-x86_64" }
 


### PR DESCRIPTION
# Close #131: Add macOS 15 Intel target to native build and release workflows

- Update the OS matrix in `.github/workflows/release.yml` and `.github/workflows/build-native.yml` to include `macOS 15 Intel`.
  This enables automated builds and releases for Intel-based Macs, generating native binaries with the `-macos-15-intel` suffix alongside the existing Apple Silicon and Linux targets.