### PR TITLE
Fix #134: Mandatory multiple selection has a rendering issue when there isn’t enough space below the selection list - by bumping `cue4s` to `0.0.12`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val props = new {
 
   val DeclineVersion = "2.6.1"
 
-  val Cue4sVersion = "0.0.11"
+  val Cue4sVersion = "0.0.12"
 
   val ExtrasVersion = "0.51.0"
 


### PR DESCRIPTION
Fix #134: Mandatory multiple selection has a rendering issue when there isn’t enough space below the selection list - by bumping `cue4s` to `0.0.12`


https://github.com/user-attachments/assets/85262dbe-c44f-452c-bb97-14c9b24bf452

