### PR TITLE
Close #145: Honor each AI agent's own env var for its global config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <p align="center">
 
-  <img src="https://ai-skills.kevinly.dev/img/ai-skills-all.svg"/>
+  <img src="https://ai-skills.kevinly.dev/img/ai-skills-all.svg" alt="ai-skills logo" width="200" />
 
 </p>
 
@@ -33,6 +33,24 @@ Built with Scala 3 and Scala Native — compiles to a standalone binary with no 
 | **Gemini**    | `.gemini/skills/`   | `~/.gemini/skills/`           |
 | **Windsurf**  | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
 | **Copilot**   | `.github/skills/`   | `~/.copilot/skills/`          |
+
+### Custom Global Config Locations
+
+`aiskills` honors each agent's own environment variable for relocating its global config directory. When the variable is set, global install, list, read, search, sync, update, and remove all use the relocated directory, and the CLI shows the path as coming from the variable (e.g. `$CLAUDE_CONFIG_DIR/skills`).
+
+| Agent       | Env Var             | Global Skills Dir when set         |
+|-------------|---------------------|------------------------------------|
+| **Claude**  | `CLAUDE_CONFIG_DIR` | `$CLAUDE_CONFIG_DIR/skills/`       |
+| **Codex**   | `CODEX_HOME`        | `$CODEX_HOME/skills/`              |
+| **Gemini**  | `GEMINI_CLI_HOME`   | `$GEMINI_CLI_HOME/.gemini/skills/` |
+| **Copilot** | `COPILOT_HOME`      | `$COPILOT_HOME/skills/`            |
+
+Notes:
+- **Universal** (`~/.agents`) has no standard env var across agents, so it always stays under `$HOME`.
+- **Cursor**: `CURSOR_CONFIG_DIR` is only documented for the CLI's `cli-config.json`, not for skills, so it is not honored.
+- **Windsurf** has no documented mechanism to relocate `~/.codeium/windsurf`.
+- Project-level directories are never relocated — no agent supports a custom project dir location.
+- Empty variable values are ignored. A leading `~` expands to your home directory; relative paths resolve against the current directory.
 
 ## Install
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -2,7 +2,7 @@ package aiskills.cli.commands
 
 import OverwritePrompt.{BulkDecision, OverwriteChoice}
 import aiskills.cli.CliDefaults
-import aiskills.core.utils.{AgentsMd, MarketplaceSkills, SkillMdFinder, SkillMetadata, Yaml}
+import aiskills.core.utils.{AgentsMd, Dirs, MarketplaceSkills, SkillMdFinder, SkillMetadata, Yaml}
 import aiskills.core.{*, given}
 import cats.syntax.all.*
 import cue4s.*
@@ -163,7 +163,7 @@ object Install {
 
   private def promptForLocation(agents: List[Agent]): Set[SkillLocation] = {
     val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
-    val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
+    val globalPaths    = agents.map(a => Dirs.displayGlobalBaseResolved(a)).distinct.mkString(", ")
     val locationLabels = List(
       s"global  ($globalPaths)",
       s"project ($projectPaths)",
@@ -206,16 +206,12 @@ object Install {
         agent    <- agents
         location <- locations
       } do {
-        val isProject    = location === SkillLocation.Project
-        val folder       = s"${agent.projectDirName}/skills"
-        val globalFolder = s"${agent.globalDirName}/skills"
-        val targetDir    =
-          if isProject then os.pwd / os.RelPath(folder)
-          else os.home / os.RelPath(globalFolder)
+        val isProject = location === SkillLocation.Project
+        val targetDir = Dirs.getSkillsDir(agent, location)
 
         val locationDisplay =
-          if isProject then s"project ($folder)".blue
-          else s"global (~/$globalFolder)".dim
+          if isProject then s"project (${Dirs.displaySkillsDir(agent, location)})".blue
+          else s"global (${Dirs.displaySkillsDir(agent, location)})".dim
 
         if agents.length > 1 || locations.size > 1
         then println(s"\n--- ${agent.toString} (${location.toString.toLowerCase}) ---".bold)
@@ -225,7 +221,7 @@ object Install {
         println(s"Location: $locationDisplay")
         if agents.length <= 1 && locations.size <= 1 then {
           if !isProject && os.pwd =!= os.home then println(
-            s"Global install selected (~/$globalFolder). Omit --global for ./$folder.".dim
+            s"Global install selected (${Dirs.displaySkillsDir(agent, SkillLocation.Global)}). Omit --global for ./${Dirs.displaySkillsDir(agent, SkillLocation.Project)}.".dim
           )
           else ()
         } else ()
@@ -233,7 +229,7 @@ object Install {
 
         resolvedSource match {
           case ResolvedSource.Local(localPath, sourceInfo) =>
-            installFromLocal(localPath, targetDir, options, sourceInfo)
+            installFromLocal(localPath, targetDir, isProject, options, sourceInfo)
 
           case ResolvedSource.Git(repoDir, repoUrl, skillSubpath, sourceInfo) =>
             if skillSubpath.nonEmpty then installSpecificSkill(
@@ -246,7 +242,7 @@ object Install {
             )
             else {
               val repoName = getRepoName(repoUrl)
-              installFromRepo(repoDir, targetDir, options, repoName, sourceInfo)
+              installFromRepo(repoDir, targetDir, isProject, options, repoName, sourceInfo)
             }
         }
 
@@ -350,6 +346,10 @@ object Install {
     }
   }
 
+  /** Display an installed skill path, annotated with the env var it came from (if any). */
+  private def displayInstallLocation(path: os.Path): String =
+    Dirs.displayPath(path) + Dirs.envVarAnnotationFor(path).fold("")(varName => s" (from $$$varName)")
+
   private def printPostInstallHints(locations: Set[SkillLocation]): Unit = {
     println(s"\n${"Read skill:".dim} ${"aiskills read <skill-name>".cyan}")
     if locations.contains(SkillLocation.Project) then println(
@@ -361,6 +361,7 @@ object Install {
   private def installFromLocal(
     localPath: os.Path,
     targetDir: os.Path,
+    isProject: Boolean,
     options: InstallOptions,
     sourceInfo: InstallSourceInfo,
   ): Unit = {
@@ -372,11 +373,8 @@ object Install {
       throw SkillInstallException(1) // scalafix:ok DisableSyntax.throw
     } else {
       val skillMdPath = localPath / "SKILL.md"
-      if os.exists(skillMdPath) then {
-        val isProject = targetDir.startsWith(os.pwd)
-        installSingleLocalSkill(localPath, targetDir, isProject, options, sourceInfo)
-      } else
-        installFromRepo(localPath, targetDir, options, none[String], sourceInfo)
+      if os.exists(skillMdPath) then installSingleLocalSkill(localPath, targetDir, isProject, options, sourceInfo)
+      else installFromRepo(localPath, targetDir, isProject, options, none[String], sourceInfo)
     }
   }
 
@@ -411,13 +409,13 @@ object Install {
             SkillMetadata.writeSkillMetadata(targetPath, buildLocalMetadata(sourceInfo, skillDir))
 
             println(s"\u2705 Installed: $skillName".green)
-            println(s"   Location: $targetPath")
+            println(s"   Location: ${displayInstallLocation(targetPath)}")
           }
 
         case ConflictResolution.Rename(newName) =>
           installSkillWithRename(skillDir, targetDir, newName, buildLocalMetadata(sourceInfo, skillDir))
           println(s"\u2705 Installed: $skillName as $newName".green)
-          println(s"   Location: ${targetDir / newName}")
+          println(s"   Location: ${displayInstallLocation(targetDir / newName)}")
       }
     }
   }
@@ -459,13 +457,13 @@ object Install {
               SkillMetadata.writeSkillMetadata(targetPath, buildGitMetadata(sourceInfo, skillSubpath))
 
               println(s"\u2705 Installed: $skillName".green)
-              println(s"   Location: $targetPath")
+              println(s"   Location: ${displayInstallLocation(targetPath)}")
             }
 
           case ConflictResolution.Rename(newName) =>
             installSkillWithRename(skillDir, targetDir, newName, buildGitMetadata(sourceInfo, skillSubpath))
             println(s"\u2705 Installed: $skillName as $newName".green)
-            println(s"   Location: ${targetDir / newName}")
+            println(s"   Location: ${displayInstallLocation(targetDir / newName)}")
         }
       }
     }
@@ -474,6 +472,7 @@ object Install {
   private def installFromRepo(
     repoDir: os.Path,
     targetDir: os.Path,
+    isProject: Boolean,
     options: InstallOptions,
     repoName: Option[String],
     sourceInfo: InstallSourceInfo,
@@ -577,8 +576,6 @@ object Install {
         skillInfos
 
     if skillsToInstall.nonEmpty then {
-      val isProject = targetDir.startsWith(os.pwd)
-
       val (installedCount, _) =
         skillsToInstall.foldLeft((0, BulkDecision.Undecided: BulkDecision)) {
           case ((count, bulk), info) =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Read.scala
@@ -54,9 +54,10 @@ object Read {
           agent    <- agents
           location <- locations
         } do {
-          val dir   = Dirs.getSkillsDir(agent, location)
-          val scope = location.toString.toLowerCase
-          val label = Dirs.displayPath(dir)
+          val dir          = Dirs.getSkillsDir(agent, location)
+          val scope        = location.toString.toLowerCase
+          val envVarSuffix = Dirs.envVarAnnotationFor(dir).fold("")(varName => s" (from $$$varName)")
+          val label        = Dirs.displayPath(dir) + envVarSuffix
           System.err.println(s"  $label ($scope, ${agent.toString})")
         }
         System.err.println()

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -393,13 +393,7 @@ object Search {
   ): (Boolean, OverwritePrompt.BulkDecision) = {
     import OverwritePrompt.{BulkDecision, OverwriteChoice}
 
-    val isProject = location === SkillLocation.Project
-    val folder    =
-      if isProject then s"${agent.projectDirName}/skills"
-      else s"${agent.globalDirName}/skills"
-    val targetDir =
-      if isProject then os.pwd / os.RelPath(folder)
-      else os.home / os.RelPath(folder)
+    val targetDir = Dirs.getSkillsDir(agent, location)
 
     val skillName     = installName
     val subpath       = metadata.subpath.getOrElse("")
@@ -521,7 +515,7 @@ object Search {
 
   private def promptForInstallLocation(agents: List[Agent]): Either[Int, Set[SkillLocation]] = {
     val projectPaths   = agents.map(_.projectDirName).distinct.mkString(", ")
-    val globalPaths    = agents.map(a => s"~/${a.globalDirName}").distinct.mkString(", ")
+    val globalPaths    = agents.map(a => Dirs.displayGlobalBaseResolved(a)).distinct.mkString(", ")
     val locationLabels = List(
       s"global  ($globalPaths)",
       s"project ($projectPaths)",

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
@@ -23,7 +23,8 @@ object SkillDisplay {
 
   def renderInfoBlock(skillPath: os.Path): Unit = {
     val baseDirDisplay = Dirs.displayPath(skillPath)
-    println(s"${padLabel(BaseDirLabel).bold} ${baseDirDisplay.yellow.bold}")
+    val envVarSuffix   = Dirs.envVarAnnotationFor(skillPath).fold("")(varName => s" (from $$$varName)".dim)
+    println(s"${padLabel(BaseDirLabel).bold} ${baseDirDisplay.yellow.bold}$envVarSuffix")
 
     val metadataOpt = SkillMetadata.readSkillMetadata(skillPath)
 

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -8,14 +8,38 @@ import io.circe.{Codec, Decoder, Encoder}
 given Eq[os.Path]   = Eq.fromUniversalEquals
 given Show[os.Path] = Show.fromToString
 
-enum Agent(val projectDirName: String, val globalDirName: String) derives Eq, Show {
-  case Universal extends Agent(".agents", ".agents")
-  case Claude extends Agent(".claude", ".claude")
-  case Cursor extends Agent(".cursor", ".cursor")
-  case Codex extends Agent(".codex", ".codex")
-  case Gemini extends Agent(".gemini", ".gemini")
-  case Windsurf extends Agent(".windsurf", ".codeium/windsurf")
-  case Copilot extends Agent(".github", ".copilot")
+/** How an agent's global config dir can be relocated via its own env var.
+  *   - ConfigDir: the env var value is the config dir itself; skills live at `<value>/skills`.
+  *   - HomeRoot: the env var value replaces the home root; skills live at `<value>/<globalDirName>/skills`.
+  */
+enum GlobalDirOverride derives Eq, Show {
+  case ConfigDir(envVarName: String)
+  case HomeRoot(envVarName: String)
+  case NoOverride
+}
+
+/** Resolved global config base dir (without the `skills` segment).
+  * `envVar` is Some(varName) only when an override was actually applied.
+  */
+final case class GlobalDirResolution(
+  configBase: os.Path,
+  envVar: Option[String],
+) derives Eq,
+      Show
+
+enum Agent(
+  val projectDirName: String,
+  val globalDirName: String,
+  val globalDirOverride: GlobalDirOverride,
+) derives Eq,
+      Show {
+  case Universal extends Agent(".agents", ".agents", GlobalDirOverride.NoOverride)
+  case Claude extends Agent(".claude", ".claude", GlobalDirOverride.ConfigDir("CLAUDE_CONFIG_DIR"))
+  case Cursor extends Agent(".cursor", ".cursor", GlobalDirOverride.NoOverride)
+  case Codex extends Agent(".codex", ".codex", GlobalDirOverride.ConfigDir("CODEX_HOME"))
+  case Gemini extends Agent(".gemini", ".gemini", GlobalDirOverride.HomeRoot("GEMINI_CLI_HOME"))
+  case Windsurf extends Agent(".windsurf", ".codeium/windsurf", GlobalDirOverride.NoOverride)
+  case Copilot extends Agent(".github", ".copilot", GlobalDirOverride.ConfigDir("COPILOT_HOME"))
 }
 object Agent {
 

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/Dirs.scala
@@ -1,26 +1,120 @@
 package aiskills.core.utils
 
-import aiskills.core.{Agent, SkillLocation, given}
+import aiskills.core.{Agent, GlobalDirOverride, GlobalDirResolution, SkillLocation, given}
 import cats.syntax.all.*
 
 object Dirs {
 
+  /** Parse an env var path value (already trimmed and non-empty).
+    * "~" and "~/..." expand to home; relative values resolve against pwd.
+    */
+  private def parseEnvPath(value: String): os.Path =
+    if value === "~" then os.home
+    else if value.startsWith("~/") then os.home / os.RelPath(value.drop(2))
+    else os.Path(value, os.pwd)
+
+  /** Resolve the global config base dir for an agent, honoring its own env var
+    * (e.g. CLAUDE_CONFIG_DIR) when set and non-blank.
+    */
+  def resolveGlobalBase(
+    agent: Agent,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): GlobalDirResolution = {
+    val default = GlobalDirResolution(os.home / os.RelPath(agent.globalDirName), none)
+    agent.globalDirOverride match {
+      case GlobalDirOverride.ConfigDir(name) =>
+        env
+          .get(name)
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .fold(default)(value => GlobalDirResolution(parseEnvPath(value), name.some))
+      case GlobalDirOverride.HomeRoot(name) =>
+        env
+          .get(name)
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .fold(default)(value => GlobalDirResolution(parseEnvPath(value) / os.RelPath(agent.globalDirName), name.some))
+      case GlobalDirOverride.NoOverride =>
+        default
+    }
+  }
+
+  /** Env var name when the global dir for this agent is currently overridden. */
+  def globalEnvVar(
+    agent: Agent,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): Option[String] =
+    resolveGlobalBase(agent, env).envVar
+
   /** Get skills directory path for a specific agent. */
-  def getSkillsDir(agent: Agent, location: SkillLocation): os.Path =
+  def getSkillsDir(
+    agent: Agent,
+    location: SkillLocation,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): os.Path =
     location match {
-      case SkillLocation.Global => os.home / os.RelPath(agent.globalDirName) / "skills"
+      case SkillLocation.Global => resolveGlobalBase(agent, env).configBase / "skills"
       case SkillLocation.Project => os.pwd / os.RelPath(agent.projectDirName) / "skills"
     }
 
+  /** Display-friendly global config base dir for an agent.
+    * Default example: "~/.claude"
+    * Overridden examples: "$CLAUDE_CONFIG_DIR", "$GEMINI_CLI_HOME/.gemini"
+    */
+  def displayGlobalBase(
+    agent: Agent,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): String =
+    resolveGlobalBase(agent, env).envVar match {
+      case Some(name) =>
+        agent.globalDirOverride match {
+          case GlobalDirOverride.HomeRoot(_) => s"$$$name/${agent.globalDirName}"
+          case GlobalDirOverride.ConfigDir(_) | GlobalDirOverride.NoOverride => s"$$$name"
+        }
+      case None => s"~/${agent.globalDirName}"
+    }
+
+  /** Like displayGlobalBase, but with the resolved dir appended when overridden.
+    * Examples: "$CLAUDE_CONFIG_DIR=~/claude-work", "$GEMINI_CLI_HOME/.gemini=~/groot/.gemini", "~/.codex"
+    */
+  def displayGlobalBaseResolved(
+    agent: Agent,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): String = {
+    val resolution = resolveGlobalBase(agent, env)
+    resolution.envVar match {
+      case Some(_) => s"${displayGlobalBase(agent, env)}=${displayPath(resolution.configBase)}"
+      case None => displayGlobalBase(agent, env)
+    }
+  }
+
   /** Display-friendly skills directory path for a given agent and location.
     * Project example: ".agents/skills"
-    * Global example: "~/.agents/skills"
+    * Global examples: "~/.agents/skills", "$CLAUDE_CONFIG_DIR/skills" (when overridden)
     */
-  def displaySkillsDir(agent: Agent, location: SkillLocation): String =
+  def displaySkillsDir(
+    agent: Agent,
+    location: SkillLocation,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): String =
     location match {
       case SkillLocation.Project => s"${agent.projectDirName}/skills"
-      case SkillLocation.Global => s"~/${agent.globalDirName}/skills"
+      case SkillLocation.Global => s"${displayGlobalBase(agent, env)}/skills"
     }
+
+  /** Env var name to annotate a path with, when the path lives under an
+    * agent's overridden global config dir.
+    */
+  def envVarAnnotationFor(
+    path: os.Path,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): Option[String] =
+    Agent
+      .all
+      .collectFirstSome { agent =>
+        val resolution = resolveGlobalBase(agent, env)
+        resolution.envVar.filter(_ => path.startsWith(resolution.configBase))
+      }
 
   /** Display-friendly path: replaces home prefix with ~, or shows relative to pwd if possible. */
   def displayPath(path: os.Path): String =
@@ -41,16 +135,19 @@ object Dirs {
   def getSearchDirs(): List[(os.Path, Agent, SkillLocation)] =
     getSearchDirs(os.pwd)
 
-  def getSearchDirs(pwd: os.Path): List[(os.Path, Agent, SkillLocation)] = {
+  def getSearchDirs(
+    pwd: os.Path,
+    env: Map[String, String] = sys.env // scalafix:ok DisableSyntax.defaultArgs
+  ): List[(os.Path, Agent, SkillLocation)] = {
     val agentsSorted = Agent.allNonUniversal.sortBy(_.toString)
 
     val globalUniversal = List(
-      (os.home / os.RelPath(Agent.Universal.globalDirName) / "skills", Agent.Universal, SkillLocation.Global)
+      (getSkillsDir(Agent.Universal, SkillLocation.Global, env), Agent.Universal, SkillLocation.Global)
     )
     val globalSpecific  =
-      agentsSorted.map(a => (os.home / os.RelPath(a.globalDirName) / "skills", a, SkillLocation.Global))
+      agentsSorted.map(a => (getSkillsDir(a, SkillLocation.Global, env), a, SkillLocation.Global))
 
-    if pwd === os.home then globalUniversal ++ globalSpecific
+    if pwd === os.home then (globalUniversal ++ globalSpecific).distinctBy { case (path, _, _) => path }
     else {
       val projectUniversal = List(
         (pwd / os.RelPath(Agent.Universal.projectDirName) / "skills", Agent.Universal, SkillLocation.Project)
@@ -58,7 +155,9 @@ object Dirs {
       val projectSpecific  =
         agentsSorted.map(a => (pwd / os.RelPath(a.projectDirName) / "skills", a, SkillLocation.Project))
 
-      projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific
+      (projectUniversal ++ projectSpecific ++ globalUniversal ++ globalSpecific).distinctBy {
+        case (path, _, _) => path
+      }
     }
   }
 

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/AgentSpec.scala
@@ -21,6 +21,7 @@ object AgentSpec extends Properties {
     example("needsAgentsMd: true for Universal and Codex", testNeedsAgentsMd),
     example("needsAgentsMd: false for Claude, Cursor, Gemini, Windsurf, Copilot", testDoesNotNeedAgentsMd),
     example("Encoder/Decoder: round-trip", testEncoderDecoderRoundTrip),
+    example("globalDirOverride: expected env var mapping per agent", testGlobalDirOverrideMapping),
   )
 
   private def testFromStringLowercase: Result =
@@ -119,5 +120,18 @@ object AgentSpec extends Properties {
         val decoded = json.as[Agent]
         decoded ==== Right(agent)
       }
+    )
+
+  private def testGlobalDirOverrideMapping: Result =
+    Result.all(
+      List(
+        Agent.Universal.globalDirOverride ==== GlobalDirOverride.NoOverride,
+        Agent.Claude.globalDirOverride ==== GlobalDirOverride.ConfigDir("CLAUDE_CONFIG_DIR"),
+        Agent.Cursor.globalDirOverride ==== GlobalDirOverride.NoOverride,
+        Agent.Codex.globalDirOverride ==== GlobalDirOverride.ConfigDir("CODEX_HOME"),
+        Agent.Gemini.globalDirOverride ==== GlobalDirOverride.HomeRoot("GEMINI_CLI_HOME"),
+        Agent.Windsurf.globalDirOverride ==== GlobalDirOverride.NoOverride,
+        Agent.Copilot.globalDirOverride ==== GlobalDirOverride.ConfigDir("COPILOT_HOME"),
+      )
     )
 }

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/DirsSpec.scala
@@ -1,6 +1,6 @@
 package aiskills.core.utils
 
-import aiskills.core.{Agent, SkillLocation}
+import aiskills.core.{Agent, SkillLocation, given}
 import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
@@ -36,25 +36,47 @@ object DirsSpec extends Properties {
     example("getSearchDirs: returns 7 global-only dirs when pwd is home", testSearchDirsPwdIsHome),
     example("getSearchDirs: returns 14 dirs when pwd is not home", testSearchDirsPwdIsNotHome),
     example("getSearchDirs: no-arg delegates to overload with os.pwd", testSearchDirsNoArgDelegates),
+    example("getSkillsDir: global Claude honors CLAUDE_CONFIG_DIR", testEnvClaudeConfigDir),
+    example("getSkillsDir: global Codex honors CODEX_HOME", testEnvCodexHome),
+    example("getSkillsDir: global Copilot honors COPILOT_HOME", testEnvCopilotHome),
+    example("getSkillsDir: global Gemini honors GEMINI_CLI_HOME as home root", testEnvGeminiCliHome),
+    example("getSkillsDir: global Cursor does not honor CURSOR_CONFIG_DIR", testEnvCursorNotHonored),
+    example(
+      "getSkillsDir: global Universal and Windsurf ignore all honored env vars",
+      testEnvUniversalWindsurfNotHonored
+    ),
+    example("getSkillsDir: blank or empty env var value falls back to default", testEnvBlankValue),
+    example("getSkillsDir: env var value with ~ expands to home", testEnvTildeExpansion),
+    example("getSkillsDir: relative env var value resolves against pwd", testEnvRelativeValue),
+    example("getSkillsDir: project location ignores env vars", testEnvProjectUnaffected),
+    example("displaySkillsDir: global shows env var form when overridden", testDisplaySkillsDirOverridden),
+    example("displayGlobalBase: env var form when overridden, ~ form otherwise", testDisplayGlobalBase),
+    example("displayGlobalBaseResolved: shows VAR=resolved dir when overridden", testDisplayGlobalBaseResolved),
+    example("globalEnvVar: Some when overridden, None otherwise", testGlobalEnvVar),
+    example("envVarAnnotationFor: Some for paths under overridden base", testEnvVarAnnotationFor),
+    example("getSearchDirs: global entries honor env overrides", testSearchDirsEnvOverride),
+    example("getSearchDirs: dedup when override collides with project dir", testSearchDirsEnvOverrideDedup),
   )
 
   private def testProjectUniversal: Result =
     Dirs.getSkillsDir(Agent.Universal, SkillLocation.Project) ==== (os.pwd / ".agents" / "skills")
 
+  private val emptyEnv = Map.empty[String, String]
+
   private def testGlobalUniversal: Result =
-    Dirs.getSkillsDir(Agent.Universal, SkillLocation.Global) ==== (os.home / ".agents" / "skills")
+    Dirs.getSkillsDir(Agent.Universal, SkillLocation.Global, emptyEnv) ==== (os.home / ".agents" / "skills")
 
   private def testProjectClaude: Result =
     Dirs.getSkillsDir(Agent.Claude, SkillLocation.Project) ==== (os.pwd / ".claude" / "skills")
 
   private def testGlobalClaude: Result =
-    Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global) ==== (os.home / ".claude" / "skills")
+    Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, emptyEnv) ==== (os.home / ".claude" / "skills")
 
   private def testProjectCopilot: Result =
     Dirs.getSkillsDir(Agent.Copilot, SkillLocation.Project) ==== (os.pwd / ".github" / "skills")
 
   private def testGlobalCopilot: Result =
-    Dirs.getSkillsDir(Agent.Copilot, SkillLocation.Global) ==== (os.home / ".copilot" / "skills")
+    Dirs.getSkillsDir(Agent.Copilot, SkillLocation.Global, emptyEnv) ==== (os.home / ".copilot" / "skills")
 
   private def testProjectCursor: Result =
     Dirs.getSkillsDir(Agent.Cursor, SkillLocation.Project) ==== (os.pwd / ".cursor" / "skills")
@@ -69,31 +91,35 @@ object DirsSpec extends Properties {
     Dirs.getSkillsDir(Agent.Windsurf, SkillLocation.Project) ==== (os.pwd / ".windsurf" / "skills")
 
   private def testGlobalWindsurf: Result =
-    Dirs.getSkillsDir(Agent.Windsurf, SkillLocation.Global) ==== (os.home / ".codeium" / "windsurf" / "skills")
+    Dirs.getSkillsDir(
+      Agent.Windsurf,
+      SkillLocation.Global,
+      emptyEnv
+    ) ==== (os.home / ".codeium" / "windsurf" / "skills")
 
   private def testDisplayProjectUniversal: Result =
     Dirs.displaySkillsDir(Agent.Universal, SkillLocation.Project) ==== ".agents/skills"
 
   private def testDisplayGlobalUniversal: Result =
-    Dirs.displaySkillsDir(Agent.Universal, SkillLocation.Global) ==== "~/.agents/skills"
+    Dirs.displaySkillsDir(Agent.Universal, SkillLocation.Global, emptyEnv) ==== "~/.agents/skills"
 
   private def testDisplayProjectClaude: Result =
     Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Project) ==== ".claude/skills"
 
   private def testDisplayGlobalClaude: Result =
-    Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Global) ==== "~/.claude/skills"
+    Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Global, emptyEnv) ==== "~/.claude/skills"
 
   private def testDisplayProjectWindsurf: Result =
     Dirs.displaySkillsDir(Agent.Windsurf, SkillLocation.Project) ==== ".windsurf/skills"
 
   private def testDisplayGlobalWindsurf: Result =
-    Dirs.displaySkillsDir(Agent.Windsurf, SkillLocation.Global) ==== "~/.codeium/windsurf/skills"
+    Dirs.displaySkillsDir(Agent.Windsurf, SkillLocation.Global, emptyEnv) ==== "~/.codeium/windsurf/skills"
 
   private def testDisplayProjectCopilot: Result =
     Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Project) ==== ".github/skills"
 
   private def testDisplayGlobalCopilot: Result =
-    Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Global) ==== "~/.copilot/skills"
+    Dirs.displaySkillsDir(Agent.Copilot, SkillLocation.Global, emptyEnv) ==== "~/.copilot/skills"
 
   private def testDisplayPathGlobal: Result =
     Dirs.displayPath(os.home / ".claude" / "skills" / "foo") ==== "~/.claude/skills/foo"
@@ -112,12 +138,12 @@ object DirsSpec extends Properties {
   private val nonHomePwd = os.root / "some" / "project"
 
   private def testSearchDirsCount: Result = {
-    val dirs = Dirs.getSearchDirs(nonHomePwd)
+    val dirs = Dirs.getSearchDirs(nonHomePwd, emptyEnv)
     dirs.length ==== 14
   }
 
   private def testSearchDirsOrder: Result = {
-    val dirs   = Dirs.getSearchDirs(nonHomePwd)
+    val dirs   = Dirs.getSearchDirs(nonHomePwd, emptyEnv)
     val agents = dirs.map { case (_, agent, _) => agent }
     // 1. Project universal
     // 2-7. Project agent-specific (alphabetical: Claude, Codex, Copilot, Cursor, Gemini, Windsurf)
@@ -126,7 +152,7 @@ object DirsSpec extends Properties {
     Result.all(
       List(
         // Project universal
-        dirs(0) ==== (nonHomePwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project),
+        dirs.headOption ==== (nonHomePwd / ".agents" / "skills", Agent.Universal, SkillLocation.Project).some,
         // Project agent-specific (alphabetical)
         agents(1) ==== Agent.Claude,
         agents(2) ==== Agent.Codex,
@@ -152,7 +178,7 @@ object DirsSpec extends Properties {
   }
 
   private def testSearchDirsFirst: Result = {
-    val dirs                    = Dirs.getSearchDirs(nonHomePwd)
+    val dirs                    = Dirs.getSearchDirs(nonHomePwd, emptyEnv)
     val (path, agent, location) = dirs.head
     Result.all(
       List(
@@ -164,7 +190,7 @@ object DirsSpec extends Properties {
   }
 
   private def testSearchDirsPwdIsHome: Result = {
-    val dirs = Dirs.getSearchDirs(os.home)
+    val dirs = Dirs.getSearchDirs(os.home, emptyEnv)
     Result.all(
       List(
         dirs.length ==== 7,
@@ -174,7 +200,7 @@ object DirsSpec extends Properties {
   }
 
   private def testSearchDirsPwdIsNotHome: Result = {
-    val dirs = Dirs.getSearchDirs(nonHomePwd)
+    val dirs = Dirs.getSearchDirs(nonHomePwd, emptyEnv)
     Result.all(
       List(
         dirs.length ==== 14,
@@ -188,6 +214,165 @@ object DirsSpec extends Properties {
     val noArg   = Dirs.getSearchDirs()
     val withPwd = Dirs.getSearchDirs(os.pwd)
     noArg ==== withPwd
+  }
+
+  private def testEnvClaudeConfigDir: Result = {
+    val env = Map("CLAUDE_CONFIG_DIR" -> "/custom/claude")
+    Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, env) ==== (os.root / "custom" / "claude" / "skills")
+  }
+
+  private def testEnvCodexHome: Result = {
+    val env = Map("CODEX_HOME" -> "/custom/codex")
+    Dirs.getSkillsDir(Agent.Codex, SkillLocation.Global, env) ==== (os.root / "custom" / "codex" / "skills")
+  }
+
+  private def testEnvCopilotHome: Result = {
+    val env = Map("COPILOT_HOME" -> "/custom/copilot")
+    Dirs.getSkillsDir(Agent.Copilot, SkillLocation.Global, env) ==== (os.root / "custom" / "copilot" / "skills")
+  }
+
+  private def testEnvGeminiCliHome: Result = {
+    val env = Map("GEMINI_CLI_HOME" -> "/custom/root")
+    Dirs.getSkillsDir(Agent.Gemini, SkillLocation.Global, env) ====
+      (os.root / "custom" / "root" / ".gemini" / "skills")
+  }
+
+  private def testEnvCursorNotHonored: Result = {
+    val env = Map("CURSOR_CONFIG_DIR" -> "/custom/cursor")
+    Dirs.getSkillsDir(Agent.Cursor, SkillLocation.Global, env) ==== (os.home / ".cursor" / "skills")
+  }
+
+  private val allHonoredEnvVars = Map(
+    "CLAUDE_CONFIG_DIR" -> "/custom/claude",
+    "CODEX_HOME"        -> "/custom/codex",
+    "GEMINI_CLI_HOME"   -> "/custom/root",
+    "COPILOT_HOME"      -> "/custom/copilot",
+  )
+
+  private def testEnvUniversalWindsurfNotHonored: Result =
+    Result.all(
+      List(
+        Dirs.getSkillsDir(Agent.Universal, SkillLocation.Global, allHonoredEnvVars) ====
+          (os.home / ".agents" / "skills"),
+        Dirs.getSkillsDir(Agent.Windsurf, SkillLocation.Global, allHonoredEnvVars) ====
+          (os.home / ".codeium" / "windsurf" / "skills"),
+      )
+    )
+
+  private def testEnvBlankValue: Result =
+    Result.all(
+      List(
+        Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, Map("CLAUDE_CONFIG_DIR" -> "  ")) ====
+          (os.home / ".claude" / "skills"),
+        Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, Map("CLAUDE_CONFIG_DIR" -> "")) ====
+          (os.home / ".claude" / "skills"),
+      )
+    )
+
+  private def testEnvTildeExpansion: Result =
+    Result.all(
+      List(
+        Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, Map("CLAUDE_CONFIG_DIR" -> "~/custom-claude")) ====
+          (os.home / "custom-claude" / "skills"),
+        Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, Map("CLAUDE_CONFIG_DIR" -> "~")) ====
+          (os.home / "skills"),
+      )
+    )
+
+  private def testEnvRelativeValue: Result =
+    Dirs.getSkillsDir(Agent.Claude, SkillLocation.Global, Map("CLAUDE_CONFIG_DIR" -> "custom/dir")) ====
+      (os.pwd / "custom" / "dir" / "skills")
+
+  private def testEnvProjectUnaffected: Result =
+    Result.all(
+      List(
+        Dirs.getSkillsDir(Agent.Claude, SkillLocation.Project, allHonoredEnvVars) ====
+          (os.pwd / ".claude" / "skills"),
+        Dirs.getSkillsDir(Agent.Gemini, SkillLocation.Project, allHonoredEnvVars) ====
+          (os.pwd / ".gemini" / "skills"),
+      )
+    )
+
+  private def testDisplaySkillsDirOverridden: Result =
+    Result.all(
+      List(
+        Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Global, allHonoredEnvVars) ====
+          "$CLAUDE_CONFIG_DIR/skills",
+        Dirs.displaySkillsDir(Agent.Gemini, SkillLocation.Global, allHonoredEnvVars) ====
+          "$GEMINI_CLI_HOME/.gemini/skills",
+        Dirs.displaySkillsDir(Agent.Claude, SkillLocation.Global, emptyEnv) ==== "~/.claude/skills",
+      )
+    )
+
+  private def testDisplayGlobalBase: Result =
+    Result.all(
+      List(
+        Dirs.displayGlobalBase(Agent.Claude, allHonoredEnvVars) ==== "$CLAUDE_CONFIG_DIR",
+        Dirs.displayGlobalBase(Agent.Gemini, allHonoredEnvVars) ==== "$GEMINI_CLI_HOME/.gemini",
+        Dirs.displayGlobalBase(Agent.Claude, emptyEnv) ==== "~/.claude",
+      )
+    )
+
+  private def testDisplayGlobalBaseResolved: Result =
+    Result.all(
+      List(
+        Dirs.displayGlobalBaseResolved(Agent.Claude, Map("CLAUDE_CONFIG_DIR" -> "/custom/claude")) ====
+          "$CLAUDE_CONFIG_DIR=/custom/claude",
+        Dirs.displayGlobalBaseResolved(Agent.Claude, Map("CLAUDE_CONFIG_DIR" -> "~/custom-claude")) ====
+          "$CLAUDE_CONFIG_DIR=~/custom-claude",
+        Dirs.displayGlobalBaseResolved(Agent.Gemini, Map("GEMINI_CLI_HOME" -> "/custom/root")) ====
+          "$GEMINI_CLI_HOME/.gemini=/custom/root/.gemini",
+        Dirs.displayGlobalBaseResolved(Agent.Claude, emptyEnv) ==== "~/.claude",
+      )
+    )
+
+  private def testGlobalEnvVar: Result =
+    Result.all(
+      List(
+        Dirs.globalEnvVar(Agent.Claude, allHonoredEnvVars) ==== Some("CLAUDE_CONFIG_DIR"),
+        Dirs.globalEnvVar(Agent.Claude, emptyEnv) ==== None,
+        Dirs.globalEnvVar(Agent.Cursor, Map("CURSOR_CONFIG_DIR" -> "/custom/cursor")) ==== None,
+      )
+    )
+
+  private def testEnvVarAnnotationFor: Result = {
+    val env = Map("CLAUDE_CONFIG_DIR" -> "/custom/claude")
+    Result.all(
+      List(
+        Dirs.envVarAnnotationFor(os.root / "custom" / "claude" / "skills" / "foo", env) ====
+          Some("CLAUDE_CONFIG_DIR"),
+        Dirs.envVarAnnotationFor(os.root / "unrelated" / "path", env) ==== None,
+        Dirs.envVarAnnotationFor(os.root / "custom" / "claude" / "skills" / "foo", emptyEnv) ==== None,
+      )
+    )
+  }
+
+  private def testSearchDirsEnvOverride: Result = {
+    val env  = Map("CLAUDE_CONFIG_DIR" -> "/custom/claude")
+    val dirs = Dirs.getSearchDirs(nonHomePwd, env)
+    Result.all(
+      List(
+        dirs.length ==== 14,
+        dirs(8) ==== (os.root / "custom" / "claude" / "skills", Agent.Claude, SkillLocation.Global),
+        Result.assert(dirs.take(7).forall {
+          case (path, _, location) =>
+            location === SkillLocation.Project && path.startsWith(nonHomePwd)
+        }),
+      )
+    )
+  }
+
+  private def testSearchDirsEnvOverrideDedup: Result = {
+    val env                 = Map("CLAUDE_CONFIG_DIR" -> (nonHomePwd / ".claude").toString)
+    val dirs                = Dirs.getSearchDirs(nonHomePwd, env)
+    val claudeSkillsEntries = dirs.filter { case (path, _, _) => path === (nonHomePwd / ".claude" / "skills") }
+    Result.all(
+      List(
+        dirs.length ==== 13,
+        claudeSkillsEntries.map { case (_, agent, location) => (agent, location) } ====
+          List((Agent.Claude, SkillLocation.Project)),
+      )
+    )
   }
 
 }


### PR DESCRIPTION
# Close #145: Honor each AI agent's own env var for its global config location

Global skills directories were hard-coded to `~/<agent-dir>/skills`, so when an agent's config directory was relocated via its own environment variable, skills were installed to and listed from a directory the agent never reads.

`aiskills` now resolves the global skills directory through the agent's official env var when set: `CLAUDE_CONFIG_DIR` (Claude), `CODEX_HOME` (Codex), and `COPILOT_HOME` (Copilot) point at the config dir itself, while `GEMINI_CLI_HOME` (Gemini) replaces the home root (`$GEMINI_CLI_HOME/.gemini/skills`). Cursor, Windsurf, and Universal keep their default locations: Cursor's `CURSOR_CONFIG_DIR` is not documented to relocate skills, Windsurf has no relocation mechanism, and Universal (`~/.agents`) has no standard env var. Project-level directories are unchanged since no agent supports relocating them.

The CLI also shows where a global path comes from: compact labels display the env-var form (e.g. `$CLAUDE_CONFIG_DIR/skills`), resolved paths are annotated with `(from $CLAUDE_CONFIG_DIR)`, and the location-selection prompt shows the resolved value (e.g. `$CODEX_HOME=~/blah/.codex`). Install no longer infers project/global scope from the target path, which would misclassify an override pointing inside the project.