### PR TITLE
Refactor

### DIFF
--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Install.scala
@@ -327,7 +327,7 @@ object Install {
           cloneWithFallback(repoUrl, (tempDir / "repo").toString)
         } match {
           case Failure(ex) =>
-            val _   = spinner.fail(Some("Clone failed"))
+            val _   = spinner.fail("Clone failed".some)
             val msg = ex.getMessage
             if msg.nonEmpty then println(msg.dim) else ()
             println("\nTip: For private repos, ensure git SSH keys or credentials are configured".yellow)
@@ -335,7 +335,7 @@ object Install {
             aiskills.cli.TempDirCleanup.unregister(tempDir)
             throw SkillInstallException(1) // scalafix:ok DisableSyntax.throw
           case Success(url) =>
-            val _ = spinner.succeed(Some("Repository cloned"))
+            val _ = spinner.succeed("Repository cloned".some)
             url
         }
 

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Search.scala
@@ -83,13 +83,13 @@ object Search {
     val results = MarketplaceSearch.searchAll(query)
 
     if results.isEmpty then {
-      val _ = spinner.fail(Some("No results found"))
+      val _ = spinner.fail("No results found".some)
       println(s"\nNo skills found matching '$query'.".yellow)
       println(s"Try a different search term or browse:")
       println(s"  ${"https://skills.sh".cyan}")
       println(s"  ${"https://agentskill.sh".cyan}")
     } else {
-      val _ = spinner.succeed(Some(s"Found ${results.length} skill(s)"))
+      val _ = spinner.succeed(s"Found ${results.length} skill(s)".some)
       println()
 
       promptForMarketplaceResults(results) match {
@@ -197,14 +197,14 @@ object Search {
           Install.cloneWithFallback(repoUrl, (tempDir / "repo").toString)
         } match {
           case scala.util.Failure(_) =>
-            val _ = spinner.fail(Some(s"Failed to clone $source"))
+            val _ = spinner.fail(s"Failed to clone $source".some)
             System.err.println(s"Could not clone repository: $source".red)
             aiskills.cli.TempDirCleanup.safeRemoveAll(tempDir)
             aiskills.cli.TempDirCleanup.unregister(tempDir)
             Nil
 
           case scala.util.Success(actualUrl) =>
-            val _ = spinner.succeed(Some(s"Cloned $source"))
+            val _ = spinner.succeed(s"Cloned $source".some)
 
             val repoDir = tempDir / "repo"
 
@@ -852,9 +852,9 @@ object Search {
       prompts.text(
         "Enter search query",
         _.validate { s =>
-          if s.trim.length < MinQueryLength
-          then Some(PromptError(s"Query must be at least $MinQueryLength characters"))
-          else None
+          Option.when(s.trim.length < MinQueryLength)(
+            PromptError(s"Query must be at least $MinQueryLength characters")
+          )
         },
       ) match {
         case Completion.Finished(query) =>

--- a/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
+++ b/modules/ai-skills-cli/src/main/scala/aiskills/cli/commands/Update.scala
@@ -128,7 +128,7 @@ object Update {
                       Install.cloneWithFallback(cloneUrl, (repoSubDir / "repo").toString)
                     } match {
                       case Failure(ex) =>
-                        val _   = spinner.fail(Some(s"Clone failed: $cloneUrl"))
+                        val _   = spinner.fail(s"Clone failed: $cloneUrl".some)
                         val msg = ex.getMessage
                         if msg.nonEmpty then println(msg.dim) else ()
                         groupSkills.foreach {
@@ -138,7 +138,7 @@ object Update {
                         }
 
                       case Success(actualUrl) =>
-                        val _       = spinner.succeed(Some(s"Cloned: $cloneUrl$skillsLabel"))
+                        val _       = spinner.succeed(s"Cloned: $cloneUrl$skillsLabel".some)
                         val repoDir = repoSubDir / "repo"
 
                         groupSkills.foreach {


### PR DESCRIPTION
# Refactor

Use `.some` and `Option.when` instead of direct `Some` / `None` constructors

Replace `Some(...)` with `.some` in spinner `fail` / `succeed` calls in `Install`, `Search`, and `Update`, and rewrite the `if ... then Some(...) else None` query validation in `Search.promptForQuery` with `Option.when`, following the 2020 Hindsight Scala practices for better type inference of `Option`.