### PR TITLE
ai-skills v2.8.0

### DIFF
--- a/changelogs/2.8.0.md
+++ b/changelogs/2.8.0.md
@@ -1,0 +1,53 @@
+## [2.8.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am13) - 2026-08-09
+
+
+## New Feature
+
+### Support custom global config locations via each agent's own env var (#145)
+
+#### Before This Release
+
+Every global skills directory was hard-coded to `~/<agent-dir>/skills`. Most supported AI agents can relocate their global config directory with their own environment variable, but `ai-skills` ignored it, so skills were installed to and listed from a directory the agent never reads.
+
+#### After This Release
+
+`aiskills` resolves the global skills directory through the agent's own environment variable when it is set.
+
+| Agent       | Env Var             | Global Skills Dir when set         |
+|-------------|---------------------|------------------------------------|
+| **Claude**  | `CLAUDE_CONFIG_DIR` | `$CLAUDE_CONFIG_DIR/skills/`       |
+| **Codex**   | `CODEX_HOME`        | `$CODEX_HOME/skills/`              |
+| **Gemini**  | `GEMINI_CLI_HOME`   | `$GEMINI_CLI_HOME/.gemini/skills/` |
+| **Copilot** | `COPILOT_HOME`      | `$COPILOT_HOME/skills/`            |
+
+`CLAUDE_CONFIG_DIR`, `CODEX_HOME` and `COPILOT_HOME` point at the config directory itself, while `GEMINI_CLI_HOME` replaces the home root so `.gemini` is appended to it.
+
+Global `install`, `list`, `read`, `search`, `sync`, `update` and `remove` all use the relocated directory.
+
+The CLI now also shows where a global path comes from:
+
+* compact labels display the env-var form (e.g. `$CLAUDE_CONFIG_DIR/skills`)
+* resolved paths are annotated with `(from $CLAUDE_CONFIG_DIR)`
+* the location-selection prompt shows the resolved value (e.g. `$CODEX_HOME=~/blah/.codex`)
+
+Notes:
+
+* **Universal** (`~/.agents`) has no standard env var across agents, so it always stays under `$HOME`.
+* **Cursor**: `CURSOR_CONFIG_DIR` is only documented for the CLI's `cli-config.json`, not for skills, so it is not honored.
+* **Windsurf** has no documented mechanism to relocate `~/.codeium/windsurf`.
+* Project-level directories are never relocated, since no agent supports a custom project dir location.
+* Empty variable values are ignored. A leading `~` expands to the home directory, and relative paths resolve against the current directory.
+* When an override makes two agents resolve to the same directory, that directory is now searched only once instead of being reported twice.
+* `install` no longer infers the project/global scope from the target path, which would misclassify an override pointing inside the project.
+
+***
+
+## Internal Housekeeping
+
+* Add issue templates (#142)
+* Add issue template config (`config.yml`) (#143)
+* Fix malformed YAML in `bug_report.yml` and `task-template.yml` (#144)
+* Bump sbt to `1.12.10` (#138) and `1.12.11` (#139)
+* Bump `sbt-devoops`: `3.5.0` => `3.5.1` (#140)
+* Bump `actions/checkout` from `6` to `7` (#141)
+* Add `dependencyOverrides` for `org.scala-native` `0.5.x+` artifacts, so sbt's strict eviction no longer fails `update` when the Scala Native plugin and `hedgehog-sbt` request different compatible `0.5.x` versions of `test-interface`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.7.1-SNAPSHOT"
+ThisBuild / version := "2.8.0"


### PR DESCRIPTION
# ai-skills v2.8.0
## [2.8.0](https://github.com/kevin-lee/ai-skills/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am13) - 2026-08-09


## New Feature

### Support custom global config locations via each agent's own env var (#145)

#### Before This Release

Every global skills directory was hard-coded to `~/<agent-dir>/skills`. Most supported AI agents can relocate their global config directory with their own environment variable, but `ai-skills` ignored it, so skills were installed to and listed from a directory the agent never reads.

#### After This Release

`aiskills` resolves the global skills directory through the agent's own environment variable when it is set.

| Agent       | Env Var             | Global Skills Dir when set         |
|-------------|---------------------|------------------------------------|
| **Claude**  | `CLAUDE_CONFIG_DIR` | `$CLAUDE_CONFIG_DIR/skills/`       |
| **Codex**   | `CODEX_HOME`        | `$CODEX_HOME/skills/`              |
| **Gemini**  | `GEMINI_CLI_HOME`   | `$GEMINI_CLI_HOME/.gemini/skills/` |
| **Copilot** | `COPILOT_HOME`      | `$COPILOT_HOME/skills/`            |

`CLAUDE_CONFIG_DIR`, `CODEX_HOME` and `COPILOT_HOME` point at the config directory itself, while `GEMINI_CLI_HOME` replaces the home root so `.gemini` is appended to it.

Global `install`, `list`, `read`, `search`, `sync`, `update` and `remove` all use the relocated directory.

The CLI now also shows where a global path comes from:

* compact labels display the env-var form (e.g. `$CLAUDE_CONFIG_DIR/skills`)
* resolved paths are annotated with `(from $CLAUDE_CONFIG_DIR)`
* the location-selection prompt shows the resolved value (e.g. `$CODEX_HOME=~/blah/.codex`)

Notes:

* **Universal** (`~/.agents`) has no standard env var across agents, so it always stays under `$HOME`.
* **Cursor**: `CURSOR_CONFIG_DIR` is only documented for the CLI's `cli-config.json`, not for skills, so it is not honored.
* **Windsurf** has no documented mechanism to relocate `~/.codeium/windsurf`.
* Project-level directories are never relocated, since no agent supports a custom project dir location.
* Empty variable values are ignored. A leading `~` expands to the home directory, and relative paths resolve against the current directory.
* When an override makes two agents resolve to the same directory, that directory is now searched only once instead of being reported twice.
* `install` no longer infers the project/global scope from the target path, which would misclassify an override pointing inside the project.

***

## Internal Housekeeping

* Add issue templates (#142)
* Add issue template config (`config.yml`) (#143)
* Fix malformed YAML in `bug_report.yml` and `task-template.yml` (#144)
* Bump sbt to `1.12.10` (#138) and `1.12.11` (#139)
* Bump `sbt-devoops`: `3.5.0` => `3.5.1` (#140)
* Bump `actions/checkout` from `6` to `7` (#141)
* Add `dependencyOverrides` for `org.scala-native` `0.5.x+` artifacts, so sbt's strict eviction no longer fails `update` when the Scala Native plugin and `hedgehog-sbt` request different compatible `0.5.x` versions of `test-interface`
