### PR TITLE
Close #151: Render `<root>` in the install selection list for repo-root skills and reuse `Install.buildGitMetadata` in `Search`

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -101,17 +101,21 @@ object Install {
     else if bytes < 1024 * 1024 then f"${bytes / 1024.0}%.1fKB"
     else f"${bytes / (1024.0 * 1024.0)}%.1fMB"
 
-  /** Format a skill label with name, subpath, and size for display in selection lists. */
+  /** Empty or whitespace-only subpath renders as `<root>` to distinguish root-level skills. */
+  private def subpathOrRoot(subpath: String): String =
+    if subpath.trim.isEmpty then "<root>" else subpath
+
+  /** Format a skill label with name, subpath, and size for display in selection lists.
+    * Empty or whitespace-only subpath renders as `<root>` to distinguish root-level skills.
+    */
   def skillLabel(skillName: String, subpath: String, size: Long): String =
-    s"${skillName.padTo(25, ' ')} ($subpath)".padTo(60, ' ') + s" ${formatSize(size)}"
+    s"${skillName.padTo(25, ' ')} (${subpathOrRoot(subpath)})".padTo(60, ' ') + s" ${formatSize(size)}"
 
   /** Format a skill name with its subpath for display in messages.
     * Empty or whitespace-only subpath renders as `<root>` to distinguish root-level skills.
     */
-  def skillNameWithSubpath(skillName: String, subpath: String): String = {
-    val shown = if subpath.trim.isEmpty then "<root>" else subpath
-    s"$skillName ($shown)"
-  }
+  def skillNameWithSubpath(skillName: String, subpath: String): String =
+    s"$skillName (${subpathOrRoot(subpath)})"
 
   /** Read the subpath of an already-installed skill from its metadata. */
   def existingSubpathLabel(targetPath: os.Path): String =
@@ -694,7 +698,7 @@ object Install {
     if sourceInfo.sourceType === SkillSourceType.Local then buildLocalMetadata(sourceInfo, skillDir)
     else buildGitMetadata(sourceInfo, skillDir.relativeTo(repoDir).toString)
 
-  private def buildGitMetadata(sourceInfo: InstallSourceInfo, subpath: String): SkillSourceMetadata =
+  private[commands] def buildGitMetadata(sourceInfo: InstallSourceInfo, subpath: String): SkillSourceMetadata =
     SkillSourceMetadata(
       source = sourceInfo.source,
       sourceType = SkillSourceType.Git,

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -292,14 +292,13 @@ object Search {
     val skillEntries = installable.map { c =>
       val subpath     = c.skillDir.relativeTo(c.repoDir).toString
       val installName = resolveInstallName(c.skillDir, c.repoDir, c.yamlName, c.result.skillId)
-      val metadata    = SkillSourceMetadata(
+      val sourceInfo  = InstallSourceInfo(
         source = c.result.source,
         sourceType = SkillSourceType.Git,
         repoUrl = c.actualRepoUrl.some,
-        subpath = subpath.some,
-        localPath = none[String],
-        installedAt = aiskills.core.utils.isoNow(),
+        localRoot = none[os.Path],
       )
+      val metadata    = Install.buildGitMetadata(sourceInfo, subpath)
       (c.skillDir, installName, metadata)
     }
 

--- a/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
+++ b/modules/ai-skills-cli/src/test/scala/aiskills/cli/commands/InstallSpec.scala
@@ -59,6 +59,8 @@ object InstallSpec extends Properties {
     // skillLabel
     example("skillLabel: formats label with name, subpath, and size", testSkillLabelBasic),
     example("skillLabel: formats label with long subpath", testSkillLabelLongSubpath),
+    example("skillLabel: empty subpath renders as <root>", testSkillLabelEmptySubpath),
+    example("skillLabel: whitespace-only subpath renders as <root>", testSkillLabelWhitespaceOnlySubpath),
     // skillNameWithSubpath
     example("skillNameWithSubpath: formats name with subpath", testSkillNameWithSubpath),
     example("skillNameWithSubpath: distinguishes duplicate names by subpath", testSkillNameWithSubpathDuplicates),
@@ -330,6 +332,12 @@ object InstallSpec extends Properties {
       )
     )
   }
+
+  private def testSkillLabelEmptySubpath: Result =
+    Result.assert(Install.skillLabel("foo", "", 100L).contains("(<root>)"))
+
+  private def testSkillLabelWhitespaceOnlySubpath: Result =
+    Result.assert(Install.skillLabel("foo", "   ", 100L).contains("(<root>)"))
 
   // skillNameWithSubpath tests
   private def testSkillNameWithSubpath: Result = {


### PR DESCRIPTION
# Close #151: Render `<root>` in the install selection list for repo-root skills and reuse `Install.buildGitMetadata` in `Search`

- `Install.skillLabel` now renders (`<root>`) for an empty or whitespace-only subpath, consistent with `skillNameWithSubpath`. Both share the new `subpathOrRoot` helper.
- `Search.installMarketplaceSkillsEnriched` builds its Git metadata via `Install.buildGitMetadata` (widened to `private[commands]`) instead of an inline `SkillSourceMetadata` record, so the Git metadata has a single construction site. Behavior-preserving: the written `.aiskills.json` is unchanged.
- Add two `InstallSpec` examples pinning the (`<root>`) rendering of `skillLabel`.