### PR TITLE
Close #149: Normalize SkillSourceMetadata.subpath so the repo-root subpath has a single representation

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -692,11 +692,7 @@ object Install {
     repoDir: os.Path,
   ): SkillSourceMetadata =
     if sourceInfo.sourceType === SkillSourceType.Local then buildLocalMetadata(sourceInfo, skillDir)
-    else {
-      val subpath           = skillDir.relativeTo(repoDir).toString
-      val normalizedSubpath = if subpath === "." then "" else subpath
-      buildGitMetadata(sourceInfo, normalizedSubpath)
-    }
+    else buildGitMetadata(sourceInfo, skillDir.relativeTo(repoDir).toString)
 
   private def buildGitMetadata(sourceInfo: InstallSourceInfo, subpath: String): SkillSourceMetadata =
     SkillSourceMetadata(
@@ -802,7 +798,7 @@ object Install {
         val updated = Yaml.replaceYamlField(content, "name", newName)
         os.write.over(skillMdPath, updated)
       } else ()
-      SkillMetadata.writeSkillMetadata(targetPath, metadata.copy(name = newName.some))
+      SkillMetadata.writeSkillMetadata(targetPath, metadata.withName(newName))
     }
   }
 }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -453,7 +453,7 @@ object Search {
                       val updated = Yaml.replaceYamlField(content, "name", newName)
                       os.write.over(skillMdPath, updated)
                     } else ()
-                    SkillMetadata.writeSkillMetadata(newTargetPath, metadata.copy(name = newName.some))
+                    SkillMetadata.writeSkillMetadata(newTargetPath, metadata.withName(newName))
                     println(s"\u2705 Installed: $labeledName as $newName $locationLabel".green)
                     (true, BulkDecision.Undecided)
                 }

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/SkillDisplay.scala
@@ -41,7 +41,7 @@ object SkillDisplay {
         if metadata.source.nonEmpty then println(s"${padLabel(SourceLabel).bold} ${metadata.source}")
         else ()
 
-        val subpathValue = metadata.subpath.filter(_.nonEmpty)
+        val subpathValue = metadata.subpath
         val isRepoSource = metadata.sourceType match {
           case SkillSourceType.Git => true
           case SkillSourceType.Local => false

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Sync.scala
@@ -297,7 +297,7 @@ object Sync {
     } else ()
     // Update .aiskills.json name field if metadata exists
     SkillMetadata.readSkillMetadata(newTargetPath).foreach { meta =>
-      SkillMetadata.writeSkillMetadata(newTargetPath, meta.copy(name = newName.some))
+      SkillMetadata.writeSkillMetadata(newTargetPath, meta.withName(newName))
     }
     println(
       s"\u2705 Synced: ${sourcePath.last} as $newName -> ${to.toString} (${targetLocation.toString.toLowerCase})".green

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -85,7 +85,7 @@ object Update {
                 missingLocalSkillFile += skill.name
               case Some(lp) =>
                 updateSkillFromDir(skill.path, lp)
-                val updatedMeta = meta.copy(installedAt = aiskills.core.utils.isoNow())
+                val updatedMeta = meta.withInstalledAt(aiskills.core.utils.isoNow())
                 SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
                 reapplyRename(skill.path, updatedMeta)
                 val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)
@@ -144,7 +144,7 @@ object Update {
                         groupSkills.foreach {
                           case (skill, meta) =>
                             val originalRepoUrl = meta.repoUrl.getOrElse("")
-                            val subpath         = meta.subpath.filter(s => s.nonEmpty && s =!= ".")
+                            val subpath         = meta.subpath
                             val sourceDir       = subpath.fold(repoDir)(sp => repoDir / os.RelPath(sp))
 
                             if !os.exists(sourceDir / "SKILL.md") then {
@@ -156,8 +156,8 @@ object Update {
                               updateSkillFromDir(skill.path, sourceDir)
                               val updatedMeta =
                                 if actualUrl =!= originalRepoUrl
-                                then meta.copy(repoUrl = actualUrl.some, installedAt = aiskills.core.utils.isoNow())
-                                else meta.copy(installedAt = aiskills.core.utils.isoNow())
+                                then meta.withRepoUrl(actualUrl.some).withInstalledAt(aiskills.core.utils.isoNow())
+                                else meta.withInstalledAt(aiskills.core.utils.isoNow())
                               SkillMetadata.writeSkillMetadata(skill.path, updatedMeta)
                               reapplyRename(skill.path, updatedMeta)
                               val pathLabel   = Dirs.displaySkillsDir(skill.agent, skill.location)

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
@@ -70,6 +70,10 @@ object InstallSpec extends Properties {
     // existingSubpathLabel
     example("existingSubpathLabel: returns subpath from metadata", testExistingSubpathLabelWithMetadata),
     example("existingSubpathLabel: returns empty when no metadata", testExistingSubpathLabelNoMetadata),
+    example(
+      "existingSubpathLabel returns empty string for legacy \".\" metadata",
+      testExistingSubpathLabelLegacyDotMetadata,
+    ),
     // selectByLabel
     example("selectByLabel: selects matching items by label", testSelectByLabelMatching),
     example("selectByLabel: returns empty when no labels selected", testSelectByLabelEmpty),
@@ -378,6 +382,24 @@ object InstallSpec extends Properties {
     val tmpDir = os.temp.dir()
     try Install.existingSubpathLabel(tmpDir) ==== ""
     finally os.remove.all(tmpDir)
+  }
+
+  private def testExistingSubpathLabelLegacyDotMetadata: Result = {
+    val tmpDir = os.temp.dir()
+    try {
+      // Write JSON with "." subpath literally, simulating records written by earlier versions
+      val legacyJson =
+        """{
+          |  "source" : "owner/repo",
+          |  "sourceType" : "git",
+          |  "repoUrl" : "https://github.com/owner/repo",
+          |  "subpath" : ".",
+          |  "localPath" : null,
+          |  "installedAt" : "2026-01-01T00:00:00Z"
+          |}""".stripMargin
+      os.write(tmpDir / SkillMetadata.SkillMetadataFile, legacyJson)
+      Install.existingSubpathLabel(tmpDir) ==== ""
+    } finally os.remove.all(tmpDir)
   }
 
   // selectByLabel tests

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/Types.scala
@@ -149,17 +149,72 @@ object SkillSourceType {
   }
 }
 
-final case class SkillSourceMetadata(
-  name: Option[String] = none, // For backward compat: existing .aiskills.json without name
+final case class SkillSourceMetadata private (
+  name: Option[String], // For backward compat: existing .aiskills.json without name
   source: String,
   sourceType: SkillSourceType,
   repoUrl: Option[String],
-  subpath: Option[String],
+  subpath: Option[String], // Canonical: None means the skill is at the repo root
   localPath: Option[String],
   installedAt: String,
 ) derives Eq,
-      Show,
-      Codec.AsObject
+      Show
+object SkillSourceMetadata {
+
+  extension (skillSourceMetadata: SkillSourceMetadata) {
+
+    def withName(newName: String): SkillSourceMetadata = skillSourceMetadata.copy(name = newName.some)
+
+    def withInstalledAt(at: String): SkillSourceMetadata = skillSourceMetadata.copy(installedAt = at)
+
+    def withRepoUrl(url: Option[String]): SkillSourceMetadata = skillSourceMetadata.copy(repoUrl = url)
+  }
+
+  /** Canonicalize the repo-root subpath. `""`, `"."`, and whitespace-only all mean "repo root",
+    * which is represented as `None`.
+    */
+  def normalizeSubpath(subpath: Option[String]): Option[String] =
+    subpath.map(_.trim).filter(s => s.nonEmpty && s =!= ".")
+
+  def apply(
+    name: Option[String] = none[String], // scalafix:ok DisableSyntax.defaultArgs
+    source: String,
+    sourceType: SkillSourceType,
+    repoUrl: Option[String],
+    subpath: Option[String],
+    localPath: Option[String],
+    installedAt: String,
+  ): SkillSourceMetadata =
+    new SkillSourceMetadata(
+      name,
+      source,
+      sourceType,
+      repoUrl,
+      normalizeSubpath(subpath),
+      localPath,
+      installedAt,
+    )
+
+  private val derivedCodec: Codec.AsObject[SkillSourceMetadata] = Codec.AsObject.derived
+
+  given Codec.AsObject[SkillSourceMetadata] =
+    Codec
+      .AsObject
+      .from(
+        derivedCodec.map(m =>
+          SkillSourceMetadata(
+            m.name,
+            m.source,
+            m.sourceType,
+            m.repoUrl,
+            m.subpath,
+            m.localPath,
+            m.installedAt,
+          )
+        ),
+        derivedCodec,
+      )
+}
 
 enum AiSkillsError derives Eq, Show {
   case SkillNotFound(name: String) extends AiSkillsError

--- a/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMetadata.scala
+++ b/modules/ai-skills-core/src/main/scala/aiskills/core/utils/SkillMetadata.scala
@@ -25,7 +25,7 @@ object SkillMetadata {
   def writeSkillMetadata(skillDir: os.Path, metadata: SkillSourceMetadata): Unit = {
     val metadataPath = skillDir / SkillMetadataFile
     val payload      =
-      if metadata.installedAt.isEmpty then metadata.copy(installedAt = isoNow())
+      if metadata.installedAt.isEmpty then metadata.withInstalledAt(isoNow())
       else
         metadata
     os.write.over(metadataPath, payload.asJson.spaces2)

--- a/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillMetadataSpec.scala
+++ b/modules/ai-skills-core/src/test/scala/aiskills/core/utils/SkillMetadataSpec.scala
@@ -13,6 +13,15 @@ object SkillMetadataSpec extends Properties {
     example("reads legacy metadata without name as None", testLegacyMetadataWithoutName),
     example("returns None when metadata is missing", testMissing),
     example("returns None for invalid JSON", testInvalidJson),
+    example("normalizes \".\" subpath to None on construction", testNormalizesDotSubpathOnConstruction),
+    example(
+      "normalizes empty and whitespace-only subpath to None on construction",
+      testNormalizesEmptySubpathOnConstruction,
+    ),
+    example("preserves a real subpath on construction", testPreservesRealSubpathOnConstruction),
+    example("reads legacy \".\" subpath as None", testLegacyDotSubpath),
+    example("reads legacy empty subpath as None", testLegacyEmptySubpath),
+    example("writes root subpath as JSON null", testWritesRootSubpathAsNull),
   )
 
   private def withTempDir[A](f: os.Path => A): A = {
@@ -114,5 +123,70 @@ object SkillMetadataSpec extends Properties {
     withTempDir { tempDir =>
       os.write(tempDir / SkillMetadata.SkillMetadataFile, "{not-json")
       Result.assert(SkillMetadata.readSkillMetadata(tempDir).isEmpty)
+    }
+
+  private def metadataWithSubpath(subpath: Option[String]): SkillSourceMetadata =
+    SkillSourceMetadata(
+      source = "owner/repo",
+      sourceType = SkillSourceType.Git,
+      repoUrl = "https://github.com/owner/repo".some,
+      subpath = subpath,
+      localPath = none[String],
+      installedAt = "2026-01-01T00:00:00.000Z",
+    )
+
+  private def testNormalizesDotSubpathOnConstruction: Result =
+    metadataWithSubpath(".".some).subpath ==== none[String]
+
+  private def testNormalizesEmptySubpathOnConstruction: Result =
+    Result.all(
+      List(
+        metadataWithSubpath("".some).subpath ==== none[String],
+        metadataWithSubpath("   ".some).subpath ==== none[String],
+      )
+    )
+
+  private def testPreservesRealSubpathOnConstruction: Result =
+    metadataWithSubpath("skills/demo".some).subpath ==== "skills/demo".some
+
+  private def legacyJsonWithSubpath(subpath: String): String =
+    s"""{
+       |  "source" : "owner/repo",
+       |  "sourceType" : "git",
+       |  "repoUrl" : "https://github.com/owner/repo",
+       |  "subpath" : "$subpath",
+       |  "localPath" : null,
+       |  "installedAt" : "2026-01-01T00:00:00.000Z"
+       |}""".stripMargin
+
+  private def testLegacyDotSubpath: Result =
+    withTempDir { tempDir =>
+      // Write JSON with "." subpath literally, simulating records written by earlier versions
+      os.write(tempDir / SkillMetadata.SkillMetadataFile, legacyJsonWithSubpath("."))
+      val read = SkillMetadata.readSkillMetadata(tempDir)
+
+      read match {
+        case Some(r) => r.subpath ==== none[String]
+        case None => Result.failure.log("Expected Some but got None")
+      }
+    }
+
+  private def testLegacyEmptySubpath: Result =
+    withTempDir { tempDir =>
+      // Write JSON with "" subpath literally, simulating records written by earlier versions
+      os.write(tempDir / SkillMetadata.SkillMetadataFile, legacyJsonWithSubpath(""))
+      val read = SkillMetadata.readSkillMetadata(tempDir)
+
+      read match {
+        case Some(r) => r.subpath ==== none[String]
+        case None => Result.failure.log("Expected Some but got None")
+      }
+    }
+
+  private def testWritesRootSubpathAsNull: Result =
+    withTempDir { tempDir =>
+      SkillMetadata.writeSkillMetadata(tempDir, metadataWithSubpath(".".some))
+      val raw = os.read(tempDir / SkillMetadata.SkillMetadataFile)
+      Result.assert(raw.contains("\"subpath\" : null")).log(s"raw was: $raw")
     }
 }


### PR DESCRIPTION
# Close #149: Normalize SkillSourceMetadata.subpath so the repo-root subpath has a single representation

The repo-root state had three representations (None, "" and "."), depending on which command wrote the metadata: `aiskills install` wrote `"subpath": ""` while `aiskills search` wrote `"subpath": "."`. As a result, `list`/`read` showed `subpath: .` instead of `<root>`, and the overwrite/replace prompts showed `my-skill (.)` instead of `my-skill (<root>)`.

Instead of patching each producer and consumer, the invariant is now enforced in `SkillSourceMetadata` itself: the constructor is private and a smart `apply` canonicalizes `""`, `"."` and whitespace-only subpaths to `None`. The circe decoder is routed through this `apply`, so legacy `.aiskills.json` files already on disk are normalized on read as well. `withName`/`withInstalledAt`/`withRepoUrl` helpers replace the now-inaccessible `copy` at the existing call sites, and the redundant per-consumer guards in `Install`, `Update` and `SkillDisplay` are removed.

Tests cover construction-time normalization, decoding of legacy `"."`/`""` records, and the encoder writing a root subpath as JSON `null`.